### PR TITLE
Working variable-elevation lakes

### DIFF
--- a/assets/materials/00_stone.png
+++ b/assets/materials/00_stone.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e53319b547c6172c72c299e21631fecf5434dc75c013b22538146badaf768d1f
-size 3254
+oid sha256:5e4b98330330e1a5e547dbf47c0a14c3cd586cbb5e4ff7d486263d150c16fd40
+size 7313

--- a/assets/materials/00_stone.png
+++ b/assets/materials/00_stone.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e4b98330330e1a5e547dbf47c0a14c3cd586cbb5e4ff7d486263d150c16fd40
-size 7313
+oid sha256:4c8cae4338e01f9b25a0edc7c187683afd449b0ca3581d7ca919e9b2a70b3ad4
+size 6404

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -68,7 +68,7 @@ impl NodeState {
             spice: 0,
             enviro: EnviroFactors {
                 max_elevation: 0,
-                temperature: 0,
+                temperature: 1,
                 rainfall: 0,
             },
         }
@@ -143,7 +143,7 @@ pub fn voxels(graph: &mut DualGraph, node: NodeId, cube: Vertex) -> VoxelData {
 
                     let elev = trilerp(&enviros.max_elevations, p);
                     let temp = trilerp(&enviros.temperatures, p);
-                    let sand_margin = 2_f64;
+                    let sand_margin = 1_f64;
 
                     let mut voxel_mat = Material::Sand;
                     let mut max_e = elev.min(temp);
@@ -178,9 +178,9 @@ struct EnviroFactors {
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: u64) -> Self {
         Self {
-            max_elevation: parent.max_elevation + ((1 - ((spice % 30) / 10) as i64)*5),
-            temperature:  parent.temperature + ((1 - (spice % 24) / 8 ) as i64 )*
-                    (parent.max_elevation - parent.temperature - 6).min(0).max(3),
+            max_elevation: parent.max_elevation + ((1 - ((spice % 30) / 10) as i64)*2),
+            temperature:  parent.temperature + ((1 - (spice % 15) / 5 ) as i64 )*
+                (parent.temperature - parent.max_elevation - 1).max(0).min(3),
 
             rainfall: parent.rainfall + (1 - ((spice % 90) / 30) as i64),
         }

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -139,15 +139,21 @@ pub fn voxels(graph: &mut DualGraph, node: NodeId, cube: Vertex) -> VoxelData {
                     let p = absolute_subchunk_coords(x, y, z, subchunk_offset);
                     let q = relative_subchunk_coords(x, y, z, subchunk_offset);
 
-                    let (voxel_mat, elevation_boost) = match trilerp(&enviros.rainfalls, p) {
-                        r if r > 2.0 => (Material::Dirt, 3.0),
-                        r if r < 1.0 => (Material::Stone, -3.0),
-                        _ => (Material::Sand, -1.0),
-                    };
+
+
+                    let elev = trilerp(&enviros.max_elevations, p);
+                    let temp = trilerp(&enviros.temperatures, p);
+
+                    let mut voxel_mat = Material::Stone;
+                    let mut max_e = temp;
+
+                    if (elev > temp){
+                        voxel_mat = Material::Dirt;
+                        max_e = elev;
+                    }
 
                     // maximum max_elevation for this voxel according to the max_elevations
                     // of the incident nodes that dictate the content of this chunk
-                    let max_e = trilerp(&enviros.max_elevations, p) - elevation_boost;
 
                     if state.surface.voxel_elevation(q, cube) < max_e / -10.0 {
                         voxels.data_mut()[index(p)] = voxel_mat;

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -68,7 +68,7 @@ impl NodeState {
             spice: 0,
             enviro: EnviroFactors {
                 max_elevation: 0,
-                temperature: 0,
+                temperature: -4,
                 rainfall: 0,
             },
         }
@@ -148,11 +148,11 @@ pub fn voxels(graph: &mut DualGraph, node: NodeId, cube: Vertex) -> VoxelData {
                     let mut voxel_mat = Material::Sand;
                     let mut max_e = elev;
 
-                    if (elev > temp){
+                    if (elev < temp){
                        voxel_mat = Material::Stone;
-                        max_e = temp
+                        max_e = temp;
                     }
-                    if (elev < temp - sand_margin){ //one is arbitrary
+                    if (elev > temp + sand_margin){ //one is arbitrary
                         voxel_mat = Material::Dirt;
                     }
 
@@ -178,10 +178,10 @@ struct EnviroFactors {
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: i64) -> Self {
         Self {
-            max_elevation: parent.max_elevation + (1 - (spice % 30) / 10)*3,
-            temperature: if parent.temperature >= parent.max_elevation {parent.temperature}
+            max_elevation: parent.max_elevation + (1 - (spice % 30) / 10),
+            temperature: if parent.temperature >= parent.max_elevation - 2 {parent.temperature}
             else {
-                parent.max_elevation + (1 - (spice % 15) / 5)
+                parent.rainfall
             },
 
             rainfall: parent.rainfall + (1 - (spice % 90) / 30),
@@ -192,7 +192,8 @@ impl EnviroFactors {
     fn continue_from(a: Self, b: Self, ab: Self) -> Self {
         Self {
             max_elevation: a.max_elevation + (b.max_elevation - ab.max_elevation),
-            temperature: a.temperature + (b.temperature - ab.temperature),
+            //temperature: a.temperature + (b.temperature - ab.temperature),
+            temperature: 0,
             rainfall: a.rainfall + (b.rainfall - ab.rainfall),
         }
     }

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -143,13 +143,17 @@ pub fn voxels(graph: &mut DualGraph, node: NodeId, cube: Vertex) -> VoxelData {
 
                     let elev = trilerp(&enviros.max_elevations, p);
                     let temp = trilerp(&enviros.temperatures, p);
+                    let sand_margin = 1_f64;
 
-                    let mut voxel_mat = Material::Stone;
-                    let mut max_e = temp;
+                    let mut voxel_mat = Material::Sand;
+                    let mut max_e = elev;
 
                     if (elev > temp){
+                       voxel_mat = Material::Stone;
+                        max_e = temp
+                    }
+                    if (elev < temp - sand_margin){ //one is arbitrary
                         voxel_mat = Material::Dirt;
-                        max_e = elev;
                     }
 
                     // maximum max_elevation for this voxel according to the max_elevations
@@ -174,11 +178,17 @@ struct EnviroFactors {
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: i64) -> Self {
         Self {
-            max_elevation: parent.max_elevation + (1 - (spice % 30) / 10),
-            temperature: parent.temperature + (1 - (spice % 15) / 5),
+            max_elevation: parent.max_elevation + (1 - (spice % 30) / 10)*3,
+            temperature: if parent.temperature >= parent.max_elevation {parent.temperature}
+            else {
+                parent.max_elevation + (1 - (spice % 15) / 5)
+            },
+
             rainfall: parent.rainfall + (1 - (spice % 90) / 30),
         }
     }
+
+
     fn continue_from(a: Self, b: Self, ab: Self) -> Self {
         Self {
             max_elevation: a.max_elevation + (b.max_elevation - ab.max_elevation),

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -68,7 +68,7 @@ impl NodeState {
             spice: 0,
             enviro: EnviroFactors {
                 max_elevation: 0,
-                temperature: 1,
+                temperature: 0,
                 rainfall: 0,
             },
         }
@@ -141,7 +141,8 @@ pub fn voxels(graph: &mut DualGraph, node: NodeId, cube: Vertex) -> VoxelData {
 
 
 
-                    let elev = trilerp(&enviros.max_elevations, p);
+                    let elev = trilerp(&enviros.max_elevations, p)
+                            + (trilerp(&enviros.rainfalls,p )/2_f64).floor()*2_f64;
                     let temp = trilerp(&enviros.temperatures, p);
                     let sand_margin = 1_f64;
 
@@ -178,11 +179,11 @@ struct EnviroFactors {
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: u64) -> Self {
         Self {
-            max_elevation: parent.max_elevation + ((1 - ((spice % 30) / 10) as i64)*2),
+            max_elevation: parent.max_elevation + (1 - ((spice % 30) / 10) as i64),
             temperature:  parent.temperature + ((1 - (spice % 15) / 5 ) as i64 )*
-                (parent.temperature - parent.max_elevation - 1).max(0).min(3),
+                (parent.temperature - parent.max_elevation - parent.rainfall*1 - 3).max(0).min(8),
 
-            rainfall: parent.rainfall + (1 - ((spice % 90) / 30) as i64),
+            rainfall: parent.rainfall + ((  ( 1 ) * (1 - (spice % 90) / 30 ) ) as i64 ),
         }
     }
 

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -68,8 +68,8 @@ impl NodeState {
             spice: 0,
             enviro: EnviroFactors {
                 max_elevation: 0,
-                temperature: -4,
-                rainfall: 0,
+                temperature: -2,
+                rainfall: -2,
             },
         }
     }
@@ -94,7 +94,7 @@ impl NodeState {
                 let parent_side = graph.parent(node).unwrap();
                 let parent_node = graph.neighbor(node, parent_side).unwrap();
                 let parent_state = graph.get(parent_node).as_ref().unwrap();
-                EnviroFactors::varied_from(parent_state.enviro, spice as i64)
+                EnviroFactors::varied_from(parent_state.enviro, spice)
             }
             (Some((a_side, a_state)), Some((b_side, b_state))) => {
                 let ab_node = graph
@@ -176,15 +176,15 @@ struct EnviroFactors {
     rainfall: i64,
 }
 impl EnviroFactors {
-    fn varied_from(parent: Self, spice: i64) -> Self {
+    fn varied_from(parent: Self, spice: u64) -> Self {
         Self {
-            max_elevation: parent.max_elevation + (1 - (spice % 30) / 10),
+            max_elevation: parent.max_elevation + (1 - ((spice % 30) / 10) as i64),
             temperature: if parent.temperature >= parent.max_elevation - 2 {parent.temperature}
             else {
                 parent.rainfall
             },
 
-            rainfall: parent.rainfall + (1 - (spice % 90) / 30),
+            rainfall: parent.rainfall + (1 - ((spice % 90) / 30) as i64),
         }
     }
 


### PR DESCRIPTION
The elevation_boost variable was scrapped.

Temperature is used in place of water_level because of the trouble adding new factors causes.
Stone is being used in the place of water..