### PR TITLE
Motion input prediction

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -13,7 +13,6 @@ pub struct Config {
     pub data_dir: PathBuf,
     pub view_distance: f64,
     pub chunks_loaded_per_frame: u32,
-    pub input_send_rate: u16,
     pub server: Option<SocketAddr>,
 }
 
@@ -27,7 +26,6 @@ impl Config {
             data_dir,
             view_distance,
             chunks_loaded_per_frame,
-            input_send_rate,
             server,
         } = match fs::read(&path) {
             Ok(data) => match toml::from_slice(&data) {
@@ -52,7 +50,6 @@ impl Config {
             data_dir: data_dir.unwrap_or_else(|| dirs.data_dir().into()),
             view_distance: view_distance.unwrap_or(6.0),
             chunks_loaded_per_frame: chunks_loaded_per_frame.unwrap_or(16),
-            input_send_rate: input_send_rate.unwrap_or(30),
             server,
         }
     }
@@ -86,6 +83,5 @@ struct RawConfig {
     data_dir: Option<PathBuf>,
     view_distance: Option<f64>,
     chunks_loaded_per_frame: Option<u32>,
-    input_send_rate: Option<u16>,
     server: Option<SocketAddr>,
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
                     socket,
                 },
                 server::SimConfig {
-                    rate: 10,
+                    rate: 4,
                     view_distance: 4,
                 },
             ) {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod graphics;
 mod net;
+mod prediction;
 mod sim;
 mod worldgen;
 
@@ -32,10 +33,6 @@ fn main() {
         let key = cert.serialize_private_key_der();
         let cert = cert.serialize_der().unwrap();
 
-        let sim_cfg = server::SimConfig {
-            rate: config.input_send_rate,
-            view_distance: 4,
-        };
         std::thread::spawn(move || {
             if let Err(e) = server::run(
                 server::NetParams {
@@ -45,7 +42,10 @@ fn main() {
                     private_key: quinn::PrivateKey::from_der(&key).unwrap(),
                     socket,
                 },
-                sim_cfg,
+                server::SimConfig {
+                    rate: 10,
+                    view_distance: 4,
+                },
             ) {
                 eprintln!("{:#}", e);
                 std::process::exit(1);
@@ -64,7 +64,7 @@ fn main() {
 
     // Kick off networking
     let net = net::spawn(config.clone());
-    let sim = Sim::new(net, config.clone());
+    let sim = Sim::new(net);
 
     // Finish creating the window, including the Vulkan resources used to render to it
     let window = graphics::Window::new(window, core.clone(), config, sim);

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -1,0 +1,90 @@
+use std::collections::VecDeque;
+
+use common::{math, proto::Position};
+
+/// Predicts the result of motion inputs in-flight to the server
+///
+/// When sending input to the server, call `push` to record the input in a local queue of in-flight
+/// inputs, and to obtaining a generation tag to send alongside the input. The server echos the
+/// highest tag it's received alongside every state update, which we then use in `reconcile` to
+/// determine which inputs have been integrated into the server's state and no longer need to be
+/// predicted.
+pub struct PredictedMotion {
+    log: VecDeque<Input>,
+    generation: u16,
+    predicted: Position,
+}
+
+impl PredictedMotion {
+    pub fn new(initial: Position) -> Self {
+        Self {
+            log: VecDeque::new(),
+            generation: 0,
+            predicted: initial,
+        }
+    }
+
+    /// Update for input about to be sent to the server, returning the generation it should be
+    /// tagged with
+    pub fn push(&mut self, direction: &na::Unit<na::Vector3<f32>>, distance: f32) -> u16 {
+        let transform = math::translate_along(direction, distance);
+        self.predicted.local *= transform;
+        self.log.push_back(Input { transform });
+        self.generation = self.generation.wrapping_add(1);
+        self.generation
+    }
+
+    /// Update with the latest state received from the server and the generation it was based on
+    pub fn reconcile(&mut self, generation: u16, position: Position) {
+        let first_gen = self.generation.wrapping_sub(self.log.len() as u16);
+        let obsolete = usize::from(generation.wrapping_sub(first_gen));
+        if obsolete > self.log.len() || obsolete == 0 {
+            // We've already processed a state incorporating equal or more recent input
+            return;
+        }
+        self.log.drain(..obsolete);
+        self.predicted.node = position.node;
+        self.predicted.local = self
+            .log
+            .iter()
+            .fold(position.local, |acc, x| acc * x.transform);
+    }
+
+    /// Latest estimate of the server's state after receiving all `push`ed inputs.
+    pub fn predicted(&self) -> &Position {
+        &self.predicted
+    }
+}
+
+struct Input {
+    transform: na::Matrix4<f32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An arbitrary position
+    fn pos() -> Position {
+        Position {
+            node: common::graph::NodeId::ROOT,
+            local: na::one(),
+        }
+    }
+
+    #[test]
+    fn wraparound() {
+        let mut pred = PredictedMotion::new(pos());
+        pred.generation = u16::max_value() - 1;
+        assert_eq!(pred.push(&na::Vector3::x_axis(), 1.0), u16::max_value());
+        assert_eq!(pred.push(&na::Vector3::x_axis(), 1.0), 0);
+        assert_eq!(pred.log.len(), 2);
+
+        pred.reconcile(u16::max_value() - 1, pos());
+        assert_eq!(pred.log.len(), 2);
+        pred.reconcile(u16::max_value(), pos());
+        assert_eq!(pred.log.len(), 1);
+        pred.reconcile(0, pos());
+        assert_eq!(pred.log.len(), 0);
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -56,3 +56,18 @@ impl<F: FnOnce()> Drop for Defer<F> {
         }
     }
 }
+
+/// Convert a motion input into direction + speed, with speed clamped to 1.0 and graceful zero
+/// handling
+pub fn sanitize_motion_input(v: na::Vector3<f32>) -> (na::Unit<na::Vector3<f32>>, f32) {
+    if !v.iter().all(|x| x.is_finite()) {
+        return (-na::Vector3::z_axis(), 0.0);
+    }
+    let (direction, speed) = na::Unit::new_and_get(v);
+    if speed == 0.0 {
+        // Return an arbitrary direction rather than NaN
+        (-na::Vector3::z_axis(), speed)
+    } else {
+        (direction, speed.min(1.0))
+    }
+}

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -10,6 +10,7 @@ pub struct ClientHello {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerHello {
     pub character: EntityId,
+    pub rate: u16,
 }
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]
@@ -18,9 +19,11 @@ pub struct Position {
     pub local: na::Matrix4<f32>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateDelta {
     pub step: Step,
+    /// Highest input generation received prior to `step`
+    pub latest_input: u16,
     pub positions: Vec<(EntityId, Position)>,
     pub character_orientations: Vec<(EntityId, na::UnitQuaternion<f32>)>,
 }
@@ -35,11 +38,9 @@ pub struct Spawns {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Command {
-    pub step: Step,
-    /// The node that `orientation` and `velocity` are relative to
-    pub node: NodeId,
+    pub generation: u16,
     pub orientation: na::UnitQuaternion<f32>,
-    /// Relative to the character's current position
+    /// Relative to the character's current position, excluding orientation
     pub velocity: na::Vector3<f32>,
 }
 

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -11,7 +11,7 @@ use common::{
     graph::{Graph, NodeId},
     math,
     proto::{self, ClientHello, Command, Component, FreshNode, Position, Spawns, StateDelta},
-    EntityId, Step,
+    sanitize_motion_input, EntityId, Step,
 };
 
 pub struct Sim {
@@ -70,13 +70,9 @@ impl Sim {
         let mut ch = self.world.get_mut::<Character>(entity)?;
         if command.generation.wrapping_sub(ch.latest_input) < u16::max_value() / 2 {
             ch.latest_input = command.generation;
-            let (direction, speed) = na::Unit::new_and_get(command.velocity);
-            ch.direction = if speed == 0.0 {
-                -na::Vector3::z_axis()
-            } else {
-                direction
-            };
-            ch.speed = speed.min(1.0);
+            let (direction, speed) = sanitize_motion_input(command.velocity);
+            ch.direction = direction;
+            ch.speed = speed;
             ch.orientation = command.orientation;
         }
         Ok(())


### PR DESCRIPTION
With these changes, the client transmits input at exactly the server's tickrate, and immediately predicts the results. To ensure motion remains smooth and controllable at low tickrates, the actual input sent is the *average* of inputs over the timestep, so e.g. briefly tapping forwards will always produce a consistent small amount of motion.