### PR TITLE
Worldgen fixes

### DIFF
--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -240,12 +240,11 @@ struct EnviroFactors {
 }
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: u64) -> Self {
+        let slopeiness = parent.slopeiness + (1 - ((spice % 78) / 26) as i64);
         Self {
-            slopeiness: parent.slopeiness + (1 - ((spice % 78) / 26) as i64),
+            slopeiness,
             max_elevation: parent.max_elevation
-                + ((3 - parent.slopeiness.rem_euclid(7))
-                    + (3 - (parent.slopeiness + (1 - ((spice % 78) / 26) as i64)) //slopeiness
-                        .rem_euclid(7)))
+                + ((3 - parent.slopeiness.rem_euclid(7)) + (3 - slopeiness.rem_euclid(7)))
                 + (1 - ((spice % 30) / 10) as i64),
             temperature: parent.temperature + (1 - ((spice % 15) / 5) as i64),
             rainfall: parent.rainfall + (1 - ((spice % 90) / 30) as i64),


### PR DESCRIPTION
Per today's insight:

> If g is a homogeneous scalar field, then the following process will result in a homogeneous field f: for any node W with single descender a, let `f(W) = f(Wa) + (g(W) + g(Wa)) * R`

This change still relies on, for homogeneous scalar field `g(x)`, `g(x) % K` being a homogeneous scalar field. I feel like that's a pretty reasonable judgement, but I'd like @MagmaMcFry's sanity check.