### PR TITLE
Generate voxel chunks on-demand in a background thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,11 @@
 [workspace]
 members = ["client", "server", "common"]
+
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package."*"]
+opt-level = 2
+
+[profile.release.build-override]
+opt-level = 0

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -13,7 +13,7 @@ use common::{SimConfig, SimConfigRaw};
 pub struct Config {
     pub name: Arc<str>,
     pub data_dir: PathBuf,
-    pub chunks_loaded_per_frame: u32,
+    pub chunk_load_parallelism: u32,
     pub server: Option<SocketAddr>,
     pub local_simulation: SimConfig,
 }
@@ -27,7 +27,7 @@ impl Config {
             name,
             data_dir,
             local_simulation,
-            chunks_loaded_per_frame,
+            chunk_load_parallelism,
             server,
         } = match fs::read(&path) {
             Ok(data) => match toml::from_slice(&data) {
@@ -50,7 +50,7 @@ impl Config {
         Config {
             name: name.unwrap_or_else(|| whoami::user().into()),
             data_dir: data_dir.unwrap_or_else(|| dirs.data_dir().into()),
-            chunks_loaded_per_frame: chunks_loaded_per_frame.unwrap_or(16),
+            chunk_load_parallelism: chunk_load_parallelism.unwrap_or(16),
             server,
             local_simulation: SimConfig::from_raw(&local_simulation),
         }
@@ -84,7 +84,7 @@ impl Config {
 struct RawConfig {
     name: Option<Arc<str>>,
     data_dir: Option<PathBuf>,
-    chunks_loaded_per_frame: Option<u32>,
+    chunk_load_parallelism: Option<u32>,
     server: Option<SocketAddr>,
     #[serde(default)]
     local_simulation: SimConfigRaw,

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -5,8 +5,8 @@ use ash::{version::DeviceV1_0, vk};
 use lahar::Staged;
 use metrics::timing;
 
-use super::{loader::Asset, voxels, Base, Fog, GltfScene, Loader, Meshes, Voxels};
-use crate::{sim, Config, Sim};
+use super::{voxels, Base, Fog, GltfScene, Meshes, Voxels};
+use crate::{sim, Asset, Config, Loader, Sim};
 use common::proto::{Character, Position};
 
 /// Manages rendering, independent of what is being rendered to

--- a/client/src/graphics/gltf_mesh.rs
+++ b/client/src/graphics/gltf_mesh.rs
@@ -13,7 +13,8 @@ use futures_util::future::{try_join_all, BoxFuture, FutureExt};
 use lahar::{BufferRegionAlloc, DedicatedImage};
 use tracing::{error, trace};
 
-use super::{loader::Cleanup, meshes::Vertex, Base, LoadCtx, LoadFuture, Loadable, Mesh};
+use super::{meshes::Vertex, Base, Mesh};
+use crate::loader::{Cleanup, LoadCtx, LoadFuture, Loadable};
 
 pub struct GlbFile {
     pub path: PathBuf,

--- a/client/src/graphics/meshes.rs
+++ b/client/src/graphics/meshes.rs
@@ -223,7 +223,7 @@ pub struct Mesh {
     pub color_view: vk::ImageView,
 }
 
-impl super::loader::Cleanup for Mesh {
+impl crate::loader::Cleanup for Mesh {
     unsafe fn cleanup(mut self, gfx: &Base) {
         let device = &*gfx.device;
         device.destroy_descriptor_pool(self.pool, None);

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -19,6 +19,6 @@ pub use self::{
     gltf_mesh::{GlbFile, GltfScene},
     meshes::{Mesh, Meshes},
     png_array::PngArray,
-    voxels::Voxels,
+    voxels::{Chunk, Voxels},
     window::{EarlyWindow, Window},
 };

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -13,7 +13,6 @@ mod draw;
 mod fog;
 mod gltf_mesh;
 mod loader;
-pub mod lru_table;
 mod meshes;
 mod png_array;
 mod voxels;
@@ -29,7 +28,6 @@ pub use self::{
     fog::Fog,
     gltf_mesh::{GlbFile, GltfScene},
     loader::{Asset, LoadCtx, LoadFuture, Loadable, Loader},
-    lru_table::LruTable,
     meshes::{Mesh, Meshes},
     png_array::PngArray,
     voxels::Voxels,

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -1,18 +1,8 @@
-macro_rules! cstr {
-    ($x:literal) => {{
-        #[allow(unused_unsafe)]
-        unsafe {
-            std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($x, "\0").as_bytes())
-        }
-    }};
-}
-
 mod base;
 mod core;
 mod draw;
 mod fog;
 mod gltf_mesh;
-mod loader;
 mod meshes;
 mod png_array;
 mod voxels;
@@ -27,7 +17,6 @@ pub use self::{
     draw::Draw,
     fog::Fog,
     gltf_mesh::{GlbFile, GltfScene},
-    loader::{Asset, LoadCtx, LoadFuture, Loadable, Loader},
     meshes::{Mesh, Meshes},
     png_array::PngArray,
     voxels::Voxels,

--- a/client/src/graphics/png_array.rs
+++ b/client/src/graphics/png_array.rs
@@ -5,7 +5,7 @@ use ash::{version::DeviceV1_0, vk};
 use lahar::DedicatedImage;
 use tracing::trace;
 
-use super::{LoadCtx, LoadFuture, Loadable};
+use crate::loader::{LoadCtx, LoadFuture, Loadable};
 
 pub struct PngArray {
     pub path: PathBuf,

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -10,11 +10,7 @@ use ash::{vk, Device};
 use metrics::timing;
 use tracing::warn;
 
-use crate::{
-    graphics::{Base, Loader},
-    sim::VoxelData,
-    Config, Sim,
-};
+use crate::{graphics::Base, sim::VoxelData, Config, Loader, Sim};
 use common::{dodeca::Vertex, graph::NodeId, math, LruSlab};
 
 use surface::Surface;

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -10,13 +10,12 @@ use ash::{vk, Device};
 use metrics::timing;
 use tracing::warn;
 
-use super::lru_table::LruTable;
 use crate::{
     graphics::{Base, Loader},
     sim::VoxelData,
     Config, Sim,
 };
-use common::{dodeca::Vertex, graph::NodeId, math};
+use common::{dodeca::Vertex, graph::NodeId, math, LruSlab};
 
 use surface::Surface;
 use surface_extraction::{DrawBuffer, ScratchBuffer, SurfaceExtraction};
@@ -26,7 +25,7 @@ pub struct Voxels {
     surface_extraction: SurfaceExtraction,
     extraction_scratch: ScratchBuffer,
     surfaces: DrawBuffer,
-    states: LruTable<SurfaceState>,
+    states: LruSlab<SurfaceState>,
     draw: Surface,
 }
 
@@ -63,7 +62,7 @@ impl Voxels {
             surface_extraction,
             extraction_scratch,
             surfaces,
-            states: LruTable::with_capacity(max_chunks),
+            states: LruSlab::with_capacity(max_chunks),
             draw,
         }
     }
@@ -226,7 +225,7 @@ pub struct Frame {
     surface: surface::Frame,
     /// Scratch slots completed in this frame
     extracted: Vec<u32>,
-    drawn: Vec<super::lru_table::SlotId>,
+    drawn: Vec<common::lru_slab::SlotId>,
 }
 
 impl Frame {

--- a/client/src/graphics/voxels/surface.rs
+++ b/client/src/graphics/voxels/surface.rs
@@ -5,7 +5,7 @@ use lahar::{DedicatedImage, DedicatedMapping};
 use vk_shader_macros::include_glsl;
 
 use super::surface_extraction::DrawBuffer;
-use crate::graphics::{Asset, Base, Loader};
+use crate::{graphics::Base, Asset, Loader};
 use common::{defer, world::Material};
 
 const VERT: &[u32] = include_glsl!("shaders/voxels.vert");

--- a/client/src/loader.rs
+++ b/client/src/loader.rs
@@ -13,8 +13,7 @@ use lahar::{transfer, transfer::TransferHandle, BufferRegion, DedicatedImage, St
 use tokio::sync::mpsc;
 use tracing::error;
 
-use super::Base;
-use crate::Config;
+use crate::{graphics::Base, Config};
 
 pub trait Cleanup {
     unsafe fn cleanup(self, gfx: &Base);

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,5 +1,15 @@
+macro_rules! cstr {
+    ($x:literal) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($x, "\0").as_bytes())
+        }
+    }};
+}
+
 mod config;
 mod graphics;
+mod loader;
 mod metrics;
 mod net;
 mod prediction;
@@ -12,6 +22,7 @@ use std::{
 };
 
 use config::Config;
+use loader::{Asset, Loader};
 use net::Net;
 use sim::Sim;
 

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -4,13 +4,11 @@ use fxhash::FxHashMap;
 use hecs::Entity;
 use tracing::{debug, error, trace};
 
-use crate::{
-    graphics::lru_table::SlotId, net, prediction::PredictedMotion, worldgen, worldgen::NodeState,
-    Net,
-};
+use crate::{net, prediction::PredictedMotion, worldgen, worldgen::NodeState, Net};
 use common::{
     dodeca,
     graph::{Graph, NodeId},
+    lru_slab::SlotId,
     math,
     proto::{self, Character, Command, Component, Position},
     sanitize_motion_input,

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -393,6 +393,8 @@ fn populate_chunk(graph: &mut DualGraph, dimension: u8, node: NodeId, chunk: dod
         .expect("must not be called on an unpopulated node")
         .chunks[chunk] = Some(Chunk {
         surface: None,
-        voxels: worldgen::voxels(graph, node, chunk, dimension),
+        voxels: worldgen::ChunkParams::new(graph, node, chunk)
+            .expect("incident nodes must all be populated")
+            .generate_voxels(dimension),
     });
 }

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -20,6 +20,8 @@ pub type DualGraph = Graph<Node>;
 
 pub struct Node {
     pub state: NodeState,
+    /// We can only populate chunks which lie within a cube of populated nodes, so nodes on the edge
+    /// of the graph always have some `None` chunks.
     pub chunks: Chunks<Option<Chunk>>,
 }
 

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -371,7 +371,6 @@ fn populate_fresh_nodes(graph: &mut DualGraph, dimension: u8) {
             }
         }
     }
-    graph.clear_fresh();
 }
 
 fn populate_node(graph: &mut DualGraph, node: NodeId) {

--- a/client/src/worldgen.rs
+++ b/client/src/worldgen.rs
@@ -9,7 +9,7 @@ use common::{
 };
 
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub enum NodeStateKind {
+enum NodeStateKind {
     RootSky,
     Sky,
     DeepSky,
@@ -19,10 +19,10 @@ pub enum NodeStateKind {
 use NodeStateKind::*;
 
 impl NodeStateKind {
-    pub const ROOT: Self = RootSky;
+    const ROOT: Self = RootSky;
 
     /// What state comes after this state, from a given side?
-    pub fn child(self, side: Side) -> Self {
+    fn child(self, side: Side) -> Self {
         match (self, side) {
             (RootSky, _) => match side {
                 _ if side.adjacent_to(Side::A) => Land,
@@ -253,7 +253,7 @@ pub fn voxels(graph: &DualGraph, node: NodeId, chunk: Vertex, dimension: u8) -> 
     voxels
 }
 
-pub struct NeighborData {
+struct NeighborData {
     coords_opposing: na::Vector3<u8>,
     material: Material,
 }
@@ -269,7 +269,7 @@ fn voxel_neighbors(dim: u8, coords: na::Vector3<u8>, voxels: &mut VoxelData) -> 
     ]
 }
 
-pub fn neighbor(
+fn neighbor(
     dimension: u8,
     w: na::Vector3<u8>,
     x: i8,
@@ -393,7 +393,7 @@ fn chunk_incident_enviro_factors(
 }
 
 /// Keeps track of the canonical surface wrt. the NodeState this is stored in
-pub struct Surface {
+struct Surface {
     normal: na::Vector4<f64>,
 }
 impl Surface {

--- a/common/src/chunks.rs
+++ b/common/src/chunks.rs
@@ -2,6 +2,9 @@ use std::ops::{Index, IndexMut};
 
 use crate::dodeca::Vertex;
 
+/// A table of chunks contained by a single node
+///
+/// Each chunk is 1/8 of a cube whose vertices are at the centers of nodes.
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Chunks<T> {
     values: [T; 20],

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cursor;
 pub mod dodeca;
 pub mod graph;
 mod graph_entities;
+pub mod lru_slab;
 pub mod math;
 pub mod proto;
 mod sim_config;
@@ -19,6 +20,7 @@ pub mod world;
 
 pub use chunks::Chunks;
 pub use graph_entities::GraphEntities;
+pub use lru_slab::LruSlab;
 pub use sim_config::{SimConfig, SimConfigRaw};
 
 // Stable IDs made of 8 random bytes for easy persistent references

--- a/common/src/lru_slab.rs
+++ b/common/src/lru_slab.rs
@@ -1,12 +1,12 @@
 /// A fixed-size random-access table that maintains an LRU list in constant time
-pub struct LruTable<T> {
+pub struct LruSlab<T> {
     slots: Box<[Slot<T>]>,
     free: Vec<SlotId>,
     head: SlotId,
     tail: SlotId,
 }
 
-impl<T> LruTable<T> {
+impl<T> LruSlab<T> {
     pub fn with_capacity(n: u32) -> Self {
         assert!(n != u32::max_value(), "capacity too large");
         Self {
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn lru_order() {
-        let mut cache = LruTable::with_capacity(4);
+        let mut cache = LruSlab::with_capacity(4);
         let b = cache.insert(1).unwrap();
         let _a = cache.insert(0).unwrap();
         let d = cache.insert(3).unwrap();

--- a/common/src/lru_slab.rs
+++ b/common/src/lru_slab.rs
@@ -1,4 +1,4 @@
-/// A fixed-size random-access table that maintains an LRU list in constant time
+/// A random-access table that maintains an LRU list in constant time
 pub struct LruSlab<T> {
     slots: Box<[Slot<T>]>,
     /// Most recently used
@@ -7,9 +7,15 @@ pub struct LruSlab<T> {
     tail: SlotId,
     /// First unused
     free: SlotId,
+    /// Number of occupied slots
+    len: u32,
 }
 
 impl<T> LruSlab<T> {
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
     pub fn with_capacity(capacity: u32) -> Self {
         assert!(capacity != u32::max_value(), "capacity too large");
         Self {
@@ -27,13 +33,21 @@ impl<T> LruSlab<T> {
                 .into(),
             head: SlotId::NONE,
             tail: SlotId::NONE,
-            free: SlotId(0),
+            free: if capacity == 0 {
+                SlotId::NONE
+            } else {
+                SlotId(0)
+            },
+            len: 0,
         }
     }
 
-    /// Whether `insert` is guaranteed to return `None`
-    pub fn is_full(&self) -> bool {
-        self.free == SlotId::NONE
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn len(&self) -> u32 {
+        self.len
     }
 
     pub fn capacity(&self) -> u32 {
@@ -43,15 +57,43 @@ impl<T> LruSlab<T> {
     /// Inserts a value, returning the slot it was stored in
     ///
     /// The returned slot is marked as the most recently used.
-    pub fn insert(&mut self, value: T) -> Option<SlotId> {
-        let id = self.alloc()?;
+    pub fn insert(&mut self, value: T) -> SlotId {
+        let id = match self.alloc() {
+            Some(id) => id,
+            None => {
+                let len = self.capacity();
+                let cap = 2 * len.max(2);
+                self.slots = self
+                    .slots
+                    .iter_mut()
+                    .map(|x| Slot {
+                        value: x.value.take(),
+                        next: x.next,
+                        prev: x.prev,
+                    })
+                    .chain((len..cap).map(|n| Slot {
+                        value: None,
+                        prev: SlotId::NONE,
+                        next: if n + 1 == cap {
+                            SlotId::NONE
+                        } else {
+                            SlotId(n + 1)
+                        },
+                    }))
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+                self.free = SlotId(len + 1);
+                SlotId(len)
+            }
+        };
         let idx = id.0 as usize;
 
         debug_assert!(self.slots[idx].value.is_none(), "corrupt free list");
         self.slots[idx].value = Some(value);
         self.link_at_head(id);
+        self.len += 1;
 
-        Some(id)
+        id
     }
 
     /// Get the least recently used slot, if any
@@ -69,6 +111,7 @@ impl<T> LruSlab<T> {
         self.slots[slot.0 as usize].next = self.free;
         self.slots[slot.0 as usize].prev = SlotId::NONE;
         self.free = slot;
+        self.len -= 1;
         self.slots[slot.0 as usize]
             .value
             .take()
@@ -95,7 +138,9 @@ impl<T> LruSlab<T> {
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             slots: &self.slots[..],
-            next: self.head,
+            head: self.head,
+            tail: self.tail,
+            len: self.len,
         }
     }
 
@@ -153,6 +198,12 @@ impl<T> LruSlab<T> {
     }
 }
 
+impl<T> Default for LruSlab<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 struct Slot<T> {
     value: Option<T>,
     /// Next slot in the LRU or free list
@@ -170,19 +221,45 @@ impl SlotId {
 
 pub struct Iter<'a, T> {
     slots: &'a [Slot<T>],
-    next: SlotId,
+    head: SlotId,
+    tail: SlotId,
+    len: u32,
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {
-        if self.next == SlotId::NONE {
+        if self.len == 0 {
             return None;
         }
-        let idx = self.next.0 as usize;
+        let idx = self.head.0 as usize;
         let result = self.slots[idx].value.as_ref().expect("corrupt LRU list");
-        self.next = self.slots[idx].next;
+        self.head = self.slots[idx].next;
+        self.len -= 1;
         Some(result)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len as usize, Some(self.len as usize))
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    fn next_back(&mut self) -> Option<&'a T> {
+        if self.len == 0 {
+            return None;
+        }
+        let idx = self.tail.0 as usize;
+        let result = self.slots[idx].value.as_ref().expect("corrupt LRU list");
+        self.tail = self.slots[idx].prev;
+        self.len -= 1;
+        Some(result)
+    }
+}
+
+impl<T> ExactSizeIterator for Iter<'_, T> {
+    fn len(&self) -> usize {
+        self.len as usize
     }
 }
 
@@ -192,36 +269,38 @@ mod tests {
 
     #[test]
     fn lru_order() {
-        let mut cache = LruSlab::with_capacity(4);
-        let b = cache.insert('b').unwrap();
+        let mut cache = LruSlab::new();
+        let b = cache.insert('b');
         assert_eq!(cache.iter().collect::<String>(), "b");
-        let _a = cache.insert('a').unwrap();
+        let _a = cache.insert('a');
         assert_eq!(cache.iter().collect::<String>(), "ab");
-        let d = cache.insert('d').unwrap();
+        let d = cache.insert('d');
         assert_eq!(cache.iter().collect::<String>(), "dab");
-        let c = cache.insert('c').unwrap();
+        let c = cache.insert('c');
         assert_eq!(cache.iter().collect::<String>(), "cdab");
-
-        assert!(cache.insert('e').is_none());
+        let e = cache.insert('e');
+        assert_eq!(cache.iter().collect::<String>(), "ecdab");
 
         cache.get_mut(b);
         cache.get_mut(c);
         cache.get_mut(d);
+        cache.get_mut(e);
 
         assert_eq!(cache.remove(cache.lru().unwrap()), 'a');
         assert_eq!(cache.remove(cache.lru().unwrap()), 'b');
         assert_eq!(cache.remove(cache.lru().unwrap()), 'c');
         assert_eq!(cache.remove(cache.lru().unwrap()), 'd');
+        assert_eq!(cache.remove(cache.lru().unwrap()), 'e');
         assert!(cache.lru().is_none());
     }
 
     #[test]
     fn slot_reuse() {
-        let mut cache = LruSlab::with_capacity(1);
-        let a = cache.insert('a').unwrap();
-        assert!(cache.insert('b').is_none());
+        let mut cache = LruSlab::new();
+        let a = cache.insert('a');
         cache.remove(a);
-        let a_prime = cache.insert('a').unwrap();
+        let a_prime = cache.insert('a');
         assert_eq!(a, a_prime);
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -45,7 +45,7 @@ impl SimConfig {
         let meters_to_absolute = meters_to_absolute(chunk_size, voxel_size);
         SimConfig {
             rate: x.rate.unwrap_or(10),
-            view_distance: x.view_distance.unwrap_or(75.0) * meters_to_absolute,
+            view_distance: x.view_distance.unwrap_or(90.0) * meters_to_absolute,
             input_queue_size: Duration::from_millis(x.input_queue_size_ms.unwrap_or(50).into()),
             chunk_size,
             movement_speed: x.movement_speed.unwrap_or(12.0) * meters_to_absolute,


### PR DESCRIPTION
Fixes #45, #46. Still TODO: async surface extraction, which seems to be the bottleneck on intel GPUs. Terrain gen CPU load seems insignificant once decoupled.