### PR TITLE
Benchmark and optimize surface extraction

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -48,6 +48,7 @@ use-repo-assets = []
 [dev-dependencies]
 approx = "0.3.2"
 bencher = "0.1.5"
+renderdoc = "0.9"
 
 [[bench]]
 name = "surface_extraction"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -47,3 +47,8 @@ use-repo-assets = []
 
 [dev-dependencies]
 approx = "0.3.2"
+bencher = "0.1.5"
+
+[[bench]]
+name = "surface_extraction"
+harness = false

--- a/client/benches/surface_extraction.rs
+++ b/client/benches/surface_extraction.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use ash::{version::DeviceV1_0, vk};
+use bencher::{benchmark_group, benchmark_main, Bencher};
+
+use client::graphics::{
+    voxels::surface_extraction::{self, SurfaceExtraction},
+    Base,
+};
+//use common::world::Material;
+
+fn extract(bench: &mut Bencher) {
+    let gfx = Arc::new(Base::headless());
+    let extract = SurfaceExtraction::new(&gfx);
+    let mut scratch = surface_extraction::ScratchBuffer::new(&gfx, &extract, BATCH_SIZE, DIMENSION);
+    let draw = surface_extraction::DrawBuffer::new(&gfx, BATCH_SIZE, DIMENSION);
+    let device = &*gfx.device;
+
+    unsafe {
+        let cmd_pool = device
+            .create_command_pool(
+                &vk::CommandPoolCreateInfo::builder().queue_family_index(gfx.queue_family),
+                None,
+            )
+            .unwrap();
+
+        let cmd = device
+            .allocate_command_buffers(
+                &vk::CommandBufferAllocateInfo::builder()
+                    .command_pool(cmd_pool)
+                    .command_buffer_count(1),
+            )
+            .unwrap()[0];
+
+        device
+            .begin_command_buffer(cmd, &vk::CommandBufferBeginInfo::default())
+            .unwrap();
+
+        for i in 0..BATCH_SIZE {
+            scratch.extract(
+                device,
+                &extract,
+                i,
+                false,
+                DIMENSION,
+                cmd,
+                (draw.indirect_buffer(), draw.indirect_offset(i)),
+                (draw.face_buffer(), draw.face_offset(i)),
+            );
+        }
+        device.end_command_buffer(cmd).unwrap();
+
+        bench.iter(|| {
+            device
+                .queue_submit(
+                    gfx.queue,
+                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    vk::Fence::null(),
+                )
+                .unwrap();
+            device.device_wait_idle().unwrap();
+        })
+    }
+}
+
+const DIMENSION: u32 = 16;
+const BATCH_SIZE: u32 = 16;
+
+benchmark_group!(benches, extract);
+benchmark_main!(benches);

--- a/client/shaders/surface-extraction/common.h
+++ b/client/shaders/surface-extraction/common.h
@@ -44,8 +44,8 @@ bool find_face(out Face info) {
         { 0,  0, -1},
     };
     const ivec3 padding_coord = ivec3(gl_NumWorkGroups.y - 1);
-    info.voxel = ivec3(gl_GlobalInvocationID.x % gl_NumWorkGroups.y, gl_GlobalInvocationID.yz);
-    info.axis = gl_GlobalInvocationID.x / gl_NumWorkGroups.y;
+    info.voxel = ivec3(gl_GlobalInvocationID.x / 3, gl_GlobalInvocationID.yz);
+    info.axis = gl_GlobalInvocationID.x % 3;
     ivec3 neighbor = info.voxel + offsets[info.axis];
     // Don't generate faces between out-of-bounds voxels
     if (any(equal(info.voxel, padding_coord)) && any(equal(neighbor, padding_coord))) return false;

--- a/client/shaders/surface-extraction/common.h
+++ b/client/shaders/surface-extraction/common.h
@@ -7,7 +7,11 @@ uint invocation_index() {
         + gl_GlobalInvocationID.x;
 }
 
-layout(set = 0, binding = 0) readonly restrict buffer Voxels {
+layout(set = 0, binding = 0) restrict uniform Parameters {
+    int dimension;
+};
+
+layout(set = 1, binding = 0) readonly restrict buffer Voxels {
     uint voxel_pair[];
 };
 
@@ -44,12 +48,11 @@ ivec3 neighbor_offset(uint axis) {
 bool find_face(out Face info) {
     // We only look at negative-facing faces of the current voxel, and iterate one past the end on
     // each dimension to enclose it fully.
-    const ivec3 padding_coord = ivec3(gl_NumWorkGroups.y - 1);
     info.voxel = ivec3(gl_GlobalInvocationID.x / 3, gl_GlobalInvocationID.yz);
     info.axis = gl_GlobalInvocationID.x % 3;
     ivec3 neighbor = info.voxel + neighbor_offset(info.axis);
     // Don't generate faces between out-of-bounds voxels
-    if (any(equal(info.voxel, padding_coord)) && any(equal(neighbor, padding_coord))) return false;
+    if (any(equal(info.voxel, ivec3(dimension))) && any(equal(neighbor, ivec3(dimension)))) return false;
     uint neighbor_mat = get_voxel(neighbor);
     uint self_mat = get_voxel(info.voxel);
     // Flip face around if the neighbor is the solid one

--- a/client/shaders/surface-extraction/common.h
+++ b/client/shaders/surface-extraction/common.h
@@ -35,18 +35,19 @@ struct Face {
     uint material;
 };
 
+ivec3 neighbor_offset(uint axis) {
+    ivec3 off = ivec3(0);
+    off[axis] = -1;
+    return off;
+}
+
 bool find_face(out Face info) {
     // We only look at negative-facing faces of the current voxel, and iterate one past the end on
     // each dimension to enclose it fully.
-    const ivec3 offsets[3] = {
-        {-1,  0,  0},
-        { 0, -1,  0},
-        { 0,  0, -1},
-    };
     const ivec3 padding_coord = ivec3(gl_NumWorkGroups.y - 1);
     info.voxel = ivec3(gl_GlobalInvocationID.x / 3, gl_GlobalInvocationID.yz);
     info.axis = gl_GlobalInvocationID.x % 3;
-    ivec3 neighbor = info.voxel + offsets[info.axis];
+    ivec3 neighbor = info.voxel + neighbor_offset(info.axis);
     // Don't generate faces between out-of-bounds voxels
     if (any(equal(info.voxel, padding_coord)) && any(equal(neighbor, padding_coord))) return false;
     uint neighbor_mat = get_voxel(neighbor);

--- a/client/shaders/surface-extraction/count.comp
+++ b/client/shaders/surface-extraction/count.comp
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-layout(set = 0, binding = 1) writeonly restrict buffer FaceCounts {
+layout(set = 1, binding = 1) writeonly restrict buffer FaceCounts {
     uint face_counts[];
 };
 

--- a/client/shaders/surface-extraction/emit.comp
+++ b/client/shaders/surface-extraction/emit.comp
@@ -37,12 +37,6 @@ uint vertex_occlusion(bool a, bool b, bool c) {
 
 // Compute the occlusion state for each vertex on a surface
 uvec4 surface_occlusion(ivec3 voxel, uint axis, bool inward) {
-    // Offset from voxel to the void voxel for this surface
-    const ivec3 offsets[3] = {
-        {-1,  0,  0},
-        { 0, -1,  0},
-        { 0,  0, -1},
-    };
     // U/V axes on this surface
     const ivec3 uvs[3][2] = {
         {{0, 1, 0}, {0, 0, 1}},
@@ -51,7 +45,7 @@ uvec4 surface_occlusion(ivec3 voxel, uint axis, bool inward) {
     };
 
     if (!inward) {
-        voxel += offsets[axis];
+        voxel += neighbor_offset(axis);
     }
 
     ivec3 u = uvs[axis][0];

--- a/client/shaders/surface-extraction/emit.comp
+++ b/client/shaders/surface-extraction/emit.comp
@@ -3,16 +3,16 @@
 #include "common.h"
 #include "surface.h"
 
-layout(set = 0, binding = 1) readonly restrict buffer FaceCounts {
+layout(set = 1, binding = 1) readonly restrict buffer FaceCounts {
     uint face_counts[];
 };
-layout(set = 0, binding = 2) writeonly restrict buffer Indirect {
+layout(set = 1, binding = 2) writeonly restrict buffer Indirect {
     uint vertex_count;
     uint instance_count;
     uint first_vertex;
     uint first_instance;
 };
-layout(set = 0, binding = 3) writeonly restrict buffer Surfaces {
+layout(set = 1, binding = 3) writeonly restrict buffer Surfaces {
     Surface surfaces[];
 };
 layout(push_constant) uniform Uniforms {
@@ -73,7 +73,7 @@ uvec4 surface_occlusion(ivec3 voxel, uint axis, bool inward) {
 
 void main() {
     uint count = face_counts[invocation_index()];
-    if (gl_GlobalInvocationID == gl_NumWorkGroups - uvec3(1)) {
+    if (gl_GlobalInvocationID == uvec3(dimension * 3, dimension, dimension)) {
         vertex_count = count * 6; // two triangles per face
         instance_count = 1;
         first_vertex = offset * 6;

--- a/client/shaders/surface-extraction/prefix-sum.comp
+++ b/client/shaders/surface-extraction/prefix-sum.comp
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-layout(set = 0, binding = 1) restrict buffer FaceCounts {
+layout(set = 1, binding = 1) restrict buffer FaceCounts {
     uint face_counts[];
 };
 layout(push_constant) uniform Uniforms {

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -50,7 +50,7 @@ impl Config {
         Config {
             name: name.unwrap_or_else(|| whoami::user().into()),
             data_dir: data_dir.unwrap_or_else(|| dirs.data_dir().into()),
-            chunk_load_parallelism: chunk_load_parallelism.unwrap_or(16),
+            chunk_load_parallelism: chunk_load_parallelism.unwrap_or(256),
             server,
             local_simulation: SimConfig::from_raw(&local_simulation),
         }

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -298,7 +298,7 @@ impl Base {
         .unwrap();
     }
 
-    #[cfg(test)]
+    /// Convenience constructor for tests and benchmarks
     pub fn headless() -> Self {
         let core = Core::new(&[]);
         Self::new(Arc::new(core), None, &[], |_, _| true).unwrap()

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -8,7 +8,7 @@ mod frustum;
 mod gltf_mesh;
 mod meshes;
 mod png_array;
-mod voxels;
+pub mod voxels;
 mod window;
 
 #[cfg(test)]

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -26,3 +26,7 @@ pub use self::{
     voxels::{Chunk, Voxels},
     window::{EarlyWindow, Window},
 };
+
+unsafe fn as_bytes<T: Copy>(x: &T) -> &[u8] {
+    std::slice::from_raw_parts(x as *const T as *const u8, std::mem::size_of::<T>())
+}

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -1,5 +1,5 @@
 mod surface;
-mod surface_extraction;
+pub mod surface_extraction;
 
 #[cfg(test)]
 mod tests;

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -72,7 +72,10 @@ impl Voxels {
         }
     }
 
-    /// Determine what to render and record the appropriate transfer commands
+    /// Determine what to render and stage chunk transforms
+    ///
+    /// Surface extraction commands are written to `cmd`, and will be presumed complete for the next
+    /// (not current) frame.
     pub unsafe fn prepare(
         &mut self,
         device: &Device,
@@ -135,7 +138,7 @@ impl Voxels {
             use Chunk::*;
             for chunk in Vertex::iter() {
                 // Fetch existing chunk, or extract surface of new chunk
-                let slot = match sim
+                match sim
                     .graph
                     .get_mut(node)
                     .as_mut()
@@ -162,13 +165,16 @@ impl Voxels {
                         ref mut surface,
                         ref voxels,
                     } => match (surface, voxels) {
-                        (&mut Some(x), _) => {
-                            // Render an extracted surface
-                            self.states.get_mut(x).refcount += 1;
-                            x
+                        (&mut Some(slot), _) => {
+                            // Render an already-extracted surface
+                            self.states.get_mut(slot).refcount += 1;
+                            frame.drawn.push(slot);
+                            // Transfer transform
+                            frame.surface.transforms_mut()[slot.0 as usize] =
+                                node_transform * chunk.chunk_to_node().map(|x| x as f32);
                         }
                         (&mut ref mut surface @ None, &VoxelData::Dense(ref data)) => {
-                            // Extract a surface
+                            // Extract a surface so it can be drawn in future frames
                             if frame.extracted.len() == self.config.chunk_load_parallelism as usize
                             {
                                 continue;
@@ -188,7 +194,7 @@ impl Voxels {
                             let slot = self.states.insert(SurfaceState {
                                 node,
                                 chunk,
-                                refcount: 1,
+                                refcount: 0,
                             });
                             *surface = Some(slot);
                             let storage = self.extraction_scratch.storage(scratch_slot);
@@ -210,15 +216,10 @@ impl Voxels {
                                 draw_id: slot.0,
                                 reverse_winding: chunk.parity() ^ node_is_odd,
                             });
-                            slot
                         }
                         (None, &VoxelData::Solid(_)) => continue,
                     },
-                };
-                frame.drawn.push(slot);
-                // Transfer transform
-                frame.surface.transforms_mut()[slot.0 as usize] =
-                    node_transform * chunk.chunk_to_node().map(|x| x as f32);
+                }
             }
         }
         self.extraction_scratch.extract(

--- a/client/src/graphics/voxels/tests.rs
+++ b/client/src/graphics/voxels/tests.rs
@@ -90,12 +90,16 @@ impl SurfaceExtractionTest {
             self.scratch.extract(
                 device,
                 &self.extract,
-                0,
-                false,
-                DIMENSION as u32,
+                self.indirect.buffer(),
+                self.vertices.buffer(),
                 self.cmd,
-                (self.indirect.buffer(), 0),
-                (self.vertices.buffer(), 0),
+                &[surface_extraction::ExtractTask {
+                    indirect_offset: 0,
+                    face_offset: 0,
+                    index: 0,
+                    draw_id: 0,
+                    reverse_winding: false,
+                }],
             );
             device.end_command_buffer(self.cmd).unwrap();
 
@@ -183,7 +187,6 @@ fn surface_extraction() {
         "solid chunks have no surfaces"
     );
 
-    // TODO: Half-empty
     let storage = test.scratch.storage(0);
     for x in &mut storage[..] {
         *x = Material::Void;


### PR DESCRIPTION
~10x speedup for surface extraction on Intel. Pop-in is now much less of an issue; we just need to fine tune view distance culling and it'll be a thing of the past.

Fixes #81.