### PR TITLE
Introduce minor quality of life improvements for movement

### DIFF
--- a/client/src/graphics/fog.rs
+++ b/client/src/graphics/fog.rs
@@ -18,13 +18,13 @@ impl Fog {
         unsafe {
             // Construct the shader modules
             let vert = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&VERT), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(VERT), None)
                 .unwrap();
             // Note that these only need to live until the pipeline itself is constructed
             let v_guard = defer(|| device.destroy_shader_module(vert, None));
 
             let frag = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&FRAG), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(FRAG), None)
                 .unwrap();
             let f_guard = defer(|| device.destroy_shader_module(frag, None));
 

--- a/client/src/graphics/meshes.rs
+++ b/client/src/graphics/meshes.rs
@@ -23,13 +23,13 @@ impl Meshes {
         unsafe {
             // Construct the shader modules
             let vert = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&VERT), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(VERT), None)
                 .unwrap();
             // Note that these only need to live until the pipeline itself is constructed
             let v_guard = defer(|| device.destroy_shader_module(vert, None));
 
             let frag = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&FRAG), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(FRAG), None)
                 .unwrap();
             let f_guard = defer(|| device.destroy_shader_module(frag, None));
 

--- a/client/src/graphics/voxels/surface.rs
+++ b/client/src/graphics/voxels/surface.rs
@@ -27,13 +27,13 @@ impl Surface {
         unsafe {
             // Construct the shader modules
             let vert = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&VERT), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(VERT), None)
                 .unwrap();
             // Note that these only need to live until the pipeline itself is constructed
             let v_guard = defer(|| device.destroy_shader_module(vert, None));
 
             let frag = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&FRAG), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(FRAG), None)
                 .unwrap();
             let f_guard = defer(|| device.destroy_shader_module(frag, None));
 

--- a/client/src/graphics/voxels/surface_extraction.rs
+++ b/client/src/graphics/voxels/surface_extraction.rs
@@ -84,7 +84,7 @@ impl SurfaceExtraction {
                 .unwrap();
 
             let extract = device
-                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(&EXTRACT), None)
+                .create_shader_module(&vk::ShaderModuleCreateInfo::builder().code(EXTRACT), None)
                 .unwrap();
             let extract_guard = defer(|| device.destroy_shader_module(extract, None));
 

--- a/client/src/graphics/voxels/tests.rs
+++ b/client/src/graphics/voxels/tests.rs
@@ -179,7 +179,7 @@ fn surface_extraction() {
     );
 
     let storage = test.scratch.storage(0);
-    for x in &mut storage[..] {
+    for x in &mut *storage {
         *x = Material::Void;
     }
     for z in 0..((DIMENSION + 2) / 2) {

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -112,7 +112,7 @@ impl Window {
         let mut clockwise = false;
         let mut anticlockwise = false;
         let mut last_frame = Instant::now();
-        let mut focused = false;
+        let mut mouse_captured = false;
         self.event_loop
             .take()
             .unwrap()
@@ -144,7 +144,7 @@ impl Window {
                     self.draw();
                 }
                 Event::DeviceEvent { event, .. } => match event {
-                    DeviceEvent::MouseMotion { delta } if focused => {
+                    DeviceEvent::MouseMotion { delta } if mouse_captured => {
                         const SENSITIVITY: f32 = 2e-3;
                         let rot = na::UnitQuaternion::from_axis_angle(
                             &na::Vector3::y_axis(),
@@ -176,7 +176,7 @@ impl Window {
                     } => {
                         let _ = self.window.set_cursor_grab(true);
                         self.window.set_cursor_visible(false);
-                        focused = true;
+                        mouse_captured = true;
                     }
                     WindowEvent::KeyboardInput {
                         input:
@@ -214,9 +214,16 @@ impl Window {
                         VirtualKeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(false);
                             self.window.set_cursor_visible(true);
-                            focused = false;
+                            mouse_captured = false;
                         }
                         _ => {}
+                    }
+                    WindowEvent::Focused(focused) => {
+                        if !focused {
+                            let _ = self.window.set_cursor_grab(false);
+                            self.window.set_cursor_visible(true);
+                            mouse_captured = false;
+                        }
                     }
                     _ => {}
                 },

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -120,14 +120,21 @@ impl Window {
                 Event::MainEventsCleared => {
                     let this_frame = Instant::now();
                     let dt = this_frame - last_frame;
-                    let move_direction: na::Vector3<f32> = na::Vector3::x() * (right as u8 as f32 - left as u8 as f32)
+                    let move_direction: na::Vector3<f32> = na::Vector3::x()
+                        * (right as u8 as f32 - left as u8 as f32)
                         + na::Vector3::y() * (up as u8 as f32 - down as u8 as f32)
                         + na::Vector3::z() * (back as u8 as f32 - forward as u8 as f32);
-                    self.sim.velocity(if move_direction.norm_squared() > 1.0 { move_direction.normalize() } else { move_direction });
+                    self.sim.velocity(if move_direction.norm_squared() > 1.0 {
+                        move_direction.normalize()
+                    } else {
+                        move_direction
+                    });
 
                     self.sim.rotate(&na::UnitQuaternion::from_axis_angle(
                         &-na::Vector3::z_axis(),
-                        (clockwise as u8 as f32 - anticlockwise as u8 as f32) * 2.0 * dt.as_secs_f32(),
+                        (clockwise as u8 as f32 - anticlockwise as u8 as f32)
+                            * 2.0
+                            * dt.as_secs_f32(),
                     ));
 
                     let had_params = self.sim.params().is_some();
@@ -217,7 +224,7 @@ impl Window {
                             mouse_captured = false;
                         }
                         _ => {}
-                    }
+                    },
                     WindowEvent::Focused(focused) => {
                         if !focused {
                             let _ = self.window.set_cursor_grab(false);

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -112,26 +112,27 @@ impl Window {
         let mut clockwise = false;
         let mut anticlockwise = false;
         let mut last_frame = Instant::now();
-        let mut focused = true;
+        let mut focused = false;
         self.event_loop
             .take()
             .unwrap()
             .run(move |event, _, control_flow| match event {
                 Event::MainEventsCleared => {
-                    let velocity = na::Vector3::x() * (right as u8 as f32 - left as u8 as f32)
+                    let this_frame = Instant::now();
+                    let dt = this_frame - last_frame;
+                    let move_direction: na::Vector3<f32> = na::Vector3::x() * (right as u8 as f32 - left as u8 as f32)
                         + na::Vector3::y() * (up as u8 as f32 - down as u8 as f32)
                         + na::Vector3::z() * (back as u8 as f32 - forward as u8 as f32);
-                    self.sim.velocity(velocity);
+                    self.sim.velocity(if move_direction.norm_squared() > 1.0 { move_direction.normalize() } else { move_direction });
 
                     self.sim.rotate(&na::UnitQuaternion::from_axis_angle(
                         &-na::Vector3::z_axis(),
-                        (clockwise as u8 as f32 - anticlockwise as u8 as f32) * 5e-2,
+                        (clockwise as u8 as f32 - anticlockwise as u8 as f32) * 2.0 * dt.as_secs_f32(),
                     ));
 
                     let had_params = self.sim.params().is_some();
 
-                    let this_frame = Instant::now();
-                    self.sim.step(this_frame - last_frame);
+                    self.sim.step(dt);
                     last_frame = this_frame;
 
                     if !had_params {
@@ -175,6 +176,7 @@ impl Window {
                     } => {
                         let _ = self.window.set_cursor_grab(true);
                         self.window.set_cursor_visible(false);
+                        focused = true;
                     }
                     WindowEvent::KeyboardInput {
                         input:
@@ -212,11 +214,9 @@ impl Window {
                         VirtualKeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(false);
                             self.window.set_cursor_visible(true);
+                            focused = false;
                         }
                         _ => {}
-                    },
-                    WindowEvent::Focused(x) => {
-                        focused = x;
                     }
                     _ => {}
                 },

--- a/client/src/loader.rs
+++ b/client/src/loader.rs
@@ -278,7 +278,7 @@ impl<T: 'static + Cleanup> AnyTable for Table<T> {
     }
 
     fn cleanup(self: Box<Self>, gfx: &Base) {
-        for x in self.data.into_iter().filter_map(|x| x) {
+        for x in self.data.into_iter().flatten() {
             unsafe {
                 x.cleanup(gfx);
             }

--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -124,7 +124,7 @@ async fn handle_unordered(
     let mut msgs = uni_streams
         .map(|stream| async {
             let stream = stream?;
-            Ok::<_, Error>(codec::recv_whole::<proto::StateDelta>(2usize.pow(16), stream).await?)
+            codec::recv_whole::<proto::StateDelta>(2usize.pow(16), stream).await
         })
         .buffer_unordered(128);
     // TODO: Don't silently die on parse errors

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -157,7 +157,7 @@ lazy_static! {
                 let cosh_distance = (REFLECTIONS[i] * REFLECTIONS[j])[(3, 3)];
                 // Possile cosh_distances: 1, 4.23606 = 2+sqrt(5), 9.47213 = 5+2*sqrt(5), 12.70820 = 6+3*sqrt(5);
                 // < 2.0 indicates identical faces; < 5.0 indicates adjacent faces; > 5.0 indicates non-adjacent faces
-                result[i][j] = cosh_distance >= 2.0 && cosh_distance < 5.0;
+                result[i][j] = (2.0..5.0).contains(&cosh_distance);
             }
         }
         result

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -39,7 +39,7 @@ impl<N: RealField> HPoint<N> {
 /// Point reflection around `p`
 pub fn reflect<N: RealField>(p: &na::Vector4<N>) -> na::Matrix4<N> {
     na::Matrix4::<N>::identity()
-        - (*p * p.transpose() * i31::<N>()) * na::convert::<_, N>(2.0) / mip(&p, &p)
+        - (*p * p.transpose() * i31::<N>()) * na::convert::<_, N>(2.0) / mip(p, p)
 }
 
 /// Transform that translates `a` to `b`

--- a/common/src/terraingen.rs
+++ b/common/src/terraingen.rs
@@ -953,8 +953,6 @@ impl VoronoiInfo {
     // terrain that are defined by elev thresholds. Variations between strata
     // are intended to represent the effects of more or less skylight being exposed.
     pub fn terraingen_voronoi(elev: f64, rain: f64, temp: f64, dist: f64) -> Material {
-        let mut voxel_mat: Material;
-
         let voronoi_choices = if dist <= TERRAIN_SURFACE_THICKNESS {
             if elev < -30.0 {
                 SURFACE_DEEP
@@ -978,7 +976,7 @@ impl VoronoiInfo {
         let y: [f32; 2] = [rain as f32, temp as f32];
         let mut dist_squared = (voronoi_choices[0].location[0] - y[0]).powi(2)
             + (voronoi_choices[0].location[1] - y[1]).powi(2);
-        voxel_mat = voronoi_choices[0].material;
+        let mut voxel_mat = voronoi_choices[0].material;
         for vc in voronoi_choices.iter().skip(1) {
             let d_squared = (vc.location[0] - y[0]).powi(2) + (vc.location[1] - y[1]).powi(2);
             if d_squared <= dist_squared {

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -113,8 +113,8 @@ impl NodeState {
             _ => unreachable!(),
         };
 
-        let child_kind = self.kind.clone().child(side);
-        let child_road = self.road_state.clone().child(side);
+        let child_kind = self.kind.child(side);
+        let child_road = self.road_state.child(side);
 
         Self {
             kind: child_kind,
@@ -399,7 +399,7 @@ impl ChunkParams {
         for _ in 0..tree_candidate_count {
             let loc = na::Vector3::from_distribution(&random_position, rng);
             let voxel_of_interest_index = index(self.dimension, loc);
-            let neighbor_data = self.voxel_neighbors(loc, &voxels);
+            let neighbor_data = self.voxel_neighbors(loc, voxels);
 
             let num_void_neighbors = neighbor_data
                 .iter()
@@ -428,12 +428,12 @@ impl ChunkParams {
     /// Provides information on the type of material in a voxel's six neighbours
     fn voxel_neighbors(&self, coords: na::Vector3<u8>, voxels: &VoxelData) -> [NeighborData; 6] {
         [
-            self.neighbor(coords, -1, 0, 0, &voxels),
-            self.neighbor(coords, 1, 0, 0, &voxels),
-            self.neighbor(coords, 0, -1, 0, &voxels),
-            self.neighbor(coords, 0, 1, 0, &voxels),
-            self.neighbor(coords, 0, 0, -1, &voxels),
-            self.neighbor(coords, 0, 0, 1, &voxels),
+            self.neighbor(coords, -1, 0, 0, voxels),
+            self.neighbor(coords, 1, 0, 0, voxels),
+            self.neighbor(coords, 0, -1, 0, voxels),
+            self.neighbor(coords, 0, 1, 0, voxels),
+            self.neighbor(coords, 0, 0, -1, voxels),
+            self.neighbor(coords, 0, 0, 1, voxels),
         ]
     }
 
@@ -500,13 +500,13 @@ impl EnviroFactors {
         }
     }
 }
-impl Into<(f64, f64, f64, f64)> for EnviroFactors {
-    fn into(self) -> (f64, f64, f64, f64) {
+impl From<EnviroFactors> for (f64, f64, f64, f64) {
+    fn from(envirofactors: EnviroFactors) -> Self {
         (
-            self.max_elevation,
-            self.temperature,
-            self.rainfall,
-            self.blockiness,
+            envirofactors.max_elevation,
+            envirofactors.temperature,
+            envirofactors.rainfall,
+            envirofactors.blockiness,
         )
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -22,10 +22,8 @@ pub struct Config {
 
 impl Config {
     pub fn load(path: &Path) -> Result<Self> {
-        Ok(
-            toml::from_slice(&fs::read(path).context("reading config file")?)
-                .context("parsing config file")?,
-        )
+        toml::from_slice(&fs::read(path).context("reading config file")?)
+            .context("parsing config file")
     }
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -65,7 +65,7 @@ impl Server {
         let mut client_events = client_events.fuse();
         loop {
             select! {
-                _ = ticks.next() => { self.on_step() }
+                _ = ticks.next() => self.on_step(),
                 conn = incoming.select_next_some() => { self.on_connect(conn, client_events_send.clone()); }
                 e = client_events.select_next_some() => { self.on_client_event(e.0, e.1); }
             }
@@ -219,7 +219,7 @@ async fn drive_recv(
 
     let mut cmds = streams
         .map(|stream| async {
-            Ok::<_, Error>(codec::recv_whole::<proto::Command>(MAX_CLIENT_MSG_SIZE, stream?).await?)
+            codec::recv_whole::<proto::Command>(MAX_CLIENT_MSG_SIZE, stream?).await
         })
         .buffer_unordered(16); // Allow a modest amount of out-of-order completion
     while let Some(msg) = cmds.try_next().await? {

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -1,4 +1,4 @@
-use std::{mem, sync::Arc};
+use std::sync::Arc;
 
 use fxhash::FxHashMap;
 use hecs::Entity;
@@ -133,7 +133,7 @@ impl Sim {
         let spawns = Spawns {
             step: self.step,
             spawns,
-            despawns: mem::replace(&mut self.despawns, Vec::new()),
+            despawns: std::mem::take(&mut self.despawns),
             nodes: self
                 .graph
                 .fresh()


### PR DESCRIPTION
This pull request has four related changes, all simple things to improve quality of life:
- The input movement vector is capped at a maximum magnitude of 1 to prevent conflicts between the server and client from causing jitter.
- Rotation speed has been modified to no longer depend on framerate
- The mouse can now only be used to look around when it's captured, allowing for easier multitasking while the app is open.
- The mouse is automatically uncaptured when the window loses focus