### PR TITLE
Fix outdated and incorrect code documentation (along with a minor code change)

### DIFF
--- a/client/shaders/surface-extraction/surface.h
+++ b/client/shaders/surface-extraction/surface.h
@@ -3,9 +3,9 @@
 
 // A face between a voxel and its neighbor in the -X, -Y, or -Z direction
 struct Surface {
-    // (x y, z, axis)
+    // From most to least significant byte, (axis, z, y, x)
     uint pos_axis;
-    // (occlusion, padding, mat, mat)
+    // From most to least significant byte, (occlusion, <padding>, mat, mat)
     uint occlusion_mat;
 };
 

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -32,7 +32,7 @@ pub struct Base {
     pub render_pass: vk::RenderPass,
     /// A reasonable general-purpose texture sampler
     pub linear_sampler: vk::Sampler,
-    /// Layout of common shader resourcs, such as the common uniform buffer
+    /// Layout of common shader resources, such as the common uniform buffer
     pub common_layout: vk::DescriptorSetLayout,
     pub limits: vk::PhysicalDeviceLimits,
     pub timestamp_bits: u32,

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -137,7 +137,7 @@ impl Vertex {
         ]) * na::Matrix4::new_scaling(0.5)
     }
 
-    /// Convenience method for `self.cube_to_node().determinant() < 0`.
+    /// Convenience method for `self.chunk_to_node().determinant() < 0`.
     pub fn parity(self) -> bool {
         CHUNK_TO_NODE_PARITY[self as usize]
     }

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -150,8 +150,8 @@ impl<N> Graph<N> {
         }
     }
 
-    /// Ensures that all neighbour nodes of a particular node exist in the graph,
-    /// as well as the nodes from the origin to each neighbour node.
+    /// Ensures that the neighbour node at a particular side of a particular node exists in the graph,
+    /// as well as the nodes from the origin to the neighbour node.
     pub fn ensure_neighbor(&mut self, node: NodeId, side: Side) -> NodeId {
         let v = &self.nodes[node.idx()];
         if let Some(x) = v.neighbors[side as usize] {
@@ -185,7 +185,7 @@ impl<N> Graph<N> {
     }
 
     pub fn insert_child(&mut self, parent: NodeId, side: Side) -> NodeId {
-        // Always create shorter nodes first so that self.nodes is always sorted by length, enabling
+        // Always create shorter nodes first so that self.nodes always puts parent nodes before their child nodes, enabling
         // graceful synchronization of the graph
         let shorter_neighbors = self.populate_shorter_neighbors_of_child(parent, side);
         let id = NodeId::from_idx(self.nodes.len());
@@ -199,13 +199,13 @@ impl<N> Graph<N> {
         id
     }
 
-    /// Ensure all shorter neighbors of a not-yet-created child node exist and return them
+    /// Ensure all shorter neighbors of a not-yet-created child node exist and return them, excluding the given parent node
     fn populate_shorter_neighbors_of_child(
         &mut self,
         parent: NodeId,
         parent_side: Side,
     ) -> impl Iterator<Item = (Side, NodeId)> {
-        let mut neighbors = [None; 3]; // Maximum number of shorter neighbors is 3
+        let mut neighbors = [None; 2]; // Maximum number of shorter neighbors other than the given parent is 2
         let mut count = 0;
         for neighbor_side in Side::iter() {
             if neighbor_side == parent_side
@@ -219,7 +219,7 @@ impl<N> Graph<N> {
             neighbors[count] = Some((neighbor_side, neighbor));
             count += 1;
         }
-        (0..3).filter_map(move |i| neighbors[i])
+        (0..2).filter_map(move |i| neighbors[i])
     }
 
     /// Register `a` and `b` as adjacent along `side`

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -114,8 +114,8 @@ fn renormalize_rotation_reflection<N: RealField>(m: &na::Matrix3<N>) -> na::Matr
     let sign = m.determinant().signum();
     na::Matrix3::new(
         sign * (yv.y * zv.z - yv.z * zv.y), yv.x, zv.x,
-	sign * (yv.z * zv.x - yv.x * zv.z), yv.y, zv.y,
-	sign * (yv.x * zv.y - yv.y * zv.x), yv.z, zv.z,
+        sign * (yv.z * zv.x - yv.x * zv.z), yv.y, zv.y,
+        sign * (yv.x * zv.y - yv.y * zv.x), yv.z, zv.z,
     )
 }
 


### PR DESCRIPTION
These are things I found while studying the code base earlier. I believe that these changes are all correct and will make the code easier to understand, but, needless to say, please check my work before merging.

There is one actual code change as well, which is the reduction of an array size from 3 to 2 in `populate_shorter_neighbors_of_child`. The purpose of the change was to stay consistent with the documentation. This did not cause any bugs based on my manual testing.