### PR TITLE
Update dependencies "futures" and "futures-util" from 0.3.1 to 0.3.21

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,7 +28,7 @@ toml = "0.5.5"
 fxhash = "0.2.1"
 downcast-rs = "1.1.1"
 quinn = "0.6.1"
-futures-util = "0.3.1"
+futures-util = "0.3.21"
 rustls = { version = "0.17.0", features = ["dangerous_configuration"] }
 webpki = "0.21.0"
 hecs = "0.5.2"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,7 @@ toml = "0.5.5"
 anyhow = "1.0.26"
 rcgen = { version = "0.8.2", default-features = false }
 hostname = "0.3.0"
-futures = "0.3.1"
+futures = "0.3.21"
 hecs = "0.5.2"
 rand = { version = "0.7.2", features = [ "small_rng" ] }
 fxhash = "0.2.1"


### PR DESCRIPTION
Previous versions of these dependencies are yanked, see https://docs.rs/futures/0.3.21/futures/