### PR TITLE
Ensure that recv_whole respects size_limit

### DIFF
--- a/common/src/codec.rs
+++ b/common/src/codec.rs
@@ -53,7 +53,10 @@ pub async fn recv_whole<T: DeserializeOwned>(
     let mut cursor = 0;
     loop {
         let slice = unsafe {
-            std::slice::from_raw_parts_mut(buf.as_mut_ptr().add(cursor), buf.capacity() - cursor)
+            std::slice::from_raw_parts_mut(
+                buf.as_mut_ptr().add(cursor),
+                size_limit.min(buf.capacity()) - cursor,
+            )
         };
         match stream.read(slice).await? {
             Some(n) => {
@@ -62,7 +65,7 @@ pub async fn recv_whole<T: DeserializeOwned>(
                     bail!("message too large");
                 }
                 if cursor == buf.capacity() {
-                    buf.reserve(size_limit.min(buf.capacity() * 2));
+                    buf.reserve(size_limit.min(buf.capacity() * 2) - buf.len());
                 }
                 unsafe {
                     buf.set_len(cursor);


### PR DESCRIPTION
There is currently a bug in `recv_whole` that allows `cursor` to overshoot `size_limit`, causing `recv_whole` to be able to keep receiving data indefinitely (until `buf.reserve` panics).

I was able to reproduce this bug by artificially reducing `size_limit` and using `println!` to see what's going on. Unfortunately, without making more major changes to `codec.rs`, I am unable to add unit tests, as there isn't an easy way to generate a `quinn::RecvStream` in a test context.

I'm not familiar with the `quinn` library, so it may now be possible to make `recv_whole` practically a one-liner, it which case it would probably make the most sense to do that refactor now instead of just fixing the bug.

The actual bug fix is in the assignment to `slice`. I believe the change to the `buf.reserve` call makes the code feel more logical to me, and may be better in edge cases (`size_limit == isize::MAX`), but due to the lack of guarantees of the `reserve` method, it does not address the underlying issue this PR addresses.

EDIT: This pull request now just replaces the entire implementation with a call to the built in `RecvStream::read_to_end` method.