### PR TITLE
Fix Clippy warnings introduced by Rust 1.63.0

### DIFF
--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -314,7 +314,7 @@ impl SwapchainMgr {
     /// Construct a swapchain manager for a certain window
     fn new(window: &Window, gfx: Arc<Base>, fallback_size: PhysicalSize<u32>) -> Self {
         let device = &*gfx.device;
-        let swapchain_fn = khr::Swapchain::new(&gfx.core.instance, &*device);
+        let swapchain_fn = khr::Swapchain::new(&gfx.core.instance, device);
         let surface_formats = unsafe {
             window
                 .surface_fn

--- a/client/src/lahar_deprecated/transfer.rs
+++ b/client/src/lahar_deprecated/transfer.rs
@@ -52,6 +52,7 @@ impl fmt::Display for ShutDown {
 
 impl std::error::Error for ShutDown {}
 
+#[allow(clippy::type_complexity)]
 struct Message {
     sender: oneshot::Sender<()>,
     op: Box<dyn FnOnce(&mut TransferContext, vk::CommandBuffer) + Send>,

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -30,7 +30,6 @@ impl Default for Chunk {
     }
 }
 
-#[derive(PartialEq)]
 pub enum VoxelData {
     Solid(Material),
     Dense(Box<[Material]>),


### PR DESCRIPTION
I believe it makes sense to resolve new clippy warnings in a separate PR for a cleaner commit history, so hopefully, this PR does the trick.

The warning in `window.rs`, [clippy::borrow_deref_ref](https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref), was straightforward.

In `transfer.rs`, there was a [clippy::type_complexity](https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity) warning, but I decided to suppress it, since the hope is to eventually replace this code entirely, and it should stay as faithful as possible to the old version of lahar unless there's an actual bug.

In `node.rs`, clippy suggested that I implement `Eq` based on [clippy::derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq). However, I instead elected to remove `PartialEq`, as this trait is not used anywhere, and the semantics of equality between `VoxelData` seems strange. If the purpose was to compare two solid chunks, an explicit implementation would likely be needed to avoid accidentally comparing dense chunks.