### PR TITLE
Upgrade all dependencies mentioned by dependabot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["client", "server", "common"]
 
 [profile.dev]
 opt-level = 1
+debug-assertions = true
 
 [profile.dev.package."*"]
 opt-level = 2

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,7 @@ tracing = "0.1.10"
 ash = { version = "0.37.0", features = ["loaded"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "88abd75e41d04c3a4199d95f581cb135f5962844" }
 winit = "0.26.1"
-ash-window = "0.10.0"
+ash-window = "0.11.0"
 directories = "4.0.1"
 vk-shader-macros = "0.2.5"
 na = { package = "nalgebra", version = "0.31.2" }
@@ -30,7 +30,7 @@ downcast-rs = "1.1.1"
 quinn = "0.8.3"
 futures-util = "0.3.1"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
-webpki = "0.21.0"
+webpki = "0.22.0"
 hecs = "0.9.0"
 rcgen = { version = "0.9.2", default-features = false }
 memoffset = "0.6"
@@ -44,7 +44,7 @@ default = ["use-repo-assets"]
 use-repo-assets = []
 
 [dev-dependencies]
-approx = "0.3.2"
+approx = "0.5.1"
 bencher = "0.1.5"
 renderdoc = "0.10.1"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,7 +14,7 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.37.0", features = ["loaded"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "88abd75e41d04c3a4199d95f581cb135f5962844" }
-winit = "0.26.1"
+winit = "0.27.2"
 ash-window = "0.11.0"
 directories = "4.0.1"
 vk-shader-macros = "0.2.5"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -35,8 +35,7 @@ hecs = "0.9.0"
 rcgen = { version = "0.9.2", default-features = false }
 memoffset = "0.6"
 gltf = { version = "1.0.0", default-features = false, features = ["utils"] }
-metrics = { version = "0.12.1", features = ["std"] }
-metrics-core = "0.5.2"
+metrics = { version = "0.20.1" }
 hdrhistogram = { version = "7", default-features = false }
 
 [features]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ winit = "0.26.1"
 ash-window = "0.10.0"
 directories = "4.0.1"
 vk-shader-macros = "0.2.5"
-na = { package = "nalgebra", version = "0.19" }
+na = { package = "nalgebra", version = "0.31.2" }
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "sync", "macros"] }
 png = "0.17.5"
 anyhow = "1.0.26"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -31,7 +31,7 @@ quinn = "0.8.3"
 futures-util = "0.3.1"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
 webpki = "0.21.0"
-hecs = "0.7.6"
+hecs = "0.9.0"
 rcgen = { version = "0.9.2", default-features = false }
 memoffset = "0.6"
 gltf = { version = "1.0.0", default-features = false, features = ["utils"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ winit = "0.27.2"
 ash-window = "0.11.0"
 directories = "4.0.1"
 vk-shader-macros = "0.2.5"
-na = { package = "nalgebra", version = "0.31.2" }
+nalgebra = "0.31.2"
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "sync", "macros"] }
 png = "0.17.5"
 anyhow = "1.0.26"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,8 @@ tracing = "0.1.10"
 ash = { version = "0.37.0", features = ["loaded"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "88abd75e41d04c3a4199d95f581cb135f5962844" }
 winit = "0.27.2"
-ash-window = "0.11.0"
+ash-window = "0.12.0"
+raw-window-handle = "0.5.0"
 directories = "4.0.1"
 vk-shader-macros = "0.2.5"
 nalgebra = "0.31.2"
@@ -32,7 +33,7 @@ futures-util = "0.3.1"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
 webpki = "0.22.0"
 hecs = "0.9.0"
-rcgen = { version = "0.9.2", default-features = false }
+rcgen = { version = "0.10.0", default-features = false }
 memoffset = "0.6"
 gltf = { version = "1.0.0", default-features = false, features = ["utils"] }
 metrics = { version = "0.20.1" }

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -447,10 +447,10 @@ impl Draw {
                     }
                     let pos = sim
                         .world
-                        .get::<Position>(entity)
+                        .get::<&Position>(entity)
                         .expect("positionless entity in graph");
                     if let Some(character_model) = self.loader.get(self.character_model) {
-                        if let Ok(ch) = sim.world.get::<Character>(entity) {
+                        if let Ok(ch) = sim.world.get::<&Character>(entity) {
                             let transform = transform
                                 * pos.local
                                 * na::Matrix4::new_scaling(params.meters_to_absolute)

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 use std::{sync::Arc, time::Instant};
 
 use ash::{vk, Device};
-use metrics::timing;
+use metrics::histogram;
 use tracing::warn;
 
 use super::draw::nearby_nodes;
@@ -120,7 +120,7 @@ impl Voxels {
             &view,
             f64::from(self.config.local_simulation.view_distance),
         );
-        timing!(
+        histogram!(
             "frame.cpu.voxels.graph_traversal",
             graph_traversal_started.elapsed()
         );
@@ -240,7 +240,7 @@ impl Voxels {
             cmd,
             &extractions,
         );
-        timing!("frame.cpu.voxels.node_scan", node_scan_started.elapsed());
+        histogram!("frame.cpu.voxels.node_scan", node_scan_started.elapsed());
     }
 
     pub unsafe fn draw(
@@ -265,7 +265,7 @@ impl Voxels {
         for chunk in &frame.drawn {
             self.draw.draw(device, cmd, &self.surfaces, chunk.0);
         }
-        timing!("frame.cpu.voxels.draw", started.elapsed());
+        histogram!("frame.cpu.voxels.draw", started.elapsed());
     }
 
     pub unsafe fn destroy(&mut self, device: &Device) {

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -4,6 +4,7 @@ use std::{f32, os::raw::c_char};
 
 use ash::{extensions::khr, vk};
 use lahar::DedicatedImage;
+use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use tracing::info;
 use winit::{
     dpi::PhysicalSize,
@@ -35,7 +36,8 @@ impl EarlyWindow {
 
     /// Identify the Vulkan extension needed to render to this window
     pub fn required_extensions(&self) -> &'static [*const c_char] {
-        ash_window::enumerate_required_extensions(&self.window).expect("unsupported platform")
+        ash_window::enumerate_required_extensions(self.event_loop.raw_display_handle())
+            .expect("unsupported platform")
     }
 }
 
@@ -64,7 +66,14 @@ impl Window {
         sim: Sim,
     ) -> Self {
         let surface = unsafe {
-            ash_window::create_surface(&core.entry, &core.instance, &early.window, None).unwrap()
+            ash_window::create_surface(
+                &core.entry,
+                &core.instance,
+                early.window.raw_display_handle(),
+                early.window.raw_window_handle(),
+                None,
+            )
+            .unwrap()
         };
         let surface_fn = khr::Surface::new(&core.entry, &core.instance);
 

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -11,7 +11,7 @@ use winit::{
         DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent,
     },
     event_loop::{ControlFlow, EventLoop},
-    window::{Window as WinitWindow, WindowBuilder},
+    window::{CursorGrabMode, Window as WinitWindow, WindowBuilder},
 };
 
 use super::{Base, Core, Draw, Frustum};
@@ -180,7 +180,10 @@ impl Window {
                         state: ElementState::Pressed,
                         ..
                     } => {
-                        let _ = self.window.set_cursor_grab(true);
+                        let _ = self
+                            .window
+                            .set_cursor_grab(CursorGrabMode::Confined)
+                            .or_else(|_e| self.window.set_cursor_grab(CursorGrabMode::Locked));
                         self.window.set_cursor_visible(false);
                         mouse_captured = true;
                     }
@@ -218,7 +221,7 @@ impl Window {
                             down = state == ElementState::Pressed;
                         }
                         VirtualKeyCode::Escape => {
-                            let _ = self.window.set_cursor_grab(false);
+                            let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);
                             mouse_captured = false;
                         }
@@ -226,7 +229,7 @@ impl Window {
                     },
                     WindowEvent::Focused(focused) => {
                         if !focused {
-                            let _ = self.window.set_cursor_grab(false);
+                            let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);
                             mouse_captured = false;
                         }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,6 +9,7 @@ macro_rules! cstr {
     }};
 }
 
+extern crate nalgebra as na;
 mod config;
 pub mod graphics;
 mod lahar_deprecated;

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use hdrhistogram::Histogram;
-use metrics_core::Key;
 use tracing::info;
 
 pub fn init() -> Arc<Recorder> {
@@ -17,11 +16,13 @@ pub fn init() -> Arc<Recorder> {
 }
 
 pub struct Recorder {
-    histograms: RwLock<HashMap<Key, Mutex<Histogram<u64>>>>,
+    histograms: RwLock<HashMap<metrics::Key, Mutex<Histogram<u64>>>>,
 }
 
 impl Recorder {
     pub fn report(&self) {
+        // metrics crate documentation assures us that Key's interior mutability does not affect the hash code.
+        #[allow(clippy::mutable_key_type)]
         let histograms = &*self.histograms.read().unwrap();
         for (key, histogram) in histograms {
             let histogram = histogram.lock().unwrap();
@@ -40,29 +41,70 @@ impl Recorder {
 struct ArcRecorder(Arc<Recorder>);
 
 impl metrics::Recorder for ArcRecorder {
-    fn increment_counter(&self, _key: Key, _value: u64) {
+    fn describe_counter(
+        &self,
+        _key: metrics::KeyName,
+        _unit: Option<metrics::Unit>,
+        _description: metrics::SharedString,
+    ) {
         todo!()
     }
 
-    fn update_gauge(&self, _key: Key, _value: i64) {
+    fn describe_gauge(
+        &self,
+        _key: metrics::KeyName,
+        _unit: Option<metrics::Unit>,
+        _description: metrics::SharedString,
+    ) {
         todo!()
     }
 
-    fn record_histogram(&self, key: Key, value: u64) {
-        let mut histograms = self.0.histograms.read().unwrap();
-        let mut histogram = match histograms.get(&key) {
+    fn describe_histogram(
+        &self,
+        _key: metrics::KeyName,
+        _unit: Option<metrics::Unit>,
+        _description: metrics::SharedString,
+    ) {
+        todo!()
+    }
+
+    fn register_counter(&self, _key: &metrics::Key) -> metrics::Counter {
+        todo!()
+    }
+
+    fn register_gauge(&self, _key: &metrics::Key) -> metrics::Gauge {
+        todo!()
+    }
+
+    fn register_histogram(&self, key: &metrics::Key) -> metrics::Histogram {
+        metrics::Histogram::from_arc(Arc::new(Handle {
+            recorder: self.0.clone(),
+            key: key.clone(),
+        }))
+    }
+}
+
+struct Handle {
+    recorder: Arc<Recorder>,
+    key: metrics::Key,
+}
+
+impl metrics::HistogramFn for Handle {
+    fn record(&self, value: f64) {
+        let mut histograms = self.recorder.histograms.read().unwrap();
+        let mut histogram = match histograms.get(&self.key) {
             Some(x) => x.lock().unwrap(),
             None => {
                 drop(histograms);
-                self.0
+                self.recorder
                     .histograms
                     .write()
                     .unwrap()
-                    .insert(key.clone(), Mutex::new(Histogram::new(3).unwrap()));
-                histograms = self.0.histograms.read().unwrap();
-                histograms.get(&key).unwrap().lock().unwrap()
+                    .insert(self.key.clone(), Mutex::new(Histogram::new(3).unwrap()));
+                histograms = self.recorder.histograms.read().unwrap();
+                histograms.get(&self.key).unwrap().lock().unwrap()
             }
         };
-        histogram.record(value).unwrap();
+        histogram.record((value * 1e9) as u64).unwrap();
     }
 }

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -152,7 +152,7 @@ impl Sim {
                 for &(id, orientation) in &msg.character_orientations {
                     match self.entity_ids.get(&id) {
                         None => debug!(%id, "character orientation update for unknown entity"),
-                        Some(&entity) => match self.world.get_mut::<Character>(entity) {
+                        Some(&entity) => match self.world.get::<&mut Character>(entity) {
                             Ok(mut ch) => {
                                 ch.orientation = orientation;
                             }
@@ -172,7 +172,7 @@ impl Sim {
         }
         match self.entity_ids.get(&id) {
             None => debug!(%id, "position update for unknown entity"),
-            Some(&entity) => match self.world.get_mut::<Position>(entity) {
+            Some(&entity) => match self.world.get::<&mut Position>(entity) {
                 Ok(mut pos) => {
                     if pos.node != new_pos.node {
                         self.graph_entities.remove(pos.node, entity);
@@ -277,7 +277,7 @@ impl Sim {
     fn destroy(&mut self, entity: Entity) {
         let id = *self
             .world
-            .get::<EntityId>(entity)
+            .get::<&EntityId>(entity)
             .expect("destroyed nonexistent entity");
         self.entity_ids.remove(&id);
         self.destroy_idless(entity);
@@ -285,7 +285,7 @@ impl Sim {
 
     /// Destroy an entity without an EntityId mapped
     fn destroy_idless(&mut self, entity: Entity) {
-        if let Ok(position) = self.world.get::<Position>(entity) {
+        if let Ok(position) = self.world.get::<&Position>(entity) {
             self.graph_entities.remove(position.node, entity);
         }
         self.world

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,7 +17,7 @@ quinn = "0.8.3"
 lazy_static = "1.4.0"
 fxhash = "0.2.1"
 tracing = "0.1.10"
-hecs = "0.7.6"
+hecs = "0.9.0"
 tracing-subscriber = { version = "0.3.15", default-features = false, features = ["env-filter", "smallvec", "fmt", "ansi", "time", "parking_lot"] }
 rand = "0.7.3"
 rand_pcg = "0.2.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR Zlib"
 
 [dependencies]
 serde = { version = "1.0.104", features = ["derive"] }
-na = { package = "nalgebra", version = "0.19", features = ["serde-serialize"] }
+na = { package = "nalgebra", version = "0.31.2", features = ["rand", "serde-serialize"] }
 bincode = "1.2.1"
 anyhow = "1.0.26"
 quinn = "0.8.3"
@@ -19,9 +19,9 @@ fxhash = "0.2.1"
 tracing = "0.1.10"
 hecs = "0.9.0"
 tracing-subscriber = { version = "0.3.15", default-features = false, features = ["env-filter", "smallvec", "fmt", "ansi", "time", "parking_lot"] }
-rand = "0.7.3"
-rand_pcg = "0.2.1"
-rand_distr = "0.3.0"
+rand = "0.8.5"
+rand_pcg = "0.3.1"
+rand_distr = "0.4.3"
 
 [dev-dependencies]
-approx = "0.3.2"
+approx = "0.5.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR Zlib"
 
 [dependencies]
 serde = { version = "1.0.104", features = ["derive"] }
-na = { package = "nalgebra", version = "0.31.2", features = ["rand", "serde-serialize"] }
+nalgebra = { version = "0.31.2", features = ["rand", "serde-serialize"] }
 bincode = "1.2.1"
 anyhow = "1.0.26"
 quinn = "0.8.3"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 fxhash = "0.2.1"
 tracing = "0.1.10"
 hecs = "0.7.6"
-tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "parking_lot"] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = ["env-filter", "smallvec", "fmt", "ansi", "time", "parking_lot"] }
 rand = "0.7.3"
 rand_pcg = "0.2.1"
 rand_distr = "0.3.0"

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -57,7 +57,7 @@ impl Side {
 
     /// Whether `p` is opposite the dodecahedron across the plane containing `self`
     #[inline]
-    pub fn is_facing<N: na::RealField>(self, p: &na::Vector4<N>) -> bool {
+    pub fn is_facing<N: na::RealField + Copy>(self, p: &na::Vector4<N>) -> bool {
         let r = na::convert::<_, na::RowVector4<N>>(self.reflection().row(3).clone_owned());
         (r * p).x < p.w
     }

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -111,7 +111,7 @@ impl<N> Graph<N> {
 
     /// Given a `transform` relative to a `reference` node, computes the node
     /// that it's closest to and the transform that moves it there
-    pub fn normalize_transform<T: na::RealField>(
+    pub fn normalize_transform<T: na::RealField + Copy>(
         &self,
         mut reference: NodeId,
         original: &na::Matrix4<T>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,6 +6,7 @@ use rand::{
 #[macro_use]
 mod id;
 
+extern crate nalgebra as na;
 mod chunks;
 pub mod codec;
 pub mod cursor;

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -20,7 +20,7 @@ impl From<Side> for Plane<f64> {
     }
 }
 
-impl<N: na::RealField> From<na::Unit<na::Vector3<N>>> for Plane<N> {
+impl<N: na::RealField + Copy> From<na::Unit<na::Vector3<N>>> for Plane<N> {
     /// A plane passing through the origin
     fn from(x: na::Unit<na::Vector3<N>>) -> Self {
         Self {
@@ -29,7 +29,7 @@ impl<N: na::RealField> From<na::Unit<na::Vector3<N>>> for Plane<N> {
     }
 }
 
-impl<N: na::RealField> Neg for Plane<N> {
+impl<N: na::RealField + Copy> Neg for Plane<N> {
     type Output = Self;
     fn neg(self) -> Self {
         Self {
@@ -46,7 +46,7 @@ impl Mul<Plane<f64>> for Side {
     }
 }
 
-impl<'a, N: na::RealField> Mul<Plane<N>> for &'a na::Matrix4<N> {
+impl<'a, N: na::RealField + Copy> Mul<Plane<N>> for &'a na::Matrix4<N> {
     type Output = Plane<N>;
     fn mul(self, rhs: Plane<N>) -> Plane<N> {
         Plane {
@@ -55,7 +55,7 @@ impl<'a, N: na::RealField> Mul<Plane<N>> for &'a na::Matrix4<N> {
     }
 }
 
-impl<N: na::RealField> Plane<N> {
+impl<N: na::RealField + Copy> Plane<N> {
     /// Hyperbolic normal vector identifying the plane
     pub fn normal(&self) -> &na::Vector4<N> {
         &self.normal

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -552,14 +552,14 @@ fn chunk_incident_enviro_factors(
 }
 
 /// Linearly interpolate at interior and boundary of a cube given values at the eight corners.
-fn trilerp<N: na::RealField>(
+fn trilerp<N: na::RealField + Copy>(
     &[v000, v001, v010, v011, v100, v101, v110, v111]: &[N; 8],
     t: na::Vector3<N>,
 ) -> N {
-    fn lerp<N: na::RealField>(v0: N, v1: N, t: N) -> N {
+    fn lerp<N: na::RealField + Copy>(v0: N, v1: N, t: N) -> N {
         v0 * (N::one() - t) + v1 * t
     }
-    fn bilerp<N: na::RealField>(v00: N, v01: N, v10: N, v11: N, t: na::Vector2<N>) -> N {
+    fn bilerp<N: na::RealField + Copy>(v00: N, v01: N, v10: N, v11: N, t: na::Vector2<N>) -> N {
         lerp(lerp(v00, v01, t.x), lerp(v10, v11, t.x), t.y)
     }
 
@@ -574,7 +574,7 @@ fn trilerp<N: na::RealField>(
 /// v0 for [0, threshold], v1 for [1-threshold, 1], and linear interpolation in between
 /// such that the overall shape is an S-shaped piecewise function.
 /// threshold should be between 0 and 0.5.
-fn serp<N: na::RealField>(v0: N, v1: N, t: N, threshold: N) -> N {
+fn serp<N: na::RealField + Copy>(v0: N, v1: N, t: N, threshold: N) -> N {
     if t < threshold {
         v0
     } else if t < (N::one() - threshold) {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.26"
 rcgen = { version = "0.9.2", default-features = false }
 hostname = "0.3.0"
 futures = "0.3.1"
-hecs = "0.7.6"
+hecs = "0.9.0"
 rand = { version = "0.7.2", features = [ "small_rng" ] }
 fxhash = "0.2.1"
 na = { package = "nalgebra", version = "0.19" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ quinn = { version = "0.8.3", features = ["rustls"] }
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 toml = "0.5.5"
 anyhow = "1.0.26"
-rcgen = { version = "0.9.2", default-features = false }
+rcgen = { version = "0.10.0", default-features = false }
 hostname = "0.3.0"
 futures = "0.3.1"
 hecs = "0.9.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.1"
 hecs = "0.9.0"
 rand = { version = "0.8.5", features = [ "small_rng" ] }
 fxhash = "0.2.1"
-na = { package = "nalgebra", version = "0.31.2" }
+nalgebra = "0.31.2"
 slotmap = "1.0.6"
 rustls = "0.20.6"
 rustls-pemfile = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,9 +21,9 @@ rcgen = { version = "0.9.2", default-features = false }
 hostname = "0.3.0"
 futures = "0.3.1"
 hecs = "0.9.0"
-rand = { version = "0.7.2", features = [ "small_rng" ] }
+rand = { version = "0.8.5", features = [ "small_rng" ] }
 fxhash = "0.2.1"
-na = { package = "nalgebra", version = "0.19" }
+na = { package = "nalgebra", version = "0.31.2" }
 slotmap = "1.0.6"
 rustls = "0.20.6"
 rustls-pemfile = "1.0.0"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate nalgebra as na;
 mod input_queue;
 mod sim;
 

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -71,7 +71,7 @@ impl Sim {
         entity: Entity,
         command: Command,
     ) -> Result<(), hecs::ComponentError> {
-        let mut ch = self.world.get_mut::<Character>(entity)?;
+        let mut ch = self.world.get::<&mut Character>(entity)?;
         let (direction, speed) = sanitize_motion_input(command.velocity);
         ch.direction = direction;
         ch.speed = speed * self.cfg.movement_speed;
@@ -80,7 +80,7 @@ impl Sim {
     }
 
     pub fn destroy(&mut self, entity: Entity) {
-        let id = *self.world.get::<EntityId>(entity).unwrap();
+        let id = *self.world.get::<&EntityId>(entity).unwrap();
         self.entity_ids.remove(&id);
         self.world.despawn(entity).unwrap();
         self.despawns.push(id);
@@ -124,7 +124,7 @@ impl Sim {
         // Capture state changes for broadcast to clients
         let mut spawns = Vec::with_capacity(self.spawns.len());
         for entity in self.spawns.drain(..) {
-            let id = *self.world.get::<EntityId>(entity).unwrap();
+            let id = *self.world.get::<&EntityId>(entity).unwrap();
             spawns.push((id, dump_entity(&self.world, entity)));
         }
         if !self.graph.fresh().is_empty() {
@@ -185,10 +185,10 @@ enum Empty {}
 
 fn dump_entity(world: &hecs::World, entity: Entity) -> Vec<Component> {
     let mut components = Vec::new();
-    if let Ok(x) = world.get::<Position>(entity) {
+    if let Ok(x) = world.get::<&Position>(entity) {
         components.push(Component::Position(*x));
     }
-    if let Ok(x) = world.get::<Character>(entity) {
+    if let Ok(x) = world.get::<&Character>(entity) {
         components.push(Component::Character(proto::Character {
             name: x.name.clone(),
             orientation: x.orientation,


### PR DESCRIPTION
### Summary
This PR upgrades the following crates (comments in parentheses):
- metrics (complicated)
- ash-window (mechanical)
- hecs (mechanical)
- nalgebra (mechanical. Was blocked by [a performance regression in nalgebra](https://github.com/dimforge/nalgebra/issues/1139), but this has now been fixed.)
- winit (mechanical)
- approx (trivial)
- rand (trivial)
- rand_distr (trivial)
- rand_pcg (trivial)
- rcgen (trivial)
- tracing (trivial)
- tracing-subscriber (trivial, apart from changing "chrono" feature to "time")
- webpki (trivial)
- metrics-core (removed, not upgraded, since "metrics" no longer uses it)

One semi-unrelated change is adding `debug-assertions = true` in the top-level Cargo.toml. [Debug assertions are only enabled by default in non-optimized builds](https://doc.rust-lang.org/std/macro.debug_assert.html), so for them to ever be triggered, they need to be enabled manually. I discovered this while debugging the nalgebra upgrade.

The below sections summarize the code changes for each crate.

Although a lot of crates were upgraded, I don't believe the diff is too complicated to review. However, the individual commits are relatively clean, so looking at these may help simplify the code review. I did create the PR under the assumption that the commits would be squashed, though.

### metrics
This is the most complicated change, as the API was significantly adjusted in the metrics crate. The `timing!` macro was removed and replaced with a `histogram!` macro. The `histogram!` macro both "registers" a histogram and records to it. I found the documentation of the crate a bit lacking, but my understanding is that registration is meant to be idempotent.

I made registration practically a no-op, just returning an object that had enough information to implement "recording" the same way as it was implemented before. Fortunately, the PR diff highlights this well.

One other major change is that the metrics crate uses `f64` instead of `u64` now, and the conversion of an `Interval` to an `f64` using this crate uses a unit of seconds, so I had the calls to `histogram!` use seconds, while I had the `hdrhistogram` use nanoseconds as before.

Fortunately, besides switching `metrics_core::Key` to `metrics::Key`, I didn't need to change the `Recorder` struct itself.

Another minor note: the `std` feature option was removed in version [0.18.0](https://github.com/metrics-rs/metrics/blob/64d5c5ae63babafbf3875f723ed263efe9332647/metrics/CHANGELOG.md#removed).

### ash-window
The required parameters for `ash_window::enumerate_required_extensions` and `ash_window::create_surface` have changed to use `RawDisplayHandle` and `RawWindowHandle` objects directly instead of relying on traits. This required adding an additional dependency: `raw_window_handle`. Implementing this change just involved following the example provided in the ash_window git repo.

### hecs
The main change in the hecs crate was the replacement of `get::<T>` and `get_mut::<T>` with `get::<&T>` and `get::<&mut T>` respectively. I believe this change was introduced in [0.8.0](https://github.com/Ralith/hecs/blob/3f530401e24baa862369b14e74aed69cb887e5c8/CHANGELOG.md#changed-1).


### nalgebra
The most repetitive code modification was changing `na::RealField` to `na::RealField + Copy`, as the `Copy` trait was removed from `na::RealField`, and we depended on that in a lot of places. I systematically made this change in all usages. This was a [breaking change in 0.29.0](https://github.com/dimforge/nalgebra/blob/daa2ea33b21b083d781a0f3c169cf15381d1e37e/CHANGELOG.md#breaking-changes-2).

Another code change was replacing some occurrences of `na::U3` with `3`, which is due to [version 0.26.0](https://github.com/dimforge/nalgebra/blob/daa2ea33b21b083d781a0f3c169cf15381d1e37e/CHANGELOG.md#0260) introducing the usage of const generics.

The final code change was that `nalgebra` is now imported in `Cargo.toml` as itself instead of `na` to make its procedural macros introduced in 0.27.0 usable. An `extern crate` declaration was added to continue allowing the use of `na`. Actually using these macros is out of scope for this PR.

Unfortunately, 0.26.0 also came with a performance regression in nalgebra that makes Hypermine laggy with a 5x CPU slowdown on my computer. The fix is in https://github.com/dimforge/nalgebra/pull/1140, which is now present in 0.31.2.

### winit
`set_cursor_grab` takes an enum insteasd of a boolean, but the change is relatively straightforward. The code for grabbing the cursor came straight from the method documentation. `ash-window` was not compatible with winit 0.27.1, but patch 0.27.2 added in backwards compatibility, making the upgrade possible.

### tracing-subscriber
The "chrono" feature option was made unavailable, and based on https://github.com/tokio-rs/tracing/pull/1646, I believe it was replaced with "time". The justification was that the maintenance status of "chrono" was uncertain, causing support for it to be dropped.

### All other crates
For all other crates, only `cargo.toml` was modified, making the upgrade easy. Due to interdependence between crates, I believe some had to be updated at the same time (like nalgebra and rand), but the upgrade process itself was trivial.