### PR TITLE
Refactor dodeca.rs to make math easier to understand

### DIFF
--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -57,7 +57,7 @@ impl Side {
 
     /// Whether `p` is opposite the dodecahedron across the plane containing `self`
     #[inline]
-    pub fn faces<N: na::RealField>(self, p: &na::Vector4<N>) -> bool {
+    pub fn is_facing<N: na::RealField>(self, p: &na::Vector4<N>) -> bool {
         let r = na::convert::<_, na::RowVector4<N>>(self.reflection().row(3).clone_owned());
         (r * p).x < p.w
     }
@@ -324,10 +324,10 @@ mod tests {
     }
 
     #[test]
-    fn side_faces() {
+    fn side_is_facing() {
         for side in Side::iter() {
-            assert!(!side.faces::<f32>(&math::origin()));
-            assert!(side.faces(&(side.reflection() * math::origin())));
+            assert!(!side.is_facing::<f32>(&math::origin()));
+            assert!(side.is_facing(&(side.reflection() * math::origin())));
         }
     }
 

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -43,6 +43,12 @@ impl Side {
         ADJACENT[self as usize][other as usize]
     }
 
+    /// Outward normal vector of this side
+    #[inline]
+    pub fn normal(self) -> &'static na::Vector4<f64> {
+        &SIDE_NORMALS[self as usize]
+    }
+
     /// Reflection across this side
     #[inline]
     pub fn reflection(self) -> &'static na::Matrix4<f64> {
@@ -137,6 +143,16 @@ impl Vertex {
         ]) * na::Matrix4::new_scaling(0.5)
     }
 
+    /// Transform from cube-centric coordinates to dodeca-centric coordinates
+    pub fn dual_to_node(self) -> &'static na::Matrix4<f64> {
+        &DUAL_TO_NODE[self as usize]
+    }
+
+    /// Transform from dodeca-centric coordinates to cube-centric coordinates
+    pub fn node_to_dual(self) -> &'static na::Matrix4<f64> {
+        &NODE_TO_DUAL[self as usize]
+    }
+
     /// Convenience method for `self.chunk_to_node().determinant() < 0`.
     pub fn parity(self) -> bool {
         CHUNK_TO_NODE_PARITY[self as usize]
@@ -163,13 +179,12 @@ lazy_static! {
         result
     };
 
-    /// Transform that moves from a neighbor to a reference node, for each side
-    static ref REFLECTIONS: [na::Matrix4<f64>; SIDE_COUNT] = {
+    /// Vector corresponding to the outer normal of each side
+    static ref SIDE_NORMALS: [na::Vector4<f64>; SIDE_COUNT] = {
         let phi = 1.25f64.sqrt() + 0.5; // golden ratio
-        let root_phi = phi.sqrt();
-        let f = math::lorentz_normalize(&na::Vector4::new(root_phi, phi * root_phi, 0.0, phi + 2.0));
+        let f = math::lorentz_normalize(&na::Vector4::new(1.0, phi, 0.0, phi.sqrt()));
 
-        let mut result = [na::zero(); SIDE_COUNT];
+        let mut result: [na::Vector4<f64>; SIDE_COUNT] = [na::zero(); SIDE_COUNT];
         let mut i = 0;
         for (x, y, z, w) in [
             (f.x, f.y, f.z, f.w),
@@ -177,17 +192,18 @@ lazy_static! {
             (f.x, -f.y, -f.z, f.w),
             (-f.x, -f.y, f.z, f.w),
         ]
-            .iter()
-            .cloned()
         {
-            for (x, y, z, w) in [(x, y, z, w), (y, z, x, w), (z, x, y, w)].iter().cloned() {
-                result[i] = math::translate(&math::origin(), &na::Vector4::new(x, y, z, w))
-                    * math::euclidean_reflect(&na::Vector4::new(x, y, z, 0.0))
-                    * math::translate(&math::origin(), &na::Vector4::new(-x, -y, -z, w));
+            for (x, y, z, w) in [(x, y, z, w), (y, z, x, w), (z, x, y, w)] {
+                result[i] = na::Vector4::new(x, y, z, w);
                 i += 1;
             }
         }
         result
+    };
+
+    /// Transform that moves from a neighbor to a reference node, for each side
+    static ref REFLECTIONS: [na::Matrix4<f64>; SIDE_COUNT] = {
+        SIDE_NORMALS.map(|r| math::reflect(&r))
     };
 
     /// Sides incident to a vertex, in canonical order
@@ -208,6 +224,25 @@ lazy_static! {
         }
         assert_eq!(vertex, 20);
         result
+    };
+
+    /// Transform that converts from cube-centric coordinates to dodeca-centric coordinates
+    static ref DUAL_TO_NODE: [na::Matrix4<f64>; VERTEX_COUNT] = {
+        let mip_origin_normal = math::mip(&math::origin(), &SIDE_NORMALS[0]); // This value is the same for every side
+        let mut result = [na::zero(); VERTEX_COUNT];
+        for i in 0..VERTEX_COUNT {
+            let [a, b, c] = VERTEX_SIDES[i];
+            let vertex_position = math::lorentz_normalize(
+                &(math::origin() - (a.normal() + b.normal() + c.normal()) * mip_origin_normal),
+            );
+            result[i] = na::Matrix4::from_columns(&[-a.normal(), -b.normal(), -c.normal(), vertex_position]);
+        }
+        result
+    };
+
+    /// Transform that converts from dodeca-centric coordinates to cube-centric coordinates
+    static ref NODE_TO_DUAL: [na::Matrix4<f64>; VERTEX_COUNT] = {
+        DUAL_TO_NODE.map(|m| m.try_inverse().unwrap())
     };
 
     /// Vertex shared by 3 sides

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -120,7 +120,7 @@ impl<N> Graph<N> {
         let mut location = original * math::origin();
         'outer: loop {
             for side in Side::iter() {
-                if !side.faces(&location) {
+                if !side.is_facing(&location) {
                     continue;
                 }
                 reference = match self.neighbor(reference, side) {

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -2,7 +2,7 @@ use std::ops::{Mul, Neg};
 
 use crate::{
     dodeca::{Side, Vertex},
-    math::{lorentz_normalize, mip, origin},
+    math::{lorentz_normalize, mip},
 };
 
 /// A hyperbolic plane
@@ -14,9 +14,8 @@ pub struct Plane<N: na::RealField> {
 impl From<Side> for Plane<f64> {
     /// A surface overlapping with a particular dodecahedron side
     fn from(side: Side) -> Self {
-        let n = side.reflection().column(3) - origin();
         Self {
-            normal: lorentz_normalize(&n),
+            normal: *side.normal(),
         }
     }
 }
@@ -81,7 +80,7 @@ impl Plane<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::math::translate_along;
+    use crate::math::{origin, translate_along};
     use approx::*;
 
     #[test]

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -104,8 +104,8 @@ mod tests {
     fn check_surface_flipped() {
         let root = Plane::from(Side::A);
         assert_abs_diff_eq!(
-            root.distance_to_chunk(Vertex::A, &(na::Vector3::x() * 2.0)),
-            root.distance_to_chunk(Vertex::J, &(na::Vector3::x() * 2.0)) * -1.0,
+            root.distance_to_chunk(Vertex::A, &na::Vector3::new(-1.0, 1.0, 1.0)),
+            root.distance_to_chunk(Vertex::J, &na::Vector3::new(-1.0, 1.0, 1.0)) * -1.0,
             epsilon = 1e-5
         );
     }
@@ -115,7 +115,7 @@ mod tests {
         assert_abs_diff_eq!(
             Plane::from(Side::A).distance_to_chunk(
                 Vertex::from_sides(Side::A, Side::B, Side::C).unwrap(),
-                &na::Vector3::new(1.0, 0.3, 0.9), // The first 1.0 is important, the plane is the midplane of the cube in Side::A direction
+                &na::Vector3::new(0.0, 0.7, 0.1), // The first 0.0 is important, the plane is the midplane of the cube in Side::A direction
             ),
             0.0,
             epsilon = 1e-8,
@@ -128,33 +128,33 @@ mod tests {
 
         // A cube corner should have the same elevation seen from different cubes
         assert_abs_diff_eq!(
-            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(0.0, 0.0, 0.0)),
+            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 1.0, 1.0)),
             Plane::from(Side::A).distance_to_chunk(
                 Vertex::from_sides(Side::F, Side::H, Side::J).unwrap(),
-                &na::Vector3::new(0.0, 0.0, 0.0),
+                &na::Vector3::new(1.0, 1.0, 1.0),
             ),
             epsilon = 1e-8,
         );
 
         // The same corner should have the same distance_to_chunk when represented from the same cube at different corners
         assert_abs_diff_eq!(
-            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 0.0, 0.0)),
+            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(0.0, 1.0, 1.0)),
             (Side::A * Plane::from(Side::A))
-                .distance_to_chunk(abc, &na::Vector3::new(1.0, 0.0, 0.0),),
+                .distance_to_chunk(abc, &na::Vector3::new(0.0, 1.0, 1.0),),
             epsilon = 1e-8,
         );
 
         // Corners of midplane cubes separated by the midplane should have the same distance_to_chunk with a different sign
         assert_abs_diff_eq!(
-            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(0.0, 0.0, 0.0)),
-            -Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(2.0, 0.0, 0.0)),
+            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 1.0, 1.0)),
+            -Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(-1.0, 1.0, 1.0)),
             epsilon = 1e-8,
         );
 
         // Corners of midplane cubes not separated by the midplane should have the same distance_to_chunk
         assert_abs_diff_eq!(
-            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(0.0, 0.0, 0.0)),
-            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(0.0, 0.0, 2.0)),
+            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 1.0, 1.0)),
+            Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 1.0, -1.0)),
             epsilon = 1e-8,
         );
     }

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -263,15 +263,16 @@ impl ChunkParams {
         for (x, y, z) in VoxelCoords::new(self.dimension) {
             let coords = na::Vector3::new(x, y, z);
             let center = voxel_center(self.dimension, coords);
-            let cube_coords = center * 0.5;
+            let trilerp_coords = center.map(|x| (1.0 - x) * 0.5);
 
-            let rain = trilerp(&self.env.rainfalls, cube_coords) + rng.sample(&normal.unwrap());
-            let temp = trilerp(&self.env.temperatures, cube_coords) + rng.sample(&normal.unwrap());
+            let rain = trilerp(&self.env.rainfalls, trilerp_coords) + rng.sample(&normal.unwrap());
+            let temp =
+                trilerp(&self.env.temperatures, trilerp_coords) + rng.sample(&normal.unwrap());
 
             // elev is calculated in multiple steps. The initial value elev_pre_terracing
             // is used to calculate elev_pre_noise which is used to calculate elev.
-            let elev_pre_terracing = trilerp(&self.env.max_elevations, cube_coords);
-            let block = trilerp(&self.env.blockinesses, cube_coords);
+            let elev_pre_terracing = trilerp(&self.env.max_elevations, trilerp_coords);
+            let block = trilerp(&self.env.blockinesses, trilerp_coords);
             let voxel_elevation = self.surface.distance_to_chunk(self.chunk, &center);
             let strength = 0.4 / (1.0 + voxel_elevation.powi(2));
             let terracing_small = terracing_diff(elev_pre_terracing, block, 5.0, strength, 2.0);
@@ -371,7 +372,7 @@ impl ChunkParams {
         let x = coords[0];
         let y = coords[1];
         let z = coords[2];
-        let offset = 2 * self.dimension / 3;
+        let offset = self.dimension / 3;
 
         // straight lines.
         criteria_met += u32::from(x == offset);


### PR DESCRIPTION
This PR has a major breaking change in dodeca.rs's API. In chunk coordinates, 0 and 1 are swapped from how they were before. This has a few advantages:
- The origin in chunk coordinates is at the center of the Beltrami-Klein model, making the mapping of these coordinates to Hyperbolic space more intuitive.
- Relatedly, the chunk coordinates give an idea of how distorted we are from a Euclidean cube, as higher-magnitude chunk coordinates have higher distortion, and everything is nicely behaved near the origin.
- Collision math should be slightly simpler due to the above points.

A potentially notable disadvantage is that the origin of a node and the origin of a chunk no longer coincide. However, I believe this is minor.

A few other helpful features have been added to dodeca.rs
- `Side` has a `normal()` method which can retrieve the outward facing normal rather than relying on the entire reflection matrix.
- In addition to "node" and "chunk" coordinates, there are also "dual" coordinates, named that way because the origin is mapped to the center of the cube in the cubic honeycomb (dual to the dodecahedral honeycomb), and the axes point directly towards the faces of the cube.
    - The conversion between "node" and "dual" coordinates is an isometry, which makes it easier to understand and work with than "chunk" coordinates.
    - The conversion between "dual" and "chunk" coordinates simply requires scaling the `x`, `y`, and `z` values by a constant factor: `Vertex::dual_to_chunk_factor()`.

I also renamed `faces` to `is_facing` because that change is relatively small and non-controversial, so it makes sense to tag it along during a dodeca.rs refactor.

The following screenshot has a 2D example (in the Beltrami-Klein model) of what chunk coordinates will look like after this PR is merged. It is centered at a node's origin. If it was centered at a chunk's origin instead, the grid of that chunk would be uniform:
![image](https://user-images.githubusercontent.com/5403380/185832902-e61f12aa-9215-41d3-96b7-bf2a4ebdd6ac.png)