### PR TITLE
Fix Clippy warnings introduced by Rust 1.65.0

### DIFF
--- a/client/src/lahar_deprecated/staging.rs
+++ b/client/src/lahar_deprecated/staging.rs
@@ -33,7 +33,7 @@ impl StagingBuffer {
     ) -> Self {
         let buffer = unsafe {
             DedicatedMapping::zeroed_array(
-                &*device,
+                &device,
                 props,
                 vk::BufferUsageFlags::TRANSFER_SRC,
                 capacity,
@@ -98,7 +98,7 @@ impl StagingBuffer {
 impl Drop for StagingBuffer {
     fn drop(&mut self) {
         unsafe {
-            self.buffer.destroy(&*self.device);
+            self.buffer.destroy(&self.device);
         }
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     if config.server.is_none() {
         // spawn an in-process server
         let socket =
-            UdpSocket::bind(&"[::1]:0".parse::<SocketAddr>().unwrap()).expect("binding socket");
+            UdpSocket::bind("[::1]:0".parse::<SocketAddr>().unwrap()).expect("binding socket");
         config.server = Some(socket.local_addr().unwrap());
 
         let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -66,7 +66,7 @@ pub fn run() -> Result<()> {
         server::NetParams {
             certificate_chain,
             private_key,
-            socket: UdpSocket::bind(&cfg.listen).context("binding socket")?,
+            socket: UdpSocket::bind(cfg.listen).context("binding socket")?,
         },
         SimConfig::from_raw(&cfg.simulation),
     )


### PR DESCRIPTION
The most common warning was
```
the borrowed expression implements the required traits
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

Apart from that, there were two warnings related to `&*device`, which were
```
deref which would be done by auto-deref
`#[warn(clippy::explicit_auto_deref)]` on by default
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
```

While touching the code, I also redefined `normal` in `generate_terrain` to require fewer calls to `unwrap`, since that change seems simple and non-controversial.