### PR TITLE
Simplify a few functions in math.rs

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -268,7 +268,7 @@ impl Draw {
         let draw_started = Instant::now();
         let view = sim.view();
         let projection = frustum.projection(0.01);
-        let view_projection = projection.matrix() * view.local.try_inverse().unwrap();
+        let view_projection = projection.matrix() * math::mtranspose(&view.local);
         self.loader.drive();
 
         let device = &*self.gfx.device;

--- a/client/src/graphics/frustum.rs
+++ b/client/src/graphics/frustum.rs
@@ -99,30 +99,12 @@ mod tests {
         // 90 degree square
         let planes = Frustum::from_vfov(f32::consts::FRAC_PI_4, 1.0).planes();
         assert!(planes.contain(&origin(), 0.1));
-        assert!(planes.contain(
-            &(translate_along(&na::Vector3::z_axis(), -1.0) * origin()),
-            0.0
-        ));
-        assert!(!planes.contain(
-            &(translate_along(&na::Vector3::z_axis(), 1.0) * origin()),
-            0.0
-        ));
+        assert!(planes.contain(&(translate_along(&-na::Vector3::z()) * origin()), 0.0));
+        assert!(!planes.contain(&(translate_along(&na::Vector3::z()) * origin()), 0.0));
 
-        assert!(!planes.contain(
-            &(translate_along(&na::Vector3::x_axis(), 1.0) * origin()),
-            0.0
-        ));
-        assert!(!planes.contain(
-            &(translate_along(&na::Vector3::y_axis(), 1.0) * origin()),
-            0.0
-        ));
-        assert!(!planes.contain(
-            &(translate_along(&na::Vector3::x_axis(), -1.0) * origin()),
-            0.0
-        ));
-        assert!(!planes.contain(
-            &(translate_along(&na::Vector3::y_axis(), -1.0) * origin()),
-            0.0
-        ));
+        assert!(!planes.contain(&(translate_along(&na::Vector3::x()) * origin()), 0.0));
+        assert!(!planes.contain(&(translate_along(&na::Vector3::y()) * origin()), 0.0));
+        assert!(!planes.contain(&(translate_along(&-na::Vector3::x()) * origin()), 0.0));
+        assert!(!planes.contain(&(translate_along(&-na::Vector3::y()) * origin()), 0.0));
     }
 }

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -134,7 +134,7 @@ impl Voxels {
         });
         let node_scan_started = Instant::now();
         let frustum_planes = frustum.planes();
-        let local_to_view = view.local.try_inverse().unwrap();
+        let local_to_view = math::mtranspose(&view.local);
         let mut extractions = Vec::new();
         for &(node, ref node_transform) in &nodes {
             let node_to_view = local_to_view * node_transform;

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -26,8 +26,8 @@ impl PredictedMotion {
 
     /// Update for input about to be sent to the server, returning the generation it should be
     /// tagged with
-    pub fn push(&mut self, direction: &na::Unit<na::Vector3<f32>>, distance: f32) -> u16 {
-        let transform = math::translate_along(&(direction.as_ref() * distance));
+    pub fn push(&mut self, velocity: &na::Vector3<f32>) -> u16 {
+        let transform = math::translate_along(velocity);
         self.predicted.local *= transform;
         self.log.push_back(Input { transform });
         self.generation = self.generation.wrapping_add(1);
@@ -76,8 +76,8 @@ mod tests {
     fn wraparound() {
         let mut pred = PredictedMotion::new(pos());
         pred.generation = u16::max_value() - 1;
-        assert_eq!(pred.push(&na::Vector3::x_axis(), 1.0), u16::max_value());
-        assert_eq!(pred.push(&na::Vector3::x_axis(), 1.0), 0);
+        assert_eq!(pred.push(&na::Vector3::x()), u16::max_value());
+        assert_eq!(pred.push(&na::Vector3::x()), 0);
         assert_eq!(pred.log.len(), 2);
 
         pred.reconcile(u16::max_value() - 1, pos());

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -27,7 +27,7 @@ impl PredictedMotion {
     /// Update for input about to be sent to the server, returning the generation it should be
     /// tagged with
     pub fn push(&mut self, direction: &na::Unit<na::Vector3<f32>>, distance: f32) -> u16 {
-        let transform = math::translate_along(direction, distance);
+        let transform = math::translate_along(&(direction.as_ref() * distance));
         self.predicted.local *= transform;
         self.log.push_back(Input { transform });
         self.generation = self.generation.wrapping_add(1);

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -268,7 +268,7 @@ impl Sim {
             // self.average_velocity is always over the entire timestep, filling in zeroes for the
             // future.
             let distance = speed * params.movement_speed * params.step_interval.as_secs_f32();
-            result.local *= math::translate_along(&direction, distance);
+            result.local *= math::translate_along(&(direction.as_ref() * distance));
         }
         result
     }

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -247,7 +247,7 @@ lazy_static! {
 
     /// Transform that converts from dodeca-centric coordinates to cube-centric coordinates
     static ref NODE_TO_DUAL: [na::Matrix4<f64>; VERTEX_COUNT] = {
-        DUAL_TO_NODE.map(|m| m.try_inverse().unwrap())
+        DUAL_TO_NODE.map(|m| math::mtranspose(&m))
     };
 
     /// Vertex shared by 3 sides

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -73,19 +73,12 @@ impl<F: FnOnce()> Drop for Defer<F> {
     }
 }
 
-/// Convert a motion input into direction + speed, with speed clamped to 1.0 and graceful zero
-/// handling
-pub fn sanitize_motion_input(v: na::Vector3<f32>) -> (na::Unit<na::Vector3<f32>>, f32) {
+/// Clamp speed to to 1.0 and graceful NaN handling
+pub fn sanitize_motion_input(v: na::Vector3<f32>) -> na::Vector3<f32> {
     if !v.iter().all(|x| x.is_finite()) {
-        return (-na::Vector3::z_axis(), 0.0);
+        return na::Vector3::zeros();
     }
-    let (direction, speed) = na::Unit::new_and_get(v);
-    if speed == 0.0 {
-        // Return an arbitrary direction rather than NaN
-        (-na::Vector3::z_axis(), speed)
-    } else {
-        (direction, speed.min(1.0))
-    }
+    v / v.norm().max(1.0)
 }
 
 pub fn tracing_guard() -> tracing::dispatcher::DefaultGuard {

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -192,11 +192,11 @@ mod tests {
     fn translate_equivalence() {
         let a = lorentz_normalize(&na::Vector4::new(-0.5, -0.5, 0.0, 1.0));
         let o = na::Vector4::new(0.0, 0.0, 0.0, 1.0);
-        let direction = na::Unit::new_normalize(a.xyz());
+        let direction = a.xyz().normalize();
         let distance = dbg!(distance(&o, &a));
         assert_abs_diff_eq!(
             translate(&o, &a),
-            translate_along(&(direction.as_ref() * distance)),
+            translate_along(&(direction * distance)),
             epsilon = 1e-5
         );
     }

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -93,7 +93,9 @@ mod tests {
             for &distance in &[-1.5, 0.0, 1.5] {
                 let plane = Plane::from(axis);
                 assert_abs_diff_eq!(
-                    plane.distance_to(&(translate_along(&axis, distance) * origin())),
+                    plane.distance_to(
+                        &(translate_along(&(axis.into_inner() * distance)) * origin())
+                    ),
                     distance
                 );
             }

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -52,7 +52,7 @@ impl Sim {
         info!(%id, name = %hello.name, "spawning character");
         let position = Position {
             node: NodeId::ROOT,
-            local: math::translate_along(&na::Vector3::y_axis(), 0.9),
+            local: math::translate_along(&(na::Vector3::y() * 0.9)),
         };
         let character = Character {
             name: hello.name,
@@ -110,8 +110,10 @@ impl Sim {
 
         // Simulate
         for (_, (ch, pos)) in self.world.query::<(&Character, &mut Position)>().iter() {
-            let next_xf =
-                pos.local * math::translate_along(&ch.direction, ch.speed / self.cfg.rate as f32);
+            let next_xf = pos.local
+                * math::translate_along(
+                    &(ch.direction.as_ref() * (ch.speed / self.cfg.rate as f32)),
+                );
             pos.local = math::renormalize_isometry(&next_xf);
             let (next_node, transition_xf) = self.graph.normalize_transform(pos.node, &pos.local);
             if next_node != pos.node {


### PR DESCRIPTION
This PR makes the following changes to math.rs that will hopefully make it more convenient to work with. I believe these changes are useful on their own, but the main purpose is to prepare for collision-related changes:

- `math::translate` now requires Lorentz-normalized vectors. Also, it uses a more direct formula rather than composing two reflections. This should hopefully be more efficient, but additional efficiency can be gained by having a special hardcoded function for translating the origin to a particular point.
- `math::translate_along` now only takes a single vector parameter, whose magnitude is how far to translate. Most users of this function benefit from the simplification. For instance, the `sanitize_motion_input` function is much shorter. Internally, it has also been simplified to call `math::translate`.
- A new function `math::mtranspose` has been added to replace `.try_inverse().unwrap()` for isometries. This has the dual benefit of being more efficient (transpose with some minus signs vs general 4x4 matrix inverse) and reducing the number of `unwrap` calls in the code.
- Internally, for readability, `i31` has been replaced with `minkowski_outer_product`, as a counterpart to `mip`.
- Internally, `renormalize_isometry` now uses `translate` instead of `translate_along` to reduce redundant computation.

For the math that `translate` uses, I took the formula of the original `translate_along` function and tried to express it in terms of the origin vector, the vector the origin is translated to, inner/outer products, and the identity matrix, and it ended up simplifying quite well. I'm not sure what the theory behind the formula is, but by symmetry arguments and manual testing, I'm confident that it's correct.