### PR TITLE
Add persistent velocity as a step towards player physics

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -222,7 +222,7 @@ impl Draw {
             &self.gfx,
             self.cfg.clone(),
             &mut self.loader,
-            u32::from(params.chunk_size),
+            u32::from(params.cfg.chunk_size),
             PIPELINE_DEPTH,
         );
         for state in &mut self.states {
@@ -455,7 +455,7 @@ impl Draw {
                         if let Ok(ch) = sim.world.get::<&Character>(entity) {
                             let transform = transform
                                 * pos.local
-                                * na::Matrix4::new_scaling(params.meters_to_absolute)
+                                * na::Matrix4::new_scaling(params.cfg.meters_to_absolute)
                                 * ch.orientation.to_homogeneous();
                             for mesh in &character_model.0 {
                                 self.meshes

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -456,7 +456,7 @@ impl Draw {
                             let transform = transform
                                 * pos.local
                                 * na::Matrix4::new_scaling(params.cfg.meters_to_absolute)
-                                * ch.orientation.to_homogeneous();
+                                * ch.state.orientation.to_homogeneous();
                             for mesh in &character_model.0 {
                                 self.meshes
                                     .draw(device, state.common_ds, cmd, mesh, &transform);

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -230,6 +230,9 @@ impl Window {
                         VirtualKeyCode::F => {
                             down = state == ElementState::Pressed;
                         }
+                        VirtualKeyCode::V if state == ElementState::Pressed => {
+                            self.sim.toggle_no_clip();
+                        }
                         VirtualKeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -132,11 +132,12 @@ impl Window {
                         * (right as u8 as f32 - left as u8 as f32)
                         + na::Vector3::y() * (up as u8 as f32 - down as u8 as f32)
                         + na::Vector3::z() * (back as u8 as f32 - forward as u8 as f32);
-                    self.sim.velocity(if move_direction.norm_squared() > 1.0 {
-                        move_direction.normalize()
-                    } else {
-                        move_direction
-                    });
+                    self.sim
+                        .set_movement_input(if move_direction.norm_squared() > 1.0 {
+                            move_direction.normalize()
+                        } else {
+                            move_direction
+                        });
 
                     self.sim.rotate(&na::UnitQuaternion::from_axis_angle(
                         &-na::Vector3::z_axis(),

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -96,6 +96,7 @@ mod tests {
         let mock_graph = DualGraph::new();
         let mock_character_input = CharacterInput {
             movement: na::Vector3::x(),
+            no_clip: true,
         };
 
         let mut pred = PredictedMotion::new(pos());

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -12,23 +12,23 @@ use common::{math, proto::Position};
 pub struct PredictedMotion {
     log: VecDeque<Input>,
     generation: u16,
-    predicted: Position,
+    predicted_position: Position,
 }
 
 impl PredictedMotion {
-    pub fn new(initial: Position) -> Self {
+    pub fn new(initial_position: Position) -> Self {
         Self {
             log: VecDeque::new(),
             generation: 0,
-            predicted: initial,
+            predicted_position: initial_position,
         }
     }
 
     /// Update for input about to be sent to the server, returning the generation it should be
     /// tagged with
-    pub fn push(&mut self, velocity: &na::Vector3<f32>) -> u16 {
-        let transform = math::translate_along(velocity);
-        self.predicted.local *= transform;
+    pub fn push(&mut self, movement: &na::Vector3<f32>) -> u16 {
+        let transform = math::translate_along(movement);
+        self.predicted_position.local *= transform;
         self.log.push_back(Input { transform });
         self.generation = self.generation.wrapping_add(1);
         self.generation
@@ -43,16 +43,16 @@ impl PredictedMotion {
             return;
         }
         self.log.drain(..obsolete);
-        self.predicted.node = position.node;
-        self.predicted.local = self
+        self.predicted_position.node = position.node;
+        self.predicted_position.local = self
             .log
             .iter()
             .fold(position.local, |acc, x| acc * x.transform);
     }
 
     /// Latest estimate of the server's state after receiving all `push`ed inputs.
-    pub fn predicted(&self) -> &Position {
-        &self.predicted
+    pub fn predicted_position(&self) -> &Position {
+        &self.predicted_position
     }
 }
 

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -9,6 +9,7 @@ pub fn run_character_step<T>(
     cfg: &SimConfig,
     graph: &Graph<T>,
     position: &mut Position,
+    velocity: &mut na::Vector3<f32>,
     input: &CharacterInput,
     dt_seconds: f32,
 ) {
@@ -16,6 +17,7 @@ pub fn run_character_step<T>(
         cfg,
         graph,
         position,
+        velocity,
         input,
         dt_seconds,
     }
@@ -26,6 +28,7 @@ struct CharacterControllerPass<'a, T> {
     cfg: &'a SimConfig,
     graph: &'a Graph<T>,
     position: &'a mut Position,
+    velocity: &'a mut na::Vector3<f32>,
     input: &'a CharacterInput,
     dt_seconds: f32,
 }
@@ -35,11 +38,33 @@ impl<T> CharacterControllerPass<'_, T> {
         let movement = sanitize_motion_input(self.input.movement);
 
         if self.input.no_clip {
+            // If no-clip is on, the velocity field is useless, and we don't want to accidentally
+            // save velocity from when no-clip was off.
+            *self.velocity = na::Vector3::zeros();
             self.position.local *= math::translate_along(
                 &(movement * self.cfg.no_clip_movement_speed * self.dt_seconds),
             );
         } else {
-            // Placeholder: If no-clip is off, the character cannot move.
+            let old_velocity = *self.velocity;
+
+            // Update velocity
+            let current_to_target_velocity = movement * self.cfg.max_ground_speed - *self.velocity;
+            let max_delta_velocity = self.cfg.ground_acceleration * self.dt_seconds;
+            if current_to_target_velocity.norm_squared() > max_delta_velocity.powi(2) {
+                *self.velocity += current_to_target_velocity.normalize() * max_delta_velocity;
+            } else {
+                *self.velocity += current_to_target_velocity;
+            }
+
+            // Update position by using the average of the old velocity and new velocity, which has
+            // the effect of modeling a velocity that changes linearly over the timestep. This is
+            // necessary to avoid the following two issues:
+            // 1. Input lag, which would occur if only the old velocity was used
+            // 2. Movement artifacts, which would occur if only the new velocity was used. One
+            //    example of such an artifact is the player moving backwards slightly when they
+            //    stop moving after releasing a direction key.
+            self.position.local *=
+                math::translate_along(&((*self.velocity + old_velocity) * 0.5 * self.dt_seconds));
         }
 
         // Renormalize

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -34,9 +34,13 @@ impl<T> CharacterControllerPass<'_, T> {
     fn step(&mut self) {
         let movement = sanitize_motion_input(self.input.movement);
 
-        self.position.local *= math::translate_along(
-            &(movement * self.cfg.movement_speed * self.dt_seconds),
-        );
+        if self.input.no_clip {
+            self.position.local *= math::translate_along(
+                &(movement * self.cfg.no_clip_movement_speed * self.dt_seconds),
+            );
+        } else {
+            // Placeholder: If no-clip is off, the character cannot move.
+        }
 
         // Renormalize
         self.position.local = math::renormalize_isometry(&self.position.local);

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -1,0 +1,51 @@
+use crate::{
+    graph::Graph,
+    math,
+    proto::{CharacterInput, Position},
+    sanitize_motion_input, SimConfig,
+};
+
+pub fn run_character_step<T>(
+    cfg: &SimConfig,
+    graph: &Graph<T>,
+    position: &mut Position,
+    input: &CharacterInput,
+    dt_seconds: f32,
+) {
+    CharacterControllerPass {
+        cfg,
+        graph,
+        position,
+        input,
+        dt_seconds,
+    }
+    .step();
+}
+
+struct CharacterControllerPass<'a, T> {
+    cfg: &'a SimConfig,
+    graph: &'a Graph<T>,
+    position: &'a mut Position,
+    input: &'a CharacterInput,
+    dt_seconds: f32,
+}
+
+impl<T> CharacterControllerPass<'_, T> {
+    fn step(&mut self) {
+        let movement = sanitize_motion_input(self.input.movement);
+
+        self.position.local *= math::translate_along(
+            &(movement * self.cfg.movement_speed * self.dt_seconds),
+        );
+
+        // Renormalize
+        self.position.local = math::renormalize_isometry(&self.position.local);
+        let (next_node, transition_xf) = self
+            .graph
+            .normalize_transform(self.position.node, &self.position.local);
+        if next_node != self.position.node {
+            self.position.node = next_node;
+            self.position.local = transition_xf * self.position.local;
+        }
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,6 +7,7 @@ use rand::{
 mod id;
 
 extern crate nalgebra as na;
+pub mod character_controller;
 mod chunks;
 pub mod codec;
 pub mod cursor;

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{dodeca, graph::NodeId, EntityId, Step};
+use crate::{dodeca, graph::NodeId, EntityId, SimConfig, Step};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClientHello {
@@ -10,13 +10,7 @@ pub struct ClientHello {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerHello {
     pub character: EntityId,
-    pub rate: u16,
-    /// Number of voxels along the edge of a chunk
-    pub chunk_size: u8,
-    /// Maximum movement speed in absolute units
-    pub movement_speed: f32,
-    /// Unit conversion factor
-    pub meters_to_absolute: f32,
+    pub sim_config: SimConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -34,7 +34,12 @@ pub struct StateDelta {
     /// Highest input generation received prior to `step`
     pub latest_input: u16,
     pub positions: Vec<(EntityId, Position)>,
-    pub character_orientations: Vec<(EntityId, na::UnitQuaternion<f32>)>,
+    pub character_states: Vec<(EntityId, CharacterState)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CharacterState {
+    pub orientation: na::UnitQuaternion<f32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -69,5 +74,5 @@ pub struct FreshNode {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Character {
     pub name: String,
-    pub orientation: na::UnitQuaternion<f32>,
+    pub state: CharacterState,
 }

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -60,7 +60,7 @@ pub struct Command {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CharacterInput {
     /// Relative to the character's current position, excluding orientation
-    pub velocity: na::Vector3<f32>,
+    pub movement: na::Vector3<f32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -39,6 +39,7 @@ pub struct StateDelta {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CharacterState {
+    pub velocity: na::Vector3<f32>,
     pub orientation: na::UnitQuaternion<f32>,
 }
 

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -53,7 +53,12 @@ pub struct Spawns {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Command {
     pub generation: u16,
+    pub character_input: CharacterInput,
     pub orientation: na::UnitQuaternion<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CharacterInput {
     /// Relative to the character's current position, excluding orientation
     pub velocity: na::Vector3<f32>,
 }

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -61,6 +61,7 @@ pub struct Command {
 pub struct CharacterInput {
     /// Relative to the character's current position, excluding orientation
     pub movement: na::Vector3<f32>,
+    pub no_clip: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -8,10 +8,12 @@ use crate::{dodeca, math};
 #[derive(Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct SimConfigRaw {
+    /// Number of steps per second
     pub rate: Option<u16>,
     /// Maximum distance at which anything can be seen in meters
     pub view_distance: Option<f32>,
     pub input_queue_size_ms: Option<u16>,
+    /// Number of voxels along the edge of a chunk
     pub chunk_size: Option<u8>,
     /// Approximate length of the edge of a voxel in meters
     ///
@@ -27,9 +29,10 @@ pub struct SimConfigRaw {
 }
 
 /// Complete simulation config parameters
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimConfig {
-    pub rate: u16,
+    /// Amount of time between each step. Inverse of the rate
+    pub step_interval: Duration,
     pub view_distance: f32,
     pub input_queue_size: Duration,
     pub chunk_size: u8,
@@ -44,7 +47,7 @@ impl SimConfig {
         let voxel_size = x.voxel_size.unwrap_or(1.0);
         let meters_to_absolute = meters_to_absolute(chunk_size, voxel_size);
         SimConfig {
-            rate: x.rate.unwrap_or(10),
+            step_interval: Duration::from_secs(1) / x.rate.unwrap_or(10) as u32,
             view_distance: x.view_distance.unwrap_or(90.0) * meters_to_absolute,
             input_queue_size: Duration::from_millis(x.input_queue_size_ms.unwrap_or(50).into()),
             chunk_size,

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -26,6 +26,10 @@ pub struct SimConfigRaw {
     pub voxel_size: Option<f32>,
     /// Character movement speed in m/s during no-clip
     pub no_clip_movement_speed: Option<f32>,
+    /// Character maximumum movement speed while on the ground in m/s
+    pub max_ground_speed: Option<f32>,
+    /// Character acceleration while on the ground in m/s^2
+    pub ground_acceleration: Option<f32>,
 }
 
 /// Complete simulation config parameters
@@ -37,6 +41,8 @@ pub struct SimConfig {
     pub input_queue_size: Duration,
     pub chunk_size: u8,
     pub no_clip_movement_speed: f32,
+    pub max_ground_speed: f32,
+    pub ground_acceleration: f32,
     /// Scaling factor converting meters to absolute units
     pub meters_to_absolute: f32,
 }
@@ -52,6 +58,8 @@ impl SimConfig {
             input_queue_size: Duration::from_millis(x.input_queue_size_ms.unwrap_or(50).into()),
             chunk_size,
             no_clip_movement_speed: x.no_clip_movement_speed.unwrap_or(12.0) * meters_to_absolute,
+            max_ground_speed: x.max_ground_speed.unwrap_or(6.0) * meters_to_absolute,
+            ground_acceleration: x.ground_acceleration.unwrap_or(30.0) * meters_to_absolute,
             meters_to_absolute,
         }
     }

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -24,8 +24,8 @@ pub struct SimConfigRaw {
     /// Note that exact voxel size varies within each chunk. We reference the mean width of the voxels
     /// along the X axis through the center of a chunk.
     pub voxel_size: Option<f32>,
-    /// Character movement speed in m/s
-    pub movement_speed: Option<f32>,
+    /// Character movement speed in m/s during no-clip
+    pub no_clip_movement_speed: Option<f32>,
 }
 
 /// Complete simulation config parameters
@@ -36,7 +36,7 @@ pub struct SimConfig {
     pub view_distance: f32,
     pub input_queue_size: Duration,
     pub chunk_size: u8,
-    pub movement_speed: f32,
+    pub no_clip_movement_speed: f32,
     /// Scaling factor converting meters to absolute units
     pub meters_to_absolute: f32,
 }
@@ -51,7 +51,7 @@ impl SimConfig {
             view_distance: x.view_distance.unwrap_or(90.0) * meters_to_absolute,
             input_queue_size: Duration::from_millis(x.input_queue_size_ms.unwrap_or(50).into()),
             chunk_size,
-            movement_speed: x.movement_speed.unwrap_or(12.0) * meters_to_absolute,
+            no_clip_movement_speed: x.no_clip_movement_speed.unwrap_or(12.0) * meters_to_absolute,
             meters_to_absolute,
         }
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,11 +2,7 @@ extern crate nalgebra as na;
 mod input_queue;
 mod sim;
 
-use std::{
-    net::UdpSocket,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{net::UdpSocket, sync::Arc, time::Instant};
 
 use anyhow::{Context, Error, Result};
 use futures::{select, StreamExt, TryStreamExt};
@@ -60,10 +56,7 @@ impl Server {
     }
 
     async fn run(mut self, incoming: quinn::Incoming) {
-        let mut ticks = IntervalStream::new(tokio::time::interval(
-            Duration::from_secs(1) / self.cfg.rate as u32,
-        ))
-        .fuse();
+        let mut ticks = IntervalStream::new(tokio::time::interval(self.cfg.step_interval)).fuse();
         let mut incoming = incoming
             .inspect(|x| trace!(address = %x.remote_address(), "connection incoming"))
             .buffer_unordered(16);
@@ -147,10 +140,7 @@ impl Server {
                 let connection = client.conn.clone();
                 let server_hello = proto::ServerHello {
                     character: id,
-                    rate: self.cfg.rate,
-                    chunk_size: self.cfg.chunk_size,
-                    meters_to_absolute: self.cfg.meters_to_absolute,
-                    movement_speed: self.cfg.movement_speed,
+                    sim_config: (*self.cfg).clone(),
                 };
                 tokio::spawn(async move {
                     // Errors will be handled by recv task

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -61,6 +61,7 @@ impl Sim {
             name: hello.name,
             state: CharacterState {
                 orientation: na::one(),
+                velocity: na::Vector3::zeros(),
             },
         };
         let initial_input = CharacterInput {
@@ -113,15 +114,16 @@ impl Sim {
         let _guard = span.enter();
 
         // Simulate
-        for (_, (position, input)) in self
+        for (_, (position, character, input)) in self
             .world
-            .query::<(&mut Position, &CharacterInput)>()
+            .query::<(&mut Position, &mut Character, &CharacterInput)>()
             .iter()
         {
             character_controller::run_character_step(
                 &self.cfg,
                 &self.graph,
                 position,
+                &mut character.state.velocity,
                 input,
                 self.cfg.step_interval.as_secs_f32(),
             );

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -64,7 +64,7 @@ impl Sim {
             },
         };
         let initial_input = CharacterInput {
-            velocity: na::Vector3::zeros(),
+            movement: na::Vector3::zeros(),
         };
         let entity = self.world.spawn((id, position, character, initial_input));
         self.entity_ids.insert(id, entity);
@@ -119,7 +119,7 @@ impl Sim {
         {
             let next_xf = pos.local
                 * math::translate_along(
-                    &(sanitize_motion_input(input.velocity)
+                    &(sanitize_motion_input(input.movement)
                         * self.cfg.movement_speed
                         * self.cfg.step_interval.as_secs_f32()),
                 );

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -65,6 +65,7 @@ impl Sim {
         };
         let initial_input = CharacterInput {
             movement: na::Vector3::zeros(),
+            no_clip: true,
         };
         let entity = self.world.spawn((id, position, character, initial_input));
         self.entity_ids.insert(id, entity);

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -108,7 +108,8 @@ impl Sim {
 
         // Simulate
         for (_, (ch, pos)) in self.world.query::<(&Character, &mut Position)>().iter() {
-            let next_xf = pos.local * math::translate_along(&(ch.velocity / self.cfg.rate as f32));
+            let next_xf = pos.local
+                * math::translate_along(&(ch.velocity * self.cfg.step_interval.as_secs_f32()));
             pos.local = math::renormalize_isometry(&next_xf);
             let (next_node, transition_xf) = self.graph.normalize_transform(pos.node, &pos.local);
             if next_node != pos.node {

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -55,7 +55,7 @@ impl Sim {
         info!(%id, name = %hello.name, "spawning character");
         let position = Position {
             node: NodeId::ROOT,
-            local: math::translate_along(&(na::Vector3::y() * 0.9)),
+            local: math::translate_along(&(na::Vector3::y() * 1.1)),
         };
         let character = Character {
             name: hello.name,


### PR DESCRIPTION
This PR does the following
- Adds persistent velocity and acceleration, which is off by default and can be toggled with "V".
- Puts player movement logic into `character_controller.rs` to separate it from the netcode and prediction logic.
- Various changes/refactors to make this separation of logic possible, some of which will likely need revision.

While I believe this PR is technically in a mergeable state, I do not have that much confidence in the current state of this PR and am definitely open to suggestions on how to improve the readability/maintainability of this code. I have the following specific concerns:

- [x] I have the server pass a `SimConfig` object to the client, which reduces some code repetition, but it also likely adds unwanted coupling between config file organization and the actual simulation configuration.
- [x] The prediction logic and server communication doesn't seem to mesh well with the entity-component abstraction, and it seems like fields are being passed around ad-hoc.
- [x] A lambda is passed into `PredictedMotion`, and a type parameter is used, both in order to allow mocking for the `wraparound()` test. However, the lambda setup seems quite ad-hoc and fragile, and it's not obvious that the type `T` refers to a tick of input.
- [x] The `handle_net` function has a large amount of code repetition. The `update_position` function should probably be inlined into `handle_net` to make the code look more consistent. This is mostly a symptom of the ad-hoc non-entity-component setup of message passing.
- [x] The purpose of `CharacterControllerPass` is to stuff contextual information into the `self` parameter and rely on regular arguments in helper functions for information relevant to the function. However, I'm not that familiar with this design pattern and am not sure if it's an antipattern. I have a more complete example at [collision-demo](https://github.com/patowen/hypermine/blob/2d2f38b1cdb51a79c9ce6480e682183b74b072ed/client/src/sim.rs#L617-L885).
- [x] The `no_clip` toggle option's current state is used as part of the input struct rather than toggling `no_clip` being a kind of input. I believe this likely results in cleaner logic, but it's a bit unintuitive.