### PR TITLE
Fix clippy warnings for Rust 1.66.0

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -418,8 +418,8 @@ impl Draw {
         let scissors = [vk::Rect2D {
             offset: vk::Offset2D { x: 0, y: 0 },
             extent: vk::Extent2D {
-                width: extent.width as u32,
-                height: extent.height as u32,
+                width: extent.width,
+                height: extent.height,
             },
         }];
         device.cmd_set_viewport(cmd, 0, &viewports);

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -394,8 +394,8 @@ impl ChunkParams {
         let random_position = Uniform::new(1, self.dimension - 1);
 
         let rain = self.env.rainfalls[0];
-        let tree_candidate_count = (u32::from(self.dimension - 2).pow(3) as f64
-            * (rain / 100.0).max(0.0).min(0.5)) as usize;
+        let tree_candidate_count =
+            (u32::from(self.dimension - 2).pow(3) as f64 * (rain / 100.0).clamp(0.0, 0.5)) as usize;
         for _ in 0..tree_candidate_count {
             let loc = na::Vector3::from_distribution(&random_position, rng);
             let voxel_of_interest_index = index(self.dimension, loc);


### PR DESCRIPTION
The two warnings being fixed are
- Casting a `u32` to a `u32` (https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast)
- using `.min(a).max(b)` instead of `.clamp(a, b)` (https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp)