### PR TITLE
Upgrade to Rust 2021 edition

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "client"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "Apache-2.0 OR Zlib"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "common"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "Apache-2.0 OR Zlib"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "server"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "Apache-2.0 OR Zlib"
 


### PR DESCRIPTION
As Hypermine is designed to work with the latest version of Rust, it also makes sense to upgrade to the latest edition as well. There are some borrow checker improvements between these two editions.

I tested this manually, and it still works as before. No changes are needed for 2021 edition compatibility.