### PR TITLE
Allow the server to generate terrain instead of just the client

### DIFF
--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -10,7 +10,6 @@ use ash::{vk, Device};
 use metrics::histogram;
 use tracing::warn;
 
-use super::draw::nearby_nodes;
 use crate::{
     graphics::{Base, Frustum},
     loader::{Cleanup, LoadCtx, LoadFuture, Loadable, WorkQueue},
@@ -23,6 +22,7 @@ use common::{
     lru_slab::SlotId,
     math,
     node::{Chunk, VoxelData},
+    traversal::nearby_nodes,
     LruSlab,
 };
 

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -8,11 +8,9 @@ use crate::{net, prediction::PredictedMotion, Net};
 use common::{
     character_controller,
     graph::{Graph, NodeId},
-    node::{DualGraph, Node},
+    node::{populate_fresh_nodes, DualGraph},
     proto::{self, Character, CharacterInput, CharacterState, Command, Component, Position},
-    sanitize_motion_input,
-    worldgen::NodeState,
-    Chunks, EntityId, GraphEntities, SimConfig, Step,
+    sanitize_motion_input, EntityId, GraphEntities, SimConfig, Step,
 };
 
 /// Game state
@@ -359,25 +357,4 @@ impl Sim {
 pub struct Parameters {
     pub cfg: SimConfig,
     pub character_id: EntityId,
-}
-
-fn populate_fresh_nodes(graph: &mut DualGraph) {
-    let fresh = graph.fresh().to_vec();
-    graph.clear_fresh();
-    for &node in &fresh {
-        populate_node(graph, node);
-    }
-}
-
-fn populate_node(graph: &mut DualGraph, node: NodeId) {
-    *graph.get_mut(node) = Some(Node {
-        state: graph
-            .parent(node)
-            .and_then(|i| {
-                let parent_state = &graph.get(graph.neighbor(node, i)?).as_ref()?.state;
-                Some(parent_state.child(graph, node, i))
-            })
-            .unwrap_or_else(NodeState::root),
-        chunks: Chunks::default(),
-    });
 }

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -1,13 +1,13 @@
 use crate::{
-    graph::Graph,
     math,
+    node::DualGraph,
     proto::{CharacterInput, Position},
     sanitize_motion_input, SimConfig,
 };
 
-pub fn run_character_step<T>(
+pub fn run_character_step(
     cfg: &SimConfig,
-    graph: &Graph<T>,
+    graph: &DualGraph,
     position: &mut Position,
     velocity: &mut na::Vector3<f32>,
     input: &CharacterInput,
@@ -24,16 +24,16 @@ pub fn run_character_step<T>(
     .step();
 }
 
-struct CharacterControllerPass<'a, T> {
+struct CharacterControllerPass<'a> {
     cfg: &'a SimConfig,
-    graph: &'a Graph<T>,
+    graph: &'a DualGraph,
     position: &'a mut Position,
     velocity: &'a mut na::Vector3<f32>,
     input: &'a CharacterInput,
     dt_seconds: f32,
 }
 
-impl<T> CharacterControllerPass<'_, T> {
+impl CharacterControllerPass<'_> {
     fn step(&mut self) {
         let movement = sanitize_motion_input(self.input.movement);
 

--- a/common/src/traversal.rs
+++ b/common/src/traversal.rs
@@ -32,3 +32,52 @@ pub fn ensure_nearby<N>(graph: &mut Graph<N>, start: &Position, distance: f64) {
         }
     }
 }
+
+/// Compute `start.node`-relative transforms of all nodes whose origins lie within `distance` of
+/// `start`
+pub fn nearby_nodes<N>(
+    graph: &Graph<N>,
+    start: &Position,
+    distance: f64,
+) -> Vec<(NodeId, na::Matrix4<f32>)> {
+    struct PendingNode {
+        id: NodeId,
+        transform: na::Matrix4<f64>,
+    }
+
+    let mut result = Vec::new();
+    let mut pending = Vec::<PendingNode>::new();
+    let mut visited = FxHashSet::<NodeId>::default();
+    let start_p = start.local.map(|x| x as f64) * math::origin();
+
+    pending.push(PendingNode {
+        id: start.node,
+        transform: na::Matrix4::identity(),
+    });
+    visited.insert(start.node);
+
+    while let Some(current) = pending.pop() {
+        let current_p = current.transform * math::origin();
+        if math::distance(&start_p, &current_p) > distance {
+            continue;
+        }
+        result.push((current.id, na::convert(current.transform)));
+
+        for side in Side::iter() {
+            let neighbor = match graph.neighbor(current.id, side) {
+                None => continue,
+                Some(x) => x,
+            };
+            if visited.contains(&neighbor) {
+                continue;
+            }
+            pending.push(PendingNode {
+                id: neighbor,
+                transform: current.transform * side.reflection(),
+            });
+            visited.insert(neighbor);
+        }
+    }
+
+    result
+}

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -10,6 +10,7 @@ use common::{
     character_controller,
     graph::{Graph, NodeId},
     math,
+    node::DualGraph,
     proto::{
         Character, CharacterInput, CharacterState, ClientHello, Command, Component, FreshNode,
         Position, Spawns, StateDelta,
@@ -24,7 +25,7 @@ pub struct Sim {
     step: Step,
     entity_ids: FxHashMap<EntityId, Entity>,
     world: hecs::World,
-    graph: Graph<Empty>,
+    graph: DualGraph,
     spawns: Vec<Entity>,
     despawns: Vec<EntityId>,
 }
@@ -189,8 +190,6 @@ impl Sim {
         }
     }
 }
-
-enum Empty {}
 
 fn dump_entity(world: &hecs::World, entity: Entity) -> Vec<Component> {
     let mut components = Vec::new();


### PR DESCRIPTION
Relying on the consistency of terrain-generation code between runs and between different computers, we have the server generate chunks in a smaller radius of nodes around the player. This, in addition to future changes, will allow the server to run code that depends on the current state of the world, such as collision checking, terrain modification, NPC spawns, etc.

As no code currently depends on this server-generated terrain, testing that these changes work as intended is not possible without additional code modification. However, even if this is broken, this should not result in any regressions, so to limit the scope of this PR, the lack of I believe the lack of testability is acceptable.

One minor concrete change this PR makes is that terrain generation for the client no longer depends on which direction the player is looking. Surface extraction is unaffected and is still affected as before.