### PR TITLE
Use libm to help prevent future terrain generation consistency bugs

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,8 @@ ash-window = "0.12.0"
 raw-window-handle = "0.5.0"
 directories = "4.0.1"
 vk-shader-macros = "0.2.5"
-nalgebra = "0.31.2"
+nalgebra = { version = "0.31.2", features = ["libm-force"] }
+libm = "0.2.6"
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "sync", "macros"] }
 png = "0.17.5"
 anyhow = "1.0.26"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,11 +10,12 @@ license = "Apache-2.0 OR Zlib"
 
 [dependencies]
 serde = { version = "1.0.104", features = ["derive"] }
-nalgebra = { version = "0.31.2", features = ["rand", "serde-serialize"] }
+nalgebra = { version = "0.31.2", features = ["libm-force", "rand", "serde-serialize"] }
 bincode = "1.2.1"
 anyhow = "1.0.26"
 quinn = "0.8.3"
 lazy_static = "1.4.0"
+libm = "0.2.6"
 fxhash = "0.2.1"
 tracing = "0.1.10"
 hecs = "0.9.0"

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -50,7 +50,7 @@ impl<T> CharacterControllerPass<'_, T> {
             // Update velocity
             let current_to_target_velocity = movement * self.cfg.max_ground_speed - *self.velocity;
             let max_delta_velocity = self.cfg.ground_acceleration * self.dt_seconds;
-            if current_to_target_velocity.norm_squared() > max_delta_velocity.powi(2) {
+            if current_to_target_velocity.norm_squared() > math::sqr(max_delta_velocity) {
                 *self.velocity += current_to_target_velocity.normalize() * max_delta_velocity;
             } else {
                 *self.velocity += current_to_target_velocity;

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -155,7 +155,7 @@ impl Vertex {
     /// Scaling the x, y, and z components of a vector in cube-centric coordinates by this value
     /// and dividing them by the w coordinate will yield euclidean chunk coordinates.
     pub fn dual_to_chunk_factor() -> f64 {
-        (2.0 + 5.0f64.sqrt()).sqrt()
+        2.0581710272714924 // sqrt(2 + sqrt(5))
     }
 
     /// Convenience method for `self.chunk_to_node().determinant() < 0`.
@@ -186,8 +186,8 @@ lazy_static! {
 
     /// Vector corresponding to the outer normal of each side
     static ref SIDE_NORMALS: [na::Vector4<f64>; SIDE_COUNT] = {
-        let phi = 1.25f64.sqrt() + 0.5; // golden ratio
-        let f = math::lorentz_normalize(&na::Vector4::new(1.0, phi, 0.0, phi.sqrt()));
+        let phi = libm::sqrt(1.25) + 0.5; // golden ratio
+        let f = math::lorentz_normalize(&na::Vector4::new(1.0, phi, 0.0, libm::sqrt(phi)));
 
         let mut result: [na::Vector4<f64>; SIDE_COUNT] = [na::zero(); SIDE_COUNT];
         let mut i = 0;

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -31,7 +31,7 @@ impl<N: RealField + Copy> HPoint<N> {
     pub fn to_homogeneous(self) -> na::Vector4<N> {
         // x^2 + y^2 + z^2 - w^2 = -1
         // sqrt(x^2 + y^2 + z^2 + 1) = w
-        let w = (self.0.x.powi(2) + self.0.y.powi(2) + self.0.z.powi(2) + na::one()).sqrt();
+        let w = (sqr(self.0.x) + sqr(self.0.y) + sqr(self.0.z) + na::one()).sqrt();
         na::Vector4::new(self.0.x, self.0.y, self.0.z, w)
     }
 }
@@ -71,7 +71,7 @@ pub fn midpoint<N: RealField + Copy>(a: &na::Vector4<N>, b: &na::Vector4<N>) -> 
 }
 
 pub fn distance<N: RealField + Copy>(a: &na::Vector4<N>, b: &na::Vector4<N>) -> N {
-    (mip(a, b).powi(2) / (mip(a, a) * mip(b, b))).sqrt().acosh()
+    (sqr(mip(a, b)) / (mip(a, a) * mip(b, b))).sqrt().acosh()
 }
 
 pub fn origin<N: RealField + Copy>() -> na::Vector4<N> {
@@ -118,6 +118,11 @@ pub fn parity<N: RealField + Copy>(m: &na::Matrix4<N>) -> bool {
 /// Minkowski inner product, aka <a, b>_h
 pub fn mip<N: RealField + Copy>(a: &na::Vector4<N>, b: &na::Vector4<N>) -> N {
     a.x * b.x + a.y * b.y + a.z * b.z - a.w * b.w
+}
+
+#[inline]
+pub fn sqr<N: RealField + Copy>(x: N) -> N {
+    x * x
 }
 
 /// Minkowski transpose. Inverse for hyperbolic isometries

--- a/common/src/terraingen.rs
+++ b/common/src/terraingen.rs
@@ -1,4 +1,4 @@
-use crate::world::Material;
+use crate::{math, world::Material};
 
 const GENERAL_HIGH: [VoronoiInfo; 113] = [
     VoronoiInfo::new(Material::ClayLoam, 10.50, -10.50),
@@ -974,11 +974,11 @@ impl VoronoiInfo {
         };
 
         let y: [f32; 2] = [rain as f32, temp as f32];
-        let mut dist_squared = (voronoi_choices[0].location[0] - y[0]).powi(2)
-            + (voronoi_choices[0].location[1] - y[1]).powi(2);
+        let mut dist_squared = math::sqr(voronoi_choices[0].location[0] - y[0])
+            + math::sqr(voronoi_choices[0].location[1] - y[1]);
         let mut voxel_mat = voronoi_choices[0].material;
         for vc in voronoi_choices.iter().skip(1) {
-            let d_squared = (vc.location[0] - y[0]).powi(2) + (vc.location[1] - y[1]).powi(2);
+            let d_squared = math::sqr(vc.location[0] - y[0]) + math::sqr(vc.location[1] - y[1]);
             if d_squared <= dist_squared {
                 dist_squared = d_squared;
                 voxel_mat = vc.material;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,9 +21,10 @@ rcgen = { version = "0.10.0", default-features = false }
 hostname = "0.3.0"
 futures = "0.3.1"
 hecs = "0.9.0"
-rand = { version = "0.8.5", features = [ "small_rng" ] }
+rand = { version = "0.8.5", features = ["small_rng"] }
 fxhash = "0.2.1"
-nalgebra = "0.31.2"
+nalgebra = { version = "0.31.2", features = ["libm-force"] }
+libm = "0.2.6"
 slotmap = "1.0.6"
 rustls = "0.20.6"
 rustls-pemfile = "1.0.0"


### PR DESCRIPTION
To prevent requiring the server to send lots of data to the client, terrain generation should be run on both the server and the client separately. To avoid inconsistencies in terrain generation caused by differing implementations of transcendental functions, we use the `libm` library, which provides its own implementation of these functions.