### PR TITLE
Fix clippy warnings for Rust 1.67.0

### DIFF
--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -282,7 +282,7 @@ impl Window {
                         self.swapchain_needs_update = true;
                     }
                     Err(e) => {
-                        panic!("acquire_next_image: {}", e);
+                        panic!("acquire_next_image: {e}");
                     }
                 }
             };
@@ -305,7 +305,7 @@ impl Window {
                 Ok(true) | Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
                     self.swapchain_needs_update = true;
                 }
-                Err(e) => panic!("queue_present: {}", e),
+                Err(e) => panic!("queue_present: {e}"),
             };
         }
     }
@@ -351,7 +351,7 @@ impl SwapchainMgr {
                 || surface_formats[0].color_space != desired_format.color_space))
             && !surface_formats.iter().any(desirable_format)
         {
-            panic!("no suitable surface format: {:?}", surface_formats);
+            panic!("no suitable surface format: {surface_formats:?}");
         }
 
         Self {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::new_without_default)]
+#![allow(clippy::needless_borrowed_reference)]
 
 macro_rules! cstr {
     ($x:literal) => {{

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
                 },
                 sim_cfg,
             ) {
-                eprintln!("{:#}", e);
+                eprintln!("{e:#}");
                 std::process::exit(1);
             }
         });

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_borrowed_reference)]
+
 use rand::{
     distributions::{Distribution, Standard},
     Rng,

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -700,7 +700,7 @@ mod test {
 
         let enviros = chunk_incident_enviro_factors(&g, NodeId::ROOT, Vertex::A).unwrap();
         for (i, max_elevation) in enviros.max_elevations.iter().cloned().enumerate() {
-            println!("{}, {}", i, max_elevation);
+            println!("{i}, {max_elevation}");
             assert_abs_diff_eq!(max_elevation, (i + 1) as f64, epsilon = 1e-8);
         }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_borrowed_reference)]
+
 extern crate nalgebra as na;
 mod input_queue;
 mod sim;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_borrowed_reference)]
+
 mod config;
 
 use std::{fs, net::UdpSocket, path::Path};
@@ -13,7 +15,7 @@ fn main() {
     common::init_tracing();
 
     if let Err(e) = run() {
-        eprintln!("{:#}", e);
+        eprintln!("{e:#}");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
~~This PR fixes 5 instances of [needless_borrowed_reference](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference) and 6 instances of [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).~~

This PR allows the [needless_borrowed_reference](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference) lint and fixes 6 instances of [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).