### PR TITLE
Add initial sphere-voxel collision detection 

### DIFF
--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -2,7 +2,7 @@ use tracing::info;
 
 use crate::{
     graph_collision, math,
-    node::DualGraph,
+    node::{ChunkLayout, DualGraph},
     proto::{CharacterInput, Position},
     sanitize_motion_input, SimConfig,
 };
@@ -107,7 +107,14 @@ impl CharacterControllerPass<'_> {
         let ray = graph_collision::Ray::new(math::origin(), displacement_normalized);
         let tanh_distance = displacement_norm.tanh();
 
-        let cast_hit = graph_collision::sphere_cast(self.position, &ray, tanh_distance);
+        let cast_hit = graph_collision::sphere_cast(
+            self.cfg.character_radius,
+            self.graph,
+            &ChunkLayout::new(self.cfg.chunk_size as usize),
+            self.position,
+            &ray,
+            tanh_distance,
+        );
 
         let allowed_displacement = math::translate(
             &ray.position,

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -1,4 +1,4 @@
-use tracing::info;
+use tracing::{error, info};
 
 use crate::{
     graph_collision, math,
@@ -115,6 +115,14 @@ impl CharacterControllerPass<'_> {
             &ray,
             tanh_distance,
         );
+
+        let cast_hit = match cast_hit {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Collision checking returned {:?}", e);
+                return CollisionCheckingResult::stationary();
+            }
+        };
 
         let allowed_displacement = math::translate(
             &ray.position,

--- a/common/src/chunk_collision.rs
+++ b/common/src/chunk_collision.rs
@@ -1,0 +1,1140 @@
+use crate::{
+    graph_collision::Ray,
+    math,
+    node::{ChunkLayout, VoxelData},
+    world::Material,
+};
+
+pub struct ChunkCastHit {
+    /// The tanh of the distance traveled along the ray to result in this hit.
+    pub tanh_distance: f32,
+
+    /// Represents the normal vector of the hit surface in the dual coordinate system of the chunk.
+    /// To get the actual normal vector, project it so that it is orthogonal to the endpoint in Lorentz space.
+    pub normal: na::Vector4<f32>,
+}
+
+/// Performs sphere casting (swept collision query) against the voxels in the chunk with the given `voxel_data`
+///
+/// The `ray` parameter is given and any resulting hit normals are given in the chunk's dual coordinate system.
+///
+/// The `tanh_distance` is the hyperbolic tangent of the distance along the ray to check for hits.
+pub fn chunk_sphere_cast(
+    collider_radius: f32,
+    voxel_data: &VoxelData,
+    layout: &ChunkLayout,
+    ray: &Ray,
+    tanh_distance: f32,
+) -> Option<ChunkCastHit> {
+    let mut hit: Option<ChunkCastHit> = None;
+
+    let Some(bounding_box) = VoxelAABB::from_ray_segment_and_radius(
+        layout,
+        ray,
+        tanh_distance,
+        collider_radius,
+    ) else {
+        return None;
+    };
+
+    for t_axis in 0..3 {
+        hit = find_face_collision(
+            collider_radius,
+            voxel_data,
+            layout,
+            &bounding_box,
+            t_axis,
+            ray,
+            hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance),
+        )
+        .or(hit);
+    }
+
+    for t_axis in 0..3 {
+        hit = find_edge_collision(
+            collider_radius,
+            voxel_data,
+            layout,
+            &bounding_box,
+            t_axis,
+            ray,
+            hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance),
+        )
+        .or(hit);
+    }
+
+    hit = find_vertex_collision(
+        collider_radius,
+        voxel_data,
+        layout,
+        &bounding_box,
+        ray,
+        hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance),
+    )
+    .or(hit);
+
+    hit
+}
+
+/// Detect collisions where a sphere contacts the front side of a voxel face
+fn find_face_collision(
+    collider_radius: f32,
+    voxel_data: &VoxelData,
+    layout: &ChunkLayout,
+    bounding_box: &VoxelAABB,
+    t_axis: usize,
+    ray: &Ray,
+    tanh_distance: f32,
+) -> Option<ChunkCastHit> {
+    let mut hit: Option<ChunkCastHit> = None;
+
+    let u_axis = (t_axis + 1) % 3;
+    let v_axis = (t_axis + 2) % 3;
+
+    // Loop through all grid planes overlapping the bounding box
+    for t in bounding_box.grid_planes(t_axis) {
+        // Find a normal to the grid plane. Note that (t, 0, 0, x) is a normal of the plane whose closest point
+        // to the origin is (x, 0, 0, t), and we use that fact here.
+        let normal = math::lorentz_normalize(&tuv_to_xyz(
+            t_axis,
+            na::Vector4::new(1.0, 0.0, 0.0, layout.grid_to_dual(t)),
+        ));
+
+        let Some(new_tanh_distance) =
+            solve_sphere_plane_intersection(ray, &normal, collider_radius.sinh()) else {
+                continue;
+            };
+
+        // If new_tanh_distance is out of range, no collision occurred.
+        if new_tanh_distance >= hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance) {
+            continue;
+        }
+
+        // Whether we are approaching the front or back of the face. An approach from the positive t direction
+        // is 1, and an approach from the negative t direction is -1.
+        let collision_side = -math::mip(&ray.direction, &normal).signum();
+
+        // Which side we approach the plane from affects which voxel we want to use for collision checking
+        let voxel_t = if collision_side > 0.0 { t } else { t + 1 };
+
+        let ray_endpoint = ray.ray_point(new_tanh_distance);
+        let contact_point = ray_endpoint - normal * math::mip(&ray_endpoint, &normal);
+
+        // Compute the u and v-coordinates of the voxels at the contact point
+        let Some(voxel_u) = layout.dual_to_voxel(contact_point[u_axis] / contact_point.w) else {
+            continue;
+        };
+        let Some(voxel_v) = layout.dual_to_voxel(contact_point[v_axis] / contact_point.w) else {
+            continue;
+        };
+
+        // Ensure that the relevant voxel is solid
+        if !voxel_is_solid(
+            voxel_data,
+            layout,
+            tuv_to_xyz(t_axis, [voxel_t, voxel_u, voxel_v]),
+        ) {
+            continue;
+        }
+
+        // A collision was found. Update the hit.
+        hit = Some(ChunkCastHit {
+            tanh_distance: new_tanh_distance,
+            normal: normal * collision_side,
+        });
+    }
+
+    hit
+}
+
+/// Detect collisions where a sphere contacts a voxel edge
+fn find_edge_collision(
+    collider_radius: f32,
+    voxel_data: &VoxelData,
+    layout: &ChunkLayout,
+    bounding_box: &VoxelAABB,
+    t_axis: usize,
+    ray: &Ray,
+    tanh_distance: f32,
+) -> Option<ChunkCastHit> {
+    let mut hit: Option<ChunkCastHit> = None;
+
+    let u_axis = (t_axis + 1) % 3;
+    let v_axis = (t_axis + 2) % 3;
+
+    // Loop through all grid lines overlapping the bounding box
+    for (u, v) in bounding_box.grid_lines(u_axis, v_axis) {
+        let edge_pos = math::lorentz_normalize(&tuv_to_xyz(
+            t_axis,
+            na::Vector4::new(0.0, layout.grid_to_dual(u), layout.grid_to_dual(v), 1.0),
+        ));
+        let edge_dir = tuv_to_xyz(t_axis, na::Vector4::new(1.0, 0.0, 0.0, 0.0));
+
+        let Some(new_tanh_distance) = solve_sphere_line_intersection(
+            ray,
+            &edge_pos,
+            &edge_dir,
+            collider_radius.cosh(),
+        ) else {
+            continue;
+        };
+
+        // If new_tanh_distance is out of range, no collision occurred.
+        if new_tanh_distance >= hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance) {
+            continue;
+        }
+
+        let ray_endpoint = ray.ray_point(new_tanh_distance);
+        let contact_point = -edge_pos * math::mip(&ray_endpoint, &edge_pos)
+            + edge_dir * math::mip(&ray_endpoint, &edge_dir);
+
+        // Compute the t-coordinate of the voxels at the contact point
+        let Some(voxel_t) = layout.dual_to_voxel(contact_point[t_axis] / contact_point.w) else {
+            continue;
+        };
+
+        // Ensure that the edge has a solid voxel adjacent to it
+        if (0..2).all(|du| {
+            (0..2).all(|dv| {
+                !voxel_is_solid(
+                    voxel_data,
+                    layout,
+                    tuv_to_xyz(t_axis, [voxel_t, u + du, v + dv]),
+                )
+            })
+        }) {
+            continue;
+        }
+
+        // A collision was found. Update the hit.
+        hit = Some(ChunkCastHit {
+            tanh_distance: new_tanh_distance,
+            normal: ray_endpoint - contact_point,
+        });
+    }
+
+    hit
+}
+
+/// Detect collisions where a sphere contacts a voxel vertex
+fn find_vertex_collision(
+    collider_radius: f32,
+    voxel_data: &VoxelData,
+    layout: &ChunkLayout,
+    bounding_box: &VoxelAABB,
+    ray: &Ray,
+    tanh_distance: f32,
+) -> Option<ChunkCastHit> {
+    let mut hit: Option<ChunkCastHit> = None;
+
+    // Loop through all grid points contained in the bounding box
+    for (x, y, z) in bounding_box.grid_points(0, 1, 2) {
+        // Skip vertices that have no solid voxels adjacent to them
+        if (0..2).all(|dx| {
+            (0..2).all(|dy| {
+                (0..2).all(|dz| !voxel_is_solid(voxel_data, layout, [x + dx, y + dy, z + dz]))
+            })
+        }) {
+            continue;
+        }
+
+        // Determine the cube-centric coordinates of the vertex
+        let vertex_position = math::lorentz_normalize(&na::Vector4::new(
+            layout.grid_to_dual(x),
+            layout.grid_to_dual(y),
+            layout.grid_to_dual(z),
+            1.0,
+        ));
+
+        let Some(new_tanh_distance) =
+            solve_sphere_point_intersection(ray, &vertex_position, collider_radius.cosh()) else {
+                continue;
+            };
+
+        // If new_tanh_distance is out of range, no collision occurred.
+        if new_tanh_distance >= hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance) {
+            continue;
+        }
+
+        // A collision was found. Update the hit.
+        let ray_endpoint = ray.ray_point(new_tanh_distance);
+        hit = Some(ChunkCastHit {
+            tanh_distance: new_tanh_distance,
+            normal: ray_endpoint - vertex_position,
+        });
+    }
+
+    hit
+}
+
+/// Finds the tanh of the distance a sphere will have to travel along a ray before it
+/// intersects the given plane.
+fn solve_sphere_plane_intersection(
+    ray: &Ray,
+    plane_normal: &na::Vector4<f32>,
+    sinh_radius: f32,
+) -> Option<f32> {
+    let mip_pos_a = math::mip(&ray.position, plane_normal);
+    let mip_dir_a = math::mip(&ray.direction, plane_normal);
+
+    solve_quadratic(
+        mip_pos_a.powi(2) - sinh_radius.powi(2),
+        mip_pos_a * mip_dir_a,
+        mip_dir_a.powi(2) + sinh_radius.powi(2),
+    )
+}
+
+/// Finds the tanh of the distance a sphere will have to travel along a ray before it
+/// intersects the given line.
+fn solve_sphere_line_intersection(
+    ray: &Ray,
+    line_position: &na::Vector4<f32>,
+    line_direction: &na::Vector4<f32>,
+    cosh_radius: f32,
+) -> Option<f32> {
+    // This could be made more numerically stable by using a formula that depends on sinh_radius,
+    // but the precision requirements of collision should be pretty lax.
+    let mip_pos_a = math::mip(&ray.position, line_position);
+    let mip_dir_a = math::mip(&ray.direction, line_position);
+    let mip_pos_b = math::mip(&ray.position, line_direction);
+    let mip_dir_b = math::mip(&ray.direction, line_direction);
+
+    solve_quadratic(
+        mip_pos_a.powi(2) - mip_pos_b.powi(2) - cosh_radius.powi(2),
+        mip_pos_a * mip_dir_a - mip_pos_b * mip_dir_b,
+        mip_dir_a.powi(2) - mip_dir_b.powi(2) + cosh_radius.powi(2),
+    )
+}
+
+/// Finds the tanh of the distance a sphere will have to travel along a ray before it
+/// intersects the given point.
+fn solve_sphere_point_intersection(
+    ray: &Ray,
+    point_position: &na::Vector4<f32>,
+    cosh_radius: f32,
+) -> Option<f32> {
+    // This could be made more numerically stable by using a formula that depends on sinh_radius,
+    // but the precision requirements of collision should be pretty lax.
+    let mip_pos_a = math::mip(&ray.position, point_position);
+    let mip_dir_a = math::mip(&ray.direction, point_position);
+
+    solve_quadratic(
+        mip_pos_a.powi(2) - cosh_radius.powi(2),
+        mip_pos_a * mip_dir_a,
+        mip_dir_a.powi(2) + cosh_radius.powi(2),
+    )
+}
+
+/// Finds the lower solution `x` of `constant_term + 2 * half_linear_term * x + quadratic_term * x * x == 0`
+/// if such a solution exists and is non-negative. Assumes that `quadratic_term` is positive. Double-roots are
+/// ignored.
+///
+/// If the lower solution is negative, but a small perturbation to the constant term would make it 0, this function
+/// returns 0.
+fn solve_quadratic(constant_term: f32, half_linear_term: f32, quadratic_term: f32) -> Option<f32> {
+    const EPSILON: f32 = 1e-4;
+
+    // If the linear term is positive, the lower solution is negative, and we're not interested. If the
+    // linear term is zero, the solution can only be non-negative if the constant term is also zero,
+    // which results in a double-root, which we also ignore.
+    if half_linear_term >= 0.0 {
+        return None;
+    }
+
+    // If the constant term is negative, the lower solution must also be negative. To avoid precision issues
+    // allowing a collider to clip through a surface, we treat small negative constant terms as zero, which
+    // results in a lower solution of zero.
+    if constant_term <= 0.0 {
+        return if constant_term > -EPSILON {
+            Some(0.0)
+        } else {
+            None
+        };
+    }
+
+    let discriminant = half_linear_term * half_linear_term - quadratic_term * constant_term;
+    if discriminant <= 0.0 {
+        return None;
+    }
+
+    // We use an alternative quadratic formula to ensure that we return a positive number if `constant_term > 0.0`.
+    // Otherwise, the edge case of a small positive `constant_term` could be mishandled.
+    // The denominator cannot be zero because both of its terms are positive.
+    Some(constant_term / (-half_linear_term + discriminant.sqrt()))
+}
+
+/// Converts from t-u-v coordinates to x-y-z coordinates. t-u-v coordinates are a permuted version of x-y-z coordinates.
+/// `t_axis` determines which of the three x-y-z coordinates corresponds to the t-coordinate. This function works with
+/// any indexable entity with at least three entries. Any entry after the third entry is ignored.
+fn tuv_to_xyz<T: std::ops::IndexMut<usize, Output = N>, N: Copy>(t_axis: usize, tuv: T) -> T {
+    let mut result = tuv;
+    (
+        result[t_axis],
+        result[(t_axis + 1) % 3],
+        result[(t_axis + 2) % 3],
+    ) = (result[0], result[1], result[2]);
+    result
+}
+
+/// Checks whether a voxel can be collided with. Any non-void voxel falls under this category.
+fn voxel_is_solid(voxel_data: &VoxelData, layout: &ChunkLayout, coords: [usize; 3]) -> bool {
+    let dimension_with_margin = layout.dimension() + 2;
+    debug_assert!(coords[0] < dimension_with_margin);
+    debug_assert!(coords[1] < dimension_with_margin);
+    debug_assert!(coords[2] < dimension_with_margin);
+    voxel_data.get(
+        coords[0] + coords[1] * dimension_with_margin + coords[2] * dimension_with_margin.pow(2),
+    ) != Material::Void
+}
+
+/// Represents a discretized region in the voxel grid contained by an axis-aligned bounding box.
+struct VoxelAABB {
+    // The bounds are of the form [[x_min, x_max], [y_min, y_max], [z_min, z_max]], using voxel coordinates with margins.
+    // Any voxel that intersects the cube of interest is included in these bounds. By adding or subtracting 1 in the right
+    // places, these bounds can be used to find other useful info related to the cube of interset, such as what grid points
+    // it contains.
+    bounds: [[usize; 2]; 3],
+}
+
+impl VoxelAABB {
+    /// Returns a bounding box that is guaranteed to cover a given radius around a ray segment. Returns None if the
+    /// bounding box lies entirely outside the chunk, including its margins.
+    pub fn from_ray_segment_and_radius(
+        layout: &ChunkLayout,
+        ray: &Ray,
+        tanh_distance: f32,
+        radius: f32,
+    ) -> Option<VoxelAABB> {
+        // Convert the ray to grid coordinates
+        let grid_start =
+            na::Point3::from_homogeneous(ray.position).unwrap() * layout.dual_to_grid_factor();
+        let grid_end = na::Point3::from_homogeneous(ray.ray_point(tanh_distance)).unwrap()
+            * layout.dual_to_grid_factor();
+        // Convert the radius to grid coordinates using a crude conservative estimate
+        let max_grid_radius = radius * layout.dual_to_grid_factor();
+        let mut bounds = [[0; 2]; 3];
+        for axis in 0..3 {
+            let grid_min = grid_start[axis].min(grid_end[axis]) - max_grid_radius;
+            let grid_max = grid_start[axis].max(grid_end[axis]) + max_grid_radius;
+            let voxel_min = (grid_min + 1.0).floor().max(0.0);
+            let voxel_max = (grid_max + 1.0)
+                .floor()
+                .min(layout.dimension() as f32 + 1.0);
+
+            // This will happen when voxel_min is greater than dimension+1 or voxel_max is less than 0, which
+            // occurs when the cube is out of range.
+            if voxel_min > voxel_max {
+                return None;
+            }
+
+            // We convert to usize here instead of earlier because out-of-range voxel coordinates can be negative.
+            bounds[axis] = [voxel_min.floor() as usize, voxel_max.floor() as usize];
+        }
+
+        Some(VoxelAABB { bounds })
+    }
+
+    /// Iterator over grid points contained in the region, represented as ordered triples
+    pub fn grid_points(
+        &self,
+        axis0: usize,
+        axis1: usize,
+        axis2: usize,
+    ) -> impl Iterator<Item = (usize, usize, usize)> {
+        let bounds = self.bounds;
+        (bounds[axis0][0]..bounds[axis0][1]).flat_map(move |i| {
+            (bounds[axis1][0]..bounds[axis1][1])
+                .flat_map(move |j| (bounds[axis2][0]..bounds[axis2][1]).map(move |k| (i, j, k)))
+        })
+    }
+
+    /// Iterator over grid lines intersecting the region, represented as ordered pairs determining the line's two fixed coordinates
+    pub fn grid_lines(&self, axis0: usize, axis1: usize) -> impl Iterator<Item = (usize, usize)> {
+        let bounds = self.bounds;
+        (bounds[axis0][0]..bounds[axis0][1])
+            .flat_map(move |i| (bounds[axis1][0]..bounds[axis1][1]).map(move |j| (i, j)))
+    }
+
+    /// Iterator over grid planes intersecting the region, represented as integers determining the plane's fixed coordinate
+    pub fn grid_planes(&self, axis: usize) -> impl Iterator<Item = usize> {
+        self.bounds[axis][0]..self.bounds[axis][1]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::node::VoxelData;
+
+    use super::*;
+    use approx::*;
+
+    /// Helper structure used to reduce the number of parameters to pass around with tests
+    struct TestSphereCastContext {
+        collider_radius: f32,
+        layout: ChunkLayout,
+        voxel_data: VoxelData,
+    }
+
+    impl TestSphereCastContext {
+        fn new(collider_radius: f32) -> Self {
+            let dimension: usize = 12;
+
+            let mut ctx = TestSphereCastContext {
+                collider_radius,
+                layout: ChunkLayout::new(dimension),
+                voxel_data: VoxelData::Solid(Material::Void),
+            };
+
+            // Populate voxels. Consists of a single voxel with voxel coordinates (2, 2, 2). The cube corresponding
+            // to this voxel has grid coordinates from (1, 1, 1) to (2, 2, 2)
+            ctx.set_voxel([2, 2, 2], Material::Dirt);
+
+            ctx
+        }
+
+        fn set_voxel(&mut self, coords: [usize; 3], material: Material) {
+            let dimension_with_margin = self.layout.dimension() + 2;
+            debug_assert!(coords[0] < dimension_with_margin);
+            debug_assert!(coords[1] < dimension_with_margin);
+            debug_assert!(coords[2] < dimension_with_margin);
+            self.voxel_data.data_mut(self.layout.dimension() as u8)[coords[0]
+                + coords[1] * dimension_with_margin
+                + coords[2] * dimension_with_margin.pow(2)] = material;
+        }
+    }
+
+    /// Helper method to create a `ChunkSphereCastContext` that can be used
+    /// in a closure to call sphere casting methods.
+    fn cast_with_test_ray(
+        ctx: &TestSphereCastContext,
+        ray_start_grid_coords: [f32; 3],
+        ray_end_grid_coords: [f32; 3],
+        wrapped_fn: impl FnOnce(&Ray, f32),
+    ) {
+        let ray_start = math::lorentz_normalize(&na::Vector4::new(
+            ray_start_grid_coords[0] / ctx.layout.dual_to_grid_factor(),
+            ray_start_grid_coords[1] / ctx.layout.dual_to_grid_factor(),
+            ray_start_grid_coords[2] / ctx.layout.dual_to_grid_factor(),
+            1.0,
+        ));
+
+        let ray_end = math::lorentz_normalize(&na::Vector4::new(
+            ray_end_grid_coords[0] / ctx.layout.dual_to_grid_factor(),
+            ray_end_grid_coords[1] / ctx.layout.dual_to_grid_factor(),
+            ray_end_grid_coords[2] / ctx.layout.dual_to_grid_factor(),
+            1.0,
+        ));
+
+        let ray = Ray::new(
+            ray_start,
+            math::lorentz_normalize(
+                &((ray_end - ray_start)
+                    + ray_start * math::mip(&ray_start, &(ray_end - ray_start))),
+            ),
+        );
+
+        let tanh_distance = (-math::mip(&ray_start, &ray_end)).acosh();
+
+        wrapped_fn(&ray, tanh_distance)
+    }
+
+    fn chunk_sphere_cast_wrapper(
+        ctx: &TestSphereCastContext,
+        ray: &Ray,
+        tanh_distance: f32,
+    ) -> Option<ChunkCastHit> {
+        chunk_sphere_cast(
+            ctx.collider_radius,
+            &ctx.voxel_data,
+            &ctx.layout,
+            ray,
+            tanh_distance,
+        )
+    }
+
+    fn find_face_collision_wrapper(
+        ctx: &TestSphereCastContext,
+        ray: &Ray,
+        t_axis: usize,
+        tanh_distance: f32,
+    ) -> Option<ChunkCastHit> {
+        find_face_collision(
+            ctx.collider_radius,
+            &ctx.voxel_data,
+            &ctx.layout,
+            &VoxelAABB::from_ray_segment_and_radius(
+                &ctx.layout,
+                ray,
+                tanh_distance,
+                ctx.collider_radius,
+            )
+            .unwrap(),
+            t_axis,
+            ray,
+            tanh_distance,
+        )
+    }
+
+    fn find_edge_collision_wrapper(
+        ctx: &TestSphereCastContext,
+        ray: &Ray,
+        t_axis: usize,
+        tanh_distance: f32,
+    ) -> Option<ChunkCastHit> {
+        find_edge_collision(
+            ctx.collider_radius,
+            &ctx.voxel_data,
+            &ctx.layout,
+            &VoxelAABB::from_ray_segment_and_radius(
+                &ctx.layout,
+                ray,
+                tanh_distance,
+                ctx.collider_radius,
+            )
+            .unwrap(),
+            t_axis,
+            ray,
+            tanh_distance,
+        )
+    }
+
+    fn find_vertex_collision_wrapper(
+        ctx: &TestSphereCastContext,
+        ray: &Ray,
+        tanh_distance: f32,
+    ) -> Option<ChunkCastHit> {
+        find_vertex_collision(
+            ctx.collider_radius,
+            &ctx.voxel_data,
+            &ctx.layout,
+            &VoxelAABB::from_ray_segment_and_radius(
+                &ctx.layout,
+                ray,
+                tanh_distance,
+                ctx.collider_radius,
+            )
+            .unwrap(),
+            ray,
+            tanh_distance,
+        )
+    }
+
+    fn test_face_collision(
+        ctx: &TestSphereCastContext,
+        ray: &Ray,
+        t_axis: usize,
+        tanh_distance: f32,
+    ) {
+        let hit = chunk_sphere_cast_wrapper(ctx, ray, tanh_distance);
+        assert_hits_exist_and_eq(
+            &hit,
+            &find_face_collision_wrapper(ctx, ray, t_axis, tanh_distance),
+        );
+        sanity_check_normal(ray, &hit.unwrap());
+    }
+
+    fn test_edge_collision(
+        ctx: &TestSphereCastContext,
+        ray: &Ray,
+        t_axis: usize,
+        tanh_distance: f32,
+    ) {
+        let hit = chunk_sphere_cast_wrapper(ctx, ray, tanh_distance);
+        assert_hits_exist_and_eq(
+            &hit,
+            &find_edge_collision_wrapper(ctx, ray, t_axis, tanh_distance),
+        );
+        sanity_check_normal(ray, &hit.unwrap());
+    }
+
+    fn test_vertex_collision(ctx: &TestSphereCastContext, ray: &Ray, tanh_distance: f32) {
+        let hit = chunk_sphere_cast_wrapper(ctx, ray, tanh_distance);
+        assert_hits_exist_and_eq(
+            &hit,
+            &find_vertex_collision_wrapper(ctx, ray, tanh_distance),
+        );
+        sanity_check_normal(ray, &hit.unwrap());
+    }
+
+    /// Check that the two hits exist and are equal to each other. Useful for ensuring that
+    /// a particular intersection type is detected by the general `chunk_sphere_cast` method.
+    fn assert_hits_exist_and_eq(hit0: &Option<ChunkCastHit>, hit1: &Option<ChunkCastHit>) {
+        assert!(hit0.is_some());
+        assert!(hit1.is_some());
+        assert_eq!(
+            hit0.as_ref().unwrap().tanh_distance,
+            hit1.as_ref().unwrap().tanh_distance
+        );
+        assert_eq!(hit0.as_ref().unwrap().normal, hit1.as_ref().unwrap().normal);
+    }
+
+    /// Ensures that the normal is pointing outward, opposite the ray direction.
+    fn sanity_check_normal(ray: &Ray, hit: &ChunkCastHit) {
+        // The ray we care about is after its start point has moved to the contact point.
+        let ray = math::translate(
+            &ray.position,
+            &math::lorentz_normalize(&ray.ray_point(hit.tanh_distance)),
+        ) * ray;
+
+        // Project normal to be perpendicular to the ray's position
+        let corrected_normal = math::lorentz_normalize(
+            &(hit.normal + ray.position * math::mip(&hit.normal, &ray.position)),
+        );
+
+        // Check that the normal and ray are pointing opposite directions
+        assert!(math::mip(&corrected_normal, &ray.direction) < 0.0);
+    }
+
+    /// Tests that a suitable collision is found when approaching a single voxel from various angles and that
+    /// no collision is found in paths that don't reach that voxel.
+    #[test]
+    fn chunk_sphere_cast_examples() {
+        let collider_radius = 0.02;
+        let ctx = TestSphereCastContext::new(collider_radius);
+
+        // Approach a single voxel from various angles. Ensure that a suitable collision is found each time.
+        // Note: The voxel is centered at (1.5, 1.5, 1.5) in the grid coordinates used in this test.
+
+        // Face collisions
+        cast_with_test_ray(
+            &ctx,
+            [0.0, 1.5, 1.5],
+            [1.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                test_face_collision(&ctx, ray, 0, tanh_distance);
+            },
+        );
+
+        cast_with_test_ray(
+            &ctx,
+            [1.5, 1.5, 3.0],
+            [1.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                test_face_collision(&ctx, ray, 2, tanh_distance);
+            },
+        );
+
+        // Edge collisions
+        cast_with_test_ray(
+            &ctx,
+            [1.5, 3.0, 0.0],
+            [1.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                test_edge_collision(&ctx, ray, 0, tanh_distance);
+            },
+        );
+
+        cast_with_test_ray(
+            &ctx,
+            [3.0, 1.5, 3.0],
+            [1.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                test_edge_collision(&ctx, ray, 1, tanh_distance);
+            },
+        );
+
+        // Vertex collisions
+        cast_with_test_ray(
+            &ctx,
+            [0.0, 0.0, 0.0],
+            [1.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                test_vertex_collision(&ctx, ray, tanh_distance);
+            },
+        );
+
+        cast_with_test_ray(
+            &ctx,
+            [3.0, 3.0, 0.0],
+            [1.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                test_vertex_collision(&ctx, ray, tanh_distance);
+            },
+        );
+
+        // No collision: Going sideways relative to a face
+        cast_with_test_ray(
+            &ctx,
+            [3.0, 1.5, 1.5],
+            [3.0, 3.0, 1.5],
+            |ray, tanh_distance| {
+                assert!(chunk_sphere_cast_wrapper(&ctx, ray, tanh_distance).is_none());
+            },
+        );
+
+        // No collision: Going away from a face
+        cast_with_test_ray(
+            &ctx,
+            [3.0, 1.5, 1.5],
+            [4.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                assert!(chunk_sphere_cast_wrapper(&ctx, ray, tanh_distance).is_none());
+            },
+        );
+
+        // No collision: Past cast endpoint
+        cast_with_test_ray(
+            &ctx,
+            [8.0, 1.5, 1.5],
+            [3.0, 1.5, 1.5],
+            |ray, tanh_distance| {
+                assert!(chunk_sphere_cast_wrapper(&ctx, ray, tanh_distance).is_none());
+            },
+        );
+    }
+
+    /// Tests that colliding with a face from the back side is impossible. Note that colliding
+    /// with the back side of an edge or vertex is still possible. Getting rid of these collisions
+    /// is a possible future enhancement.
+    #[test]
+    fn face_collisions_one_sided() {
+        let collider_radius = 0.01;
+        let ctx = TestSphereCastContext::new(collider_radius);
+
+        cast_with_test_ray(
+            &ctx,
+            [1.5, 1.5, 1.5],
+            [4.5, 1.5, 1.5],
+            |ray, tanh_distance| {
+                assert!(chunk_sphere_cast_wrapper(&ctx, ray, tanh_distance).is_none());
+            },
+        )
+    }
+
+    #[test]
+    fn solve_sphere_plane_intersection_example() {
+        // Hit the z=0 plane with a radius of 0.2
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::new(0.8, 0.0, 0.6, 0.0));
+        let normal = -na::Vector4::z();
+        let hit_point = math::lorentz_normalize(
+            &ray.ray_point(solve_sphere_plane_intersection(&ray, &normal, 0.2_f32.sinh()).unwrap()),
+        );
+        assert_abs_diff_eq!(
+            math::mip(&hit_point, &normal),
+            0.2_f32.sinh(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn solve_sphere_plane_intersection_direct_hit() {
+        // Directly hit the z=0 plane with a ray 0.5 units away and a radius of 0.2.
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::z());
+        let normal = -na::Vector4::z();
+        assert_abs_diff_eq!(
+            solve_sphere_plane_intersection(&ray, &normal, 0.2_f32.sinh()).unwrap(),
+            0.3_f32.tanh(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn solve_sphere_plane_intersection_miss() {
+        // No collision with the plane anywhere along the ray's line
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::x());
+        let normal = -na::Vector4::z();
+        assert!(solve_sphere_plane_intersection(&ray, &normal, 0.2_f32.sinh()).is_none());
+    }
+
+    #[test]
+    fn solve_sphere_plane_intersection_margin() {
+        // Sphere is already contacting the plane, with some error
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.2))
+            * &Ray::new(math::origin(), na::Vector4::z());
+        let normal = -na::Vector4::z();
+        assert_eq!(
+            solve_sphere_plane_intersection(&ray, &normal, 0.2001_f32.sinh()).unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn solve_sphere_line_intersection_example() {
+        // Hit the x=z=0 line with a radius of 0.2
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(
+                math::origin(),
+                na::Vector4::new(1.0, 2.0, 3.0, 0.0).normalize(),
+            );
+        let line_position = na::Vector4::w();
+        let line_direction = na::Vector4::y();
+        let hit_point = math::lorentz_normalize(
+            &ray.ray_point(
+                solve_sphere_line_intersection(
+                    &ray,
+                    &line_position,
+                    &line_direction,
+                    0.2_f32.cosh(),
+                )
+                .unwrap(),
+            ),
+        );
+        // Measue the distance from hit_point to the line and ensure it's equal to the radius
+        assert_abs_diff_eq!(
+            (math::mip(&hit_point, &line_position).powi(2)
+                - math::mip(&hit_point, &line_direction).powi(2))
+            .sqrt(),
+            0.2_f32.cosh(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn solve_sphere_line_intersection_direct_hit() {
+        // Directly hit the x=z=0 line with a ray 0.5 units away and a radius of 0.2.
+
+        // Ensure the ray is slightly off-center so that the distance math is shown to be correct
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.7, 0.0))
+            * math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::z());
+        let line_position = na::Vector4::w();
+        let line_direction = na::Vector4::y();
+        assert_abs_diff_eq!(
+            solve_sphere_line_intersection(&ray, &line_position, &line_direction, 0.2_f32.cosh())
+                .unwrap(),
+            0.3_f32.tanh(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn solve_sphere_line_intersection_miss() {
+        // No collision with the line anywhere along the ray's line
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::x());
+        let line_position = na::Vector4::w();
+        let line_direction = na::Vector4::y();
+        assert!(solve_sphere_line_intersection(
+            &ray,
+            &line_position,
+            &line_direction,
+            0.2_f32.cosh()
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn solve_sphere_line_intersection_margin() {
+        // Sphere is already contacting the line, with some error
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.2))
+            * &Ray::new(math::origin(), na::Vector4::z());
+        let line_position = na::Vector4::w();
+        let line_direction = na::Vector4::y();
+        assert_eq!(
+            solve_sphere_line_intersection(
+                &ray,
+                &line_position,
+                &line_direction,
+                0.2001_f32.cosh()
+            )
+            .unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn solve_sphere_point_intersection_example() {
+        // Hit the origin with a radius of 0.2
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(
+                math::origin(),
+                na::Vector4::new(1.0, 2.0, 6.0, 0.0).normalize(),
+            );
+        let point_position = math::origin();
+        let hit_point = math::lorentz_normalize(&ray.ray_point(
+            solve_sphere_point_intersection(&ray, &point_position, 0.2_f32.cosh()).unwrap(),
+        ));
+        assert_abs_diff_eq!(
+            -math::mip(&hit_point, &point_position),
+            0.2_f32.cosh(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn solve_sphere_point_intersection_direct_hit() {
+        // Directly hit the origin with a ray 0.5 units away and a radius of 0.2.
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::z());
+        let point_position = math::origin();
+        assert_abs_diff_eq!(
+            solve_sphere_point_intersection(&ray, &point_position, 0.2_f32.cosh()).unwrap(),
+            0.3_f32.tanh(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn solve_sphere_point_intersection_miss() {
+        // No collision with the point anywhere along the ray's line
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+            * &Ray::new(math::origin(), na::Vector4::x());
+        let point_position = math::origin();
+        assert!(solve_sphere_point_intersection(&ray, &point_position, 0.2_f32.cosh()).is_none());
+    }
+
+    #[test]
+    fn solve_sphere_point_intersection_margin() {
+        // Sphere is already contacting the point, with some error
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.2))
+            * &Ray::new(math::origin(), na::Vector4::z());
+        let point_position = math::origin();
+        assert_eq!(
+            solve_sphere_point_intersection(&ray, &point_position, 0.2001_f32.cosh()).unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn solve_quadratic_example() {
+        let a = 1.0;
+        let b = -2.0;
+        let c = 0.2;
+        let x = solve_quadratic(c, b / 2.0, a).unwrap();
+
+        // x should be a solution
+        assert_abs_diff_eq!(a * x * x + b * x + c, 0.0, epsilon = 1e-4);
+
+        // x should be the smallest solution, less than the parabola's vertex.
+        assert!(x < -b / (2.0 * a));
+    }
+
+    #[test]
+    fn tuv_to_xyz_example() {
+        assert_eq!(tuv_to_xyz(0, [2, 4, 6]), [2, 4, 6]);
+        assert_eq!(tuv_to_xyz(1, [2, 4, 6]), [6, 2, 4]);
+        assert_eq!(tuv_to_xyz(2, [2, 4, 6]), [4, 6, 2]);
+
+        assert_eq!(tuv_to_xyz(1, [2, 4, 6, 8]), [6, 2, 4, 8]);
+    }
+
+    /// Any voxel AABB should at least cover a capsule-shaped region consisting of all points
+    /// `radius` units away from the ray's line segment. This region consists of two spheres
+    /// and a cylinder. We only test planes because covered lines and points are a strict subset.
+    #[test]
+    fn voxel_aabb_coverage() {
+        let dimension = 12;
+        let layout = ChunkLayout::new(dimension);
+
+        // Pick an arbitrary ray by transforming the positive-x-axis ray.
+        let ray = na::Rotation3::from_axis_angle(&na::Vector3::z_axis(), 0.4).to_homogeneous()
+            * math::translate_along(&na::Vector3::new(0.2, 0.3, 0.1))
+            * &Ray::new(na::Vector4::w(), na::Vector4::x());
+
+        let tanh_distance = 0.2;
+        let radius = 0.1;
+
+        // We want to test that the whole capsule-shaped region around the ray segment is covered by
+        // the AABB. However, the math to test for this is complicated, so we instead check a bunch of
+        // spheres along this ray segment.
+        let num_ray_test_points = 20;
+        let ray_test_points: Vec<_> = (0..num_ray_test_points)
+            .map(|i| {
+                math::lorentz_normalize(
+                    &ray.ray_point(tanh_distance * (i as f32 / (num_ray_test_points - 1) as f32)),
+                )
+            })
+            .collect();
+
+        let aabb =
+            VoxelAABB::from_ray_segment_and_radius(&layout, &ray, tanh_distance, radius).unwrap();
+
+        // For variable names and further comments, we use a tuv coordinate system, which
+        // is a permuted xyz coordinate system.
+
+        // Test planes in all 3 axes.
+        for t_axis in 0..3 {
+            let covered_planes: HashSet<_> = aabb.grid_planes(t_axis).collect();
+
+            // Check that all uv-aligned planes that should be covered are covered
+            for t in 0..=dimension {
+                if covered_planes.contains(&t) {
+                    continue;
+                }
+
+                let mut plane_normal = na::Vector4::zeros();
+                plane_normal[t_axis] = 1.0;
+                plane_normal[3] = layout.grid_to_dual(t);
+                let plane_normal = math::lorentz_normalize(&plane_normal);
+
+                for test_point in &ray_test_points {
+                    assert!(
+                        math::mip(test_point, &plane_normal).abs() > radius.sinh(),
+                        "Plane not covered: t_axis={t_axis}, t={t}, test_point={test_point:?}",
+                    );
+                }
+            }
+        }
+
+        // Test lines in all 3 axes
+        for t_axis in 0..3 {
+            let u_axis = (t_axis + 1) % 3;
+            let v_axis = (u_axis + 1) % 3;
+            let covered_lines: HashSet<_> = aabb.grid_lines(u_axis, v_axis).collect();
+
+            // For a given axis, all lines have the same direction, so set up the appropriate vector
+            // in advance.
+            let mut line_direction = na::Vector4::zeros();
+            line_direction[t_axis] = 1.0;
+            let line_direction = line_direction;
+
+            // Check that all t-aligned lines that should be covered are covered
+            for u in 0..=dimension {
+                for v in 0..=dimension {
+                    if covered_lines.contains(&(u, v)) {
+                        continue;
+                    }
+
+                    let mut line_position = na::Vector4::zeros();
+                    line_position[u_axis] = layout.grid_to_dual(u);
+                    line_position[v_axis] = layout.grid_to_dual(v);
+                    line_position[3] = 1.0;
+                    let line_position = math::lorentz_normalize(&line_position);
+
+                    for test_point in &ray_test_points {
+                        assert!(
+                            (math::mip(test_point, &line_position).powi(2)
+                                - math::mip(test_point, &line_direction).powi(2))
+                            .sqrt()
+                                > radius.cosh(),
+                            "Line not covered: t_axis={t_axis}, u={u}, v={v}, test_point={test_point:?}",
+                        );
+                    }
+                }
+            }
+        }
+
+        // Test points
+        let covered_points: HashSet<_> = aabb.grid_points(0, 1, 2).collect();
+
+        // Check that all points that should be covered are covered
+        for x in 0..=dimension {
+            for y in 0..=dimension {
+                for z in 0..=dimension {
+                    if covered_points.contains(&(x, y, z)) {
+                        continue;
+                    }
+
+                    let point_position = math::lorentz_normalize(&na::Vector4::new(
+                        layout.grid_to_dual(x),
+                        layout.grid_to_dual(y),
+                        layout.grid_to_dual(z),
+                        1.0,
+                    ));
+
+                    for test_point in &ray_test_points {
+                        assert!(
+                            -math::mip(test_point, &point_position) > radius.cosh(),
+                            "Point not covered: x={x}, y={y}, z={z}, test_point={test_point:?}",
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/common/src/cursor.rs
+++ b/common/src/cursor.rs
@@ -1,5 +1,6 @@
 use crate::dodeca::{Side, Vertex, SIDE_COUNT};
 use crate::graph::{Graph, NodeId};
+use crate::node::ChunkId;
 
 use lazy_static::lazy_static;
 
@@ -49,11 +50,11 @@ impl Cursor {
     }
 
     /// Node and dodecahedral vertex that contains the representation for this cube in the graph
-    pub fn canonicalize<N>(self, graph: &Graph<N>) -> Option<(NodeId, Vertex)> {
-        graph.canonicalize(
+    pub fn canonicalize<N>(self, graph: &Graph<N>) -> Option<ChunkId> {
+        graph.canonicalize(ChunkId::new(
             self.node,
             Vertex::from_sides(self.a, self.b, self.c).unwrap(),
-        )
+        ))
     }
 }
 
@@ -177,7 +178,7 @@ mod tests {
                 .expect("positive");
             assert_eq!(
                 looped.canonicalize(&graph).unwrap(),
-                (NodeId::ROOT, Vertex::A),
+                ChunkId::new(NodeId::ROOT, Vertex::A),
             );
         };
         vcycle(Dir::Left);

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -64,7 +64,7 @@ impl Side {
 }
 
 /// Vertices of a right dodecahedron
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Vertex {
     A,
     B,

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -7,8 +7,9 @@ use std::num::NonZeroU32;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dodeca::{Side, Vertex, SIDE_COUNT},
+    dodeca::{Side, SIDE_COUNT},
     math,
+    node::ChunkId,
 };
 
 /// Graph of the right dodecahedral tiling of H^3
@@ -54,16 +55,16 @@ impl<N> Graph<N> {
     /// Each cube is said to be canonically assigned to the shortest of the nodes it touches.
     ///
     /// A node's length is defined as a its distance from the root node.
-    pub fn canonicalize(&self, mut node: NodeId, vertex: Vertex) -> Option<(NodeId, Vertex)> {
-        for side in vertex.canonical_sides().iter().cloned() {
+    pub fn canonicalize(&self, mut chunk: ChunkId) -> Option<ChunkId> {
+        for side in chunk.vertex.canonical_sides().iter().cloned() {
             // missing neighbors are always longer
-            if let Some(neighbor) = self.neighbor(node, side) {
-                if self.length(neighbor) < self.length(node) {
-                    node = neighbor;
+            if let Some(neighbor) = self.neighbor(chunk.node, side) {
+                if self.length(neighbor) < self.length(chunk.node) {
+                    chunk.node = neighbor;
                 }
             }
         }
-        Some((node, vertex))
+        Some(chunk)
     }
 
     /// Returns all of the sides between the provided node and its shorter neighbors.

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -1,0 +1,108 @@
+use crate::{math, proto::Position};
+
+/// Performs ray casting against a fixed plane.
+///
+/// This is a temporary implementation, as it is designed to perfrom sphere casting (swept collision query) against
+/// the voxels in a `DualGraph` when it is ready for use.
+///
+/// The `ray` parameter and any resulting hit normals are given in the local coordinate system of `position`.
+///
+/// The `tanh_distance` is the hyperbolic tangent of the cast_distance, or the distance along the ray to check for hits.
+pub fn sphere_cast(position: &Position, ray: &Ray, tanh_distance: f32) -> Option<GraphCastHit> {
+    let node_ray = position.local * ray;
+
+    // As a temporary placeholder implementation, check for collision against the z=0 plane going in the -z direction.
+
+    const EPSILON: f32 = 1e-4;
+    let normal = math::mtranspose(&position.local) * na::Vector4::z();
+    if node_ray.direction.z >= 0.0 {
+        // Going the wrong way. Don't report a collision.
+        None
+    } else if (-EPSILON..=0.0).contains(&node_ray.position.z) {
+        // Extra logic to ensure precision issues don't allow a collider to clip through a surface
+        Some(GraphCastHit {
+            tanh_distance: 0.0,
+            normal,
+        })
+    } else {
+        // Compute needed tanh_distance to reach z=0 plane.
+        let new_tanh_distance = -node_ray.position.z / node_ray.direction.z;
+        if new_tanh_distance >= 0.0 && new_tanh_distance < tanh_distance {
+            // Report a collision if the needed tanh_distance is in the right range
+            Some(GraphCastHit {
+                tanh_distance: new_tanh_distance,
+                normal,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Information about the intersection at the end of a ray segment.
+#[derive(Debug)]
+pub struct GraphCastHit {
+    /// The tanh of the distance traveled along the ray to result in this hit.
+    pub tanh_distance: f32,
+
+    /// Represents the normal vector of the hit surface in the original coordinate system
+    /// of the sphere casting. To get the actual normal vector, project it so that it is orthogonal
+    /// to the endpoint in Lorentz space.
+    pub normal: na::Vector4<f32>,
+}
+
+/// A ray in hyperbolic space. The fields must be lorentz normalized, with `mip(position, position) == -1`,
+/// `mip(direction, direction) == 1`, and `mip(position, direction) == 0`.
+#[derive(Debug)]
+pub struct Ray {
+    pub position: na::Vector4<f32>,
+    pub direction: na::Vector4<f32>,
+}
+
+impl Ray {
+    pub fn new(position: na::Vector4<f32>, direction: na::Vector4<f32>) -> Ray {
+        Ray {
+            position,
+            direction,
+        }
+    }
+
+    /// Returns a point along this ray `atanh(tanh_distance)` units away from the origin. This point
+    /// is _not_ lorentz normalized.
+    pub fn ray_point(&self, tanh_distance: f32) -> na::Vector4<f32> {
+        self.position + self.direction * tanh_distance
+    }
+}
+
+impl std::ops::Mul<&Ray> for na::Matrix4<f32> {
+    type Output = Ray;
+
+    #[inline]
+    fn mul(self, rhs: &Ray) -> Self::Output {
+        Ray {
+            position: self * rhs.position,
+            direction: self * rhs.direction,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_abs_diff_eq;
+
+    use super::*;
+
+    #[test]
+    fn temp_shape_cast_example() {
+        // Directly hit the z=0 plane with a ray 0.5 units away.
+        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, 0.5))
+            * &Ray::new(math::origin(), -na::Vector4::z());
+        assert_abs_diff_eq!(
+            sphere_cast(&Position::origin(), &ray, 0.9)
+                .unwrap()
+                .tanh_distance,
+            0.5_f32.tanh(),
+            epsilon = 1e-4
+        );
+    }
+}

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -1,42 +1,50 @@
-use crate::{math, proto::Position};
+use crate::{
+    chunk_collision::chunk_sphere_cast,
+    dodeca::Vertex,
+    math,
+    node::{Chunk, ChunkId, ChunkLayout, DualGraph},
+    proto::Position,
+};
 
-/// Performs ray casting against a fixed plane.
-///
-/// This is a temporary implementation, as it is designed to perfrom sphere casting (swept collision query) against
-/// the voxels in a `DualGraph` when it is ready for use.
+/// Performs sphere casting (swept collision query) against the voxels in the `DualGraph`
 ///
 /// The `ray` parameter and any resulting hit normals are given in the local coordinate system of `position`.
 ///
 /// The `tanh_distance` is the hyperbolic tangent of the cast_distance, or the distance along the ray to check for hits.
-pub fn sphere_cast(position: &Position, ray: &Ray, tanh_distance: f32) -> Option<GraphCastHit> {
-    let node_ray = position.local * ray;
+///
+/// This implementaion is incomplete, and it will only detect intersection with voxels in the "A" chunk of the position's node.
+pub fn sphere_cast(
+    collider_radius: f32,
+    graph: &DualGraph,
+    layout: &ChunkLayout,
+    position: &Position,
+    ray: &Ray,
+    tanh_distance: f32,
+) -> Option<GraphCastHit> {
+    let chunk = ChunkId::new(position.node, Vertex::A);
+    let node_transform = position.local;
+    let Chunk::Populated {
+            voxels: ref voxel_data,
+            ..
+        } = graph[chunk] else {
+            // Collision checking on unpopulated chunk
+            panic!("Collision checking on unpopulated chunk");
+        };
+    let local_ray = chunk.vertex.node_to_dual().cast::<f32>() * node_transform * ray;
 
-    // As a temporary placeholder implementation, check for collision against the z=0 plane going in the -z direction.
-
-    const EPSILON: f32 = 1e-4;
-    let normal = math::mtranspose(&position.local) * na::Vector4::z();
-    if node_ray.direction.z >= 0.0 {
-        // Going the wrong way. Don't report a collision.
-        None
-    } else if (-EPSILON..=0.0).contains(&node_ray.position.z) {
-        // Extra logic to ensure precision issues don't allow a collider to clip through a surface
-        Some(GraphCastHit {
-            tanh_distance: 0.0,
-            normal,
-        })
-    } else {
-        // Compute needed tanh_distance to reach z=0 plane.
-        let new_tanh_distance = -node_ray.position.z / node_ray.direction.z;
-        if new_tanh_distance >= 0.0 && new_tanh_distance < tanh_distance {
-            // Report a collision if the needed tanh_distance is in the right range
-            Some(GraphCastHit {
-                tanh_distance: new_tanh_distance,
-                normal,
-            })
-        } else {
-            None
-        }
-    }
+    // Check collision within a single chunk
+    chunk_sphere_cast(
+        collider_radius,
+        voxel_data,
+        layout,
+        &local_ray,
+        tanh_distance,
+    )
+    .map(|hit| GraphCastHit {
+        tanh_distance: hit.tanh_distance,
+        chunk,
+        normal: math::mtranspose(&node_transform) * chunk.vertex.dual_to_node().cast() * hit.normal,
+    })
 }
 
 /// Information about the intersection at the end of a ray segment.
@@ -44,6 +52,9 @@ pub fn sphere_cast(position: &Position, ray: &Ray, tanh_distance: f32) -> Option
 pub struct GraphCastHit {
     /// The tanh of the distance traveled along the ray to result in this hit.
     pub tanh_distance: f32,
+
+    /// Which chunk in the graph the hit occurred in
+    pub chunk: ChunkId,
 
     /// Represents the normal vector of the hit surface in the original coordinate system
     /// of the sphere casting. To get the actual normal vector, project it so that it is orthogonal
@@ -83,26 +94,5 @@ impl std::ops::Mul<&Ray> for na::Matrix4<f32> {
             position: self * rhs.position,
             direction: self * rhs.direction,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use approx::assert_abs_diff_eq;
-
-    use super::*;
-
-    #[test]
-    fn temp_shape_cast_example() {
-        // Directly hit the z=0 plane with a ray 0.5 units away.
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, 0.5))
-            * &Ray::new(math::origin(), -na::Vector4::z());
-        assert_abs_diff_eq!(
-            sphere_cast(&Position::origin(), &ray, 0.9)
-                .unwrap()
-                .tanh_distance,
-            0.5_f32.tanh(),
-            epsilon = 1e-4
-        );
     }
 }

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -1,6 +1,10 @@
+use std::collections::VecDeque;
+
+use fxhash::FxHashSet;
+
 use crate::{
     chunk_collision::chunk_sphere_cast,
-    dodeca::Vertex,
+    dodeca::{self, Vertex},
     math,
     node::{Chunk, ChunkId, ChunkLayout, DualGraph},
     proto::Position,
@@ -12,7 +16,9 @@ use crate::{
 ///
 /// The `tanh_distance` is the hyperbolic tangent of the cast_distance, or the distance along the ray to check for hits.
 ///
-/// This implementaion is incomplete, and it will only detect intersection with voxels in the "A" chunk of the position's node.
+/// This function may return a `SphereCastError` if not enough chunks are generated, even if the ray never reaches an
+/// ungenerated chunk. To prevent these errors, make sure that the distance between the ray's start point and the center of
+/// the closest node with ungenerated chunks is greater than `cast_distance + collider_radius + dodeca::BOUNDING_SPHERE_RADIUS`
 pub fn sphere_cast(
     collider_radius: f32,
     graph: &DualGraph,
@@ -20,31 +26,112 @@ pub fn sphere_cast(
     position: &Position,
     ray: &Ray,
     tanh_distance: f32,
-) -> Option<GraphCastHit> {
-    let chunk = ChunkId::new(position.node, Vertex::A);
-    let node_transform = position.local;
-    let Chunk::Populated {
-            voxels: ref voxel_data,
-            ..
-        } = graph[chunk] else {
-            // Collision checking on unpopulated chunk
-            panic!("Collision checking on unpopulated chunk");
-        };
-    let local_ray = chunk.vertex.node_to_dual().cast::<f32>() * node_transform * ray;
+) -> Result<Option<GraphCastHit>, SphereCastError> {
+    // A collision check is assumed to be a miss until a collision is found.
+    // This `hit` variable gets updated over time before being returned.
+    let mut hit: Option<GraphCastHit> = None;
 
-    // Check collision within a single chunk
-    chunk_sphere_cast(
-        collider_radius,
-        voxel_data,
-        layout,
-        &local_ray,
-        tanh_distance,
-    )
-    .map(|hit| GraphCastHit {
-        tanh_distance: hit.tanh_distance,
-        chunk,
-        normal: math::mtranspose(&node_transform) * chunk.vertex.dual_to_node().cast() * hit.normal,
-    })
+    // Start a breadth-first search of the graph's chunks, performing collision checks in each relevant chunk.
+    // The `chunk_queue` contains ordered pairs containing the `ChunkId` and the transformation needed to switch
+    // from the original node coordinates to the current chunk's node coordinates.
+    let mut visited_chunks = FxHashSet::<ChunkId>::default();
+    let mut chunk_queue: VecDeque<(ChunkId, na::Matrix4<f32>)> = VecDeque::new();
+    chunk_queue.push_back((ChunkId::new(position.node, Vertex::A), position.local));
+
+    // Precalculate the chunk boundaries for collision purposes. If the collider goes outside these bounds,
+    // the corresponding neighboring chunk will also be used for collision checking.
+    let klein_lower_boundary = collider_radius.tanh();
+    let klein_upper_boundary =
+        ((Vertex::chunk_to_dual_factor() as f32).atanh() - collider_radius).tanh();
+
+    // Breadth-first search loop
+    while let Some((chunk, node_transform)) = chunk_queue.pop_front() {
+        let Chunk::Populated {
+                voxels: ref voxel_data,
+                ..
+            } = graph[chunk] else {
+                // Collision checking on unpopulated chunk
+                return Err(SphereCastError::OutOfBounds);
+            };
+        let local_ray = chunk.vertex.node_to_dual().cast::<f32>() * node_transform * ray;
+
+        // Check collision within a single chunk
+        let current_tanh_distance = hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance);
+        hit = chunk_sphere_cast(
+            collider_radius,
+            voxel_data,
+            layout,
+            &local_ray,
+            current_tanh_distance,
+        )
+        .map_or(hit, |hit| {
+            Some(GraphCastHit {
+                tanh_distance: hit.tanh_distance,
+                chunk,
+                normal: math::mtranspose(&node_transform)
+                    * chunk.vertex.dual_to_node().cast()
+                    * hit.normal,
+            })
+        });
+
+        // Compute the Klein-Beltrami coordinates of the ray segment's endpoints. To check whether neighboring chunks
+        // are needed, we need to check whether the endpoints of the line segments lie outside the boundaries of the square
+        // bounded by `klein_lower_boundary` and `klein_upper_boundary`.
+        let klein_ray_start = na::Point3::from_homogeneous(local_ray.position).unwrap();
+        let klein_ray_end =
+            na::Point3::from_homogeneous(local_ray.ray_point(current_tanh_distance)).unwrap();
+
+        // Add neighboring chunks as necessary based on a conservative AABB check, using one coordinate at a time.
+        for axis in 0..3 {
+            // Check for neighboring nodes
+            if klein_ray_start[axis] <= klein_lower_boundary
+                || klein_ray_end[axis] <= klein_lower_boundary
+            {
+                let side = chunk.vertex.canonical_sides()[axis];
+                let next_node_transform = side.reflection().cast::<f32>() * node_transform;
+                // Crude check to ensure that the neighboring chunk's node can be in the path of the ray. For simplicity, this
+                // check treats each node as a sphere and assumes the ray is pointed directly towards its center. The check is
+                // needed because chunk generation uses this approximation, and this check is not guaranteed to pass near corners
+                // because the AABB check can have false positives.
+                let ray_node_distance = (next_node_transform * ray.position).w.acosh();
+                let ray_length = current_tanh_distance.atanh();
+                if ray_node_distance - ray_length - collider_radius
+                    > dodeca::BOUNDING_SPHERE_RADIUS as f32
+                {
+                    // Ray cannot intersect node
+                    continue;
+                }
+                // If we have to do collision checking on nodes that don't exist in the graph, we cannot have a conclusive result.
+                let Some(neighbor) = graph.neighbor(chunk.node, side) else {
+                    // Collision checking on nonexistent node
+                    return Err(SphereCastError::OutOfBounds);
+                };
+                // Assuming everything goes well, add the new chunk to the queue.
+                let next_chunk = ChunkId::new(neighbor, chunk.vertex);
+                if visited_chunks.insert(next_chunk) {
+                    chunk_queue.push_back((next_chunk, next_node_transform));
+                }
+            }
+
+            // Check for neighboring chunks within the same node
+            if klein_ray_start[axis] >= klein_upper_boundary
+                || klein_ray_end[axis] >= klein_upper_boundary
+            {
+                let vertex = chunk.vertex.adjacent_vertices()[axis];
+                let next_chunk = ChunkId::new(chunk.node, vertex);
+                if visited_chunks.insert(next_chunk) {
+                    chunk_queue.push_back((next_chunk, node_transform));
+                }
+            }
+        }
+    }
+
+    Ok(hit)
+}
+
+#[derive(Debug)]
+pub enum SphereCastError {
+    OutOfBounds,
 }
 
 /// Information about the intersection at the end of a ray segment.
@@ -94,5 +181,379 @@ impl std::ops::Mul<&Ray> for na::Matrix4<f32> {
             position: self * rhs.position,
             direction: self * rhs.direction,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        dodeca::{Side, Vertex},
+        graph::NodeId,
+        node::{populate_fresh_nodes, VoxelData},
+        proto::Position,
+        traversal::{ensure_nearby, nearby_nodes},
+        world::Material,
+    };
+
+    use super::*;
+
+    /// Convenience struct used to locate a particular voxel that should be solid in a test case.
+    struct VoxelLocation<'a> {
+        /// Path from the origin node to the voxel
+        node_path: &'a [Side],
+
+        /// Which chunk in the given node the voxel is in
+        vertex: Vertex,
+
+        /// The coordinates of the voxel, including margins
+        coords: [usize; 3],
+    }
+
+    impl VoxelLocation<'_> {
+        fn new(node_path: &[Side], vertex: Vertex, coords: [usize; 3]) -> VoxelLocation<'_> {
+            VoxelLocation {
+                node_path,
+                vertex,
+                coords,
+            }
+        }
+    }
+
+    struct SphereCastExampleTestCase<'a> {
+        /// Which voxel the test case focuses on. Also determines the coordinate system of the ray.
+        /// Any detected collision is expected to be on this voxel.
+        chosen_voxel: VoxelLocation<'a>,
+
+        /// Which voxels should be solid in the test case
+        additional_populated_voxels: &'a [VoxelLocation<'a>],
+
+        /// Grid coordinates of ray's start position relative to the root's "A" chunk
+        start_chunk_relative_grid_ray_start: [f32; 3],
+
+        /// Grid coordinates of ray's end position relative to chunk given by the chosen node and vertex
+        chosen_chunk_relative_grid_ray_end: [f32; 3],
+
+        /// What to use as the collider radius for shape casting
+        collider_radius: f32,
+
+        /// Amount to increase (or decrease) the ray's length compared to ending it at grid_ray_end
+        ray_length_modifier: f32,
+
+        /// Whether a collision should occur for the test to pass
+        collision_expected: bool,
+    }
+
+    impl SphereCastExampleTestCase<'_> {
+        fn execute(self) {
+            let dimension: usize = 12;
+            let layout = ChunkLayout::new(dimension);
+            let mut graph = DualGraph::new();
+            let graph_radius = 3.0;
+
+            // Set up a graph with void chunks
+            ensure_nearby(&mut graph, &Position::origin(), graph_radius);
+            populate_fresh_nodes(&mut graph);
+            for (node, _) in nearby_nodes(&graph, &Position::origin(), graph_radius) {
+                for vertex in dodeca::Vertex::iter() {
+                    graph[ChunkId::new(node, vertex)] = Chunk::Populated {
+                        voxels: VoxelData::Solid(Material::Void),
+                        surface: None,
+                    };
+                }
+            }
+
+            Self::populate_voxel(&mut graph, dimension, &self.chosen_voxel);
+
+            for voxel in self.additional_populated_voxels {
+                Self::populate_voxel(&mut graph, dimension, voxel);
+            }
+
+            // Find the transform of the chosen chunk
+            let chosen_chunk_transform: na::Matrix4<f32> =
+                self.chosen_voxel.node_path.iter().fold(
+                    na::Matrix4::identity(),
+                    |transform: na::Matrix4<f32>, side| transform * side.reflection().cast::<f32>(),
+                ) * self.chosen_voxel.vertex.dual_to_node().cast();
+
+            let ray_target = chosen_chunk_transform
+                * math::lorentz_normalize(&na::Vector4::new(
+                    self.chosen_chunk_relative_grid_ray_end[0] / layout.dual_to_grid_factor(),
+                    self.chosen_chunk_relative_grid_ray_end[1] / layout.dual_to_grid_factor(),
+                    self.chosen_chunk_relative_grid_ray_end[2] / layout.dual_to_grid_factor(),
+                    1.0,
+                ));
+
+            let ray_position = Vertex::A.dual_to_node().cast()
+                * math::lorentz_normalize(&na::Vector4::new(
+                    self.start_chunk_relative_grid_ray_start[0] / layout.dual_to_grid_factor(),
+                    self.start_chunk_relative_grid_ray_start[1] / layout.dual_to_grid_factor(),
+                    self.start_chunk_relative_grid_ray_start[2] / layout.dual_to_grid_factor(),
+                    1.0,
+                ));
+            let ray_direction = ray_target - ray_position;
+
+            let ray = Ray::new(
+                ray_position,
+                math::lorentz_normalize(
+                    &(ray_direction + ray_position * math::mip(&ray_position, &ray_direction)),
+                ),
+            );
+
+            let tanh_distance = ((-math::mip(&ray_position, &ray_target)).acosh()
+                + self.ray_length_modifier)
+                .tanh();
+
+            let hit = sphere_cast(
+                self.collider_radius,
+                &graph,
+                &layout,
+                &Position::origin(),
+                &ray,
+                tanh_distance,
+            )
+            .expect("conclusive collision result");
+
+            if self.collision_expected {
+                assert!(hit.is_some(), "no collision detected");
+                assert_eq!(
+                    hit.as_ref().unwrap().chunk,
+                    Self::get_voxel_chunk(&graph, &self.chosen_voxel),
+                    "collision occurred in wrong chunk"
+                );
+                assert!(
+                    math::mip(&hit.as_ref().unwrap().normal, &ray.direction) < 0.0,
+                    "normal is facing the wrong way"
+                );
+            } else {
+                assert!(hit.is_none(), "unexpected collision detected");
+            }
+        }
+
+        fn populate_voxel(graph: &mut DualGraph, dimension: usize, voxel_location: &VoxelLocation) {
+            // Find the ChunkId of the given chunk
+            let chunk = ChunkId::new(
+                voxel_location
+                    .node_path
+                    .iter()
+                    .fold(NodeId::ROOT, |node, &side| {
+                        graph.neighbor(node, side).unwrap()
+                    }),
+                voxel_location.vertex,
+            );
+            let Chunk::Populated { voxels: voxel_data, .. } = graph.get_chunk_mut(chunk).unwrap() else {
+                panic!("All chunks should be populated.");
+            };
+
+            // Populate the given voxel with dirt.
+            voxel_data.data_mut(dimension as u8)[voxel_location.coords[0]
+                + voxel_location.coords[1] * (dimension + 2)
+                + voxel_location.coords[2] * (dimension + 2).pow(2)] = Material::Dirt;
+        }
+
+        fn get_voxel_chunk(graph: &DualGraph, voxel_location: &VoxelLocation) -> ChunkId {
+            ChunkId::new(
+                voxel_location
+                    .node_path
+                    .iter()
+                    .fold(NodeId::ROOT, |node, &side| {
+                        graph.neighbor(node, side).unwrap()
+                    }),
+                voxel_location.vertex,
+            )
+        }
+    }
+
+    /// Checks that `sphere_cast` behaves as expected under normal circumstances.
+    #[test]
+    fn sphere_cast_examples() {
+        // Basic test case
+        SphereCastExampleTestCase {
+            chosen_voxel: VoxelLocation::new(&[Side::G], Vertex::I, [3, 4, 6]),
+            additional_populated_voxels: &[],
+            start_chunk_relative_grid_ray_start: [12.0, 12.0, 12.0], // Node center
+            chosen_chunk_relative_grid_ray_end: [2.5, 3.5, 5.5],
+            collider_radius: 0.02,
+            ray_length_modifier: 0.0,
+            collision_expected: true,
+        }
+        .execute();
+
+        // Barely touching a neighboring node
+        SphereCastExampleTestCase {
+            chosen_voxel: VoxelLocation::new(
+                &[Vertex::B.canonical_sides()[0]],
+                Vertex::B,
+                [1, 12, 12],
+            ),
+            additional_populated_voxels: &[],
+            start_chunk_relative_grid_ray_start: [12.0, 12.0, 12.0], // Node center
+            chosen_chunk_relative_grid_ray_end: [0.0, 12.0, 12.0],
+            collider_radius: 0.02,
+            ray_length_modifier: -0.019,
+            collision_expected: true,
+        }
+        .execute();
+
+        // Barely not touching a neighboring node
+        SphereCastExampleTestCase {
+            chosen_voxel: VoxelLocation::new(
+                &[Vertex::B.canonical_sides()[0]],
+                Vertex::B,
+                [1, 12, 12],
+            ),
+            additional_populated_voxels: &[],
+            start_chunk_relative_grid_ray_start: [12.0, 12.0, 12.0], // Node center
+            chosen_chunk_relative_grid_ray_end: [0.0, 12.0, 12.0],
+            collider_radius: 0.02,
+            ray_length_modifier: -0.021,
+            collision_expected: false,
+        }
+        .execute();
+
+        // Barely touching a neighboring vertex
+        {
+            // This test case requires a bit of extra logic because getting the voxel coordinates
+            // adjacent to a voxel in a neighboring chunk requires inspecting the canonical side
+            // order of both vertices.
+            let chosen_vertex = Vertex::A.adjacent_vertices()[0];
+            let corresponding_axis = chosen_vertex
+                .canonical_sides()
+                .iter()
+                .position(|side| !Vertex::A.canonical_sides().contains(side))
+                .unwrap();
+            let mut chosen_voxel_coords = [1, 1, 1];
+            chosen_voxel_coords[corresponding_axis] = 12;
+            let mut grid_ray_end = [0.0, 0.0, 0.0];
+            grid_ray_end[corresponding_axis] = 12.0;
+            SphereCastExampleTestCase {
+                chosen_voxel: VoxelLocation::new(&[], chosen_vertex, chosen_voxel_coords),
+                additional_populated_voxels: &[],
+                start_chunk_relative_grid_ray_start: [0.0, 0.0, 0.0], // Node's A-vertex corner
+                chosen_chunk_relative_grid_ray_end: grid_ray_end,
+                collider_radius: 0.02,
+                ray_length_modifier: -0.019,
+                collision_expected: true,
+            }
+            .execute();
+        }
+
+        // Barely touching a node opposite the original node at a corner
+        SphereCastExampleTestCase {
+            chosen_voxel: VoxelLocation::new(
+                &[
+                    Vertex::D.canonical_sides()[0],
+                    Vertex::D.canonical_sides()[1],
+                    Vertex::D.canonical_sides()[2],
+                ],
+                Vertex::D,
+                [1, 1, 1],
+            ),
+            additional_populated_voxels: &[],
+            start_chunk_relative_grid_ray_start: [12.0, 12.0, 12.0], // Node center
+            chosen_chunk_relative_grid_ray_end: [0.0, 0.0, 0.0],
+            collider_radius: 0.02,
+            ray_length_modifier: -0.019,
+            collision_expected: true,
+        }
+        .execute();
+
+        // Colliding with a neighboring node's voxel before the center node's voxel
+        SphereCastExampleTestCase {
+            chosen_voxel: VoxelLocation::new(
+                &[Vertex::A.canonical_sides()[0]],
+                Vertex::A,
+                [1, 5, 5],
+            ),
+            additional_populated_voxels: &[VoxelLocation::new(&[], Vertex::A, [1, 6, 5])],
+            // Because we use the "A" vertex, the two coordinate systems below coincide for x = 0.0
+            start_chunk_relative_grid_ray_start: [0.0, 3.0, 4.5],
+            chosen_chunk_relative_grid_ray_end: [0.0, 8.0, 4.5],
+            collider_radius: 0.02,
+            ray_length_modifier: 0.0,
+            collision_expected: true,
+        }
+        .execute();
+
+        // Colliding with the center node's voxel before a neighboring node's voxel
+        SphereCastExampleTestCase {
+            chosen_voxel: VoxelLocation::new(&[], Vertex::A, [1, 5, 5]),
+            additional_populated_voxels: &[VoxelLocation::new(
+                &[Vertex::A.canonical_sides()[0]],
+                Vertex::A,
+                [1, 6, 5],
+            )],
+            start_chunk_relative_grid_ray_start: [0.0, 3.0, 4.5],
+            chosen_chunk_relative_grid_ray_end: [0.0, 8.0, 4.5],
+            collider_radius: 0.02,
+            ray_length_modifier: 0.0,
+            collision_expected: true,
+        }
+        .execute();
+    }
+
+    /// Tests that a sphere cast that gets close to the corner of an unloaded chunk does not throw an error as
+    /// long as the contract for sphere_cast is upheld.
+    #[test]
+    fn sphere_cast_near_unloaded_chunk() {
+        let dimension: usize = 12;
+        let layout = ChunkLayout::new(dimension);
+        let mut graph = DualGraph::new();
+
+        let sides = Vertex::A.canonical_sides();
+
+        // Add six nodes surrounding the origin's Vertex::A to total 7 out of 8 nodes.
+        // Only the far corner is missing.
+        let first_neighbors = [
+            graph.ensure_neighbor(NodeId::ROOT, sides[0]),
+            graph.ensure_neighbor(NodeId::ROOT, sides[1]),
+            graph.ensure_neighbor(NodeId::ROOT, sides[2]),
+        ];
+        let second_neighbors = [
+            graph.ensure_neighbor(first_neighbors[0], sides[1]),
+            graph.ensure_neighbor(first_neighbors[1], sides[2]),
+            graph.ensure_neighbor(first_neighbors[2], sides[0]),
+        ];
+
+        // Populate all graph nodes
+        populate_fresh_nodes(&mut graph);
+        for node in [
+            &[NodeId::ROOT],
+            first_neighbors.as_slice(),
+            second_neighbors.as_slice(),
+        ]
+        .concat()
+        {
+            for vertex in dodeca::Vertex::iter() {
+                graph[ChunkId::new(node, vertex)] = Chunk::Populated {
+                    voxels: VoxelData::Solid(Material::Void),
+                    surface: None,
+                };
+            }
+        }
+
+        // The node coordinates of the corner of the missing node
+        let vertex_pos = Vertex::A.dual_to_node().cast::<f32>() * math::origin();
+
+        // Use a ray starting from the origin. The direction vector is vertex_pos with the w coordinate
+        // set to 0 and normalized
+        let ray = Ray::new(
+            math::origin(),
+            (vertex_pos - na::Vector4::w() * vertex_pos.w).normalize(),
+        );
+        let sphere_radius = 0.1;
+
+        // Use a distance slightly less than the maximum possible before an error would occur.
+        let distance = vertex_pos.w.acosh() - sphere_radius - 1e-4;
+
+        let hit = sphere_cast(
+            sphere_radius,
+            &graph,
+            &layout,
+            &Position::origin(),
+            &ray,
+            distance.tanh(),
+        );
+
+        assert!(hit.is_ok());
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,6 +10,7 @@ mod id;
 
 extern crate nalgebra as na;
 pub mod character_controller;
+pub mod chunk_collision;
 mod chunks;
 pub mod codec;
 pub mod cursor;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,6 +15,7 @@ pub mod codec;
 pub mod cursor;
 pub mod dodeca;
 pub mod graph;
+pub mod graph_collision;
 mod graph_entities;
 pub mod lru_slab;
 pub mod math;

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -93,6 +93,54 @@ impl VoxelData {
     }
 }
 
+/// Contains the context needed to know the locations of individual cubes within a chunk in the chunk's coordinate
+/// system. A given `ChunkLayout` is uniquely determined by its dimension.
+pub struct ChunkLayout {
+    dimension: usize,
+    dual_to_grid_factor: f32,
+}
+
+impl ChunkLayout {
+    pub fn new(dimension: usize) -> Self {
+        ChunkLayout {
+            dimension,
+            dual_to_grid_factor: Vertex::dual_to_chunk_factor() as f32 * dimension as f32,
+        }
+    }
+
+    /// Number of cubes on one axis of the chunk. Margins are not included.
+    #[inline]
+    pub fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    /// Scale by this to convert dual coordinates to homogeneous grid coordinates.
+    #[inline]
+    pub fn dual_to_grid_factor(&self) -> f32 {
+        self.dual_to_grid_factor
+    }
+
+    /// Converts a single coordinate from dual coordinates in the Klein-Beltrami model to an integer coordinate
+    /// suitable for voxel lookup. Margins are included. Returns `None` if the coordinate is outside the chunk.
+    #[inline]
+    pub fn dual_to_voxel(&self, dual_coord: f32) -> Option<usize> {
+        let floor_grid_coord = (dual_coord * self.dual_to_grid_factor).floor();
+
+        if !(floor_grid_coord >= 0.0 && floor_grid_coord < self.dimension as f32) {
+            None
+        } else {
+            Some(floor_grid_coord as usize + 1)
+        }
+    }
+
+    /// Converts a single coordinate from grid coordinates to dual coordiantes in the Klein-Beltrami model. This
+    /// can be used to find the positions of voxel gridlines.
+    #[inline]
+    pub fn grid_to_dual(&self, grid_coord: usize) -> f32 {
+        grid_coord as f32 / self.dual_to_grid_factor
+    }
+}
+
 /// Ensures that every new node of the given DualGraph is populated with a [Node] and is
 /// ready for world generation.
 pub fn populate_fresh_nodes(graph: &mut DualGraph) {

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -1,5 +1,8 @@
 /*the name of this module is pretty arbitrary at the moment*/
 
+use std::ops::{Index, IndexMut};
+
+use crate::dodeca::Vertex;
 use crate::graph::{Graph, NodeId};
 use crate::lru_slab::SlotId;
 use crate::world::Material;
@@ -7,6 +10,42 @@ use crate::worldgen::NodeState;
 use crate::Chunks;
 
 pub type DualGraph = Graph<Node>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ChunkId {
+    pub node: NodeId,
+    pub vertex: Vertex,
+}
+
+impl ChunkId {
+    pub fn new(node: NodeId, vertex: Vertex) -> Self {
+        ChunkId { node, vertex }
+    }
+}
+
+impl DualGraph {
+    pub fn get_chunk_mut(&mut self, chunk: ChunkId) -> Option<&mut Chunk> {
+        Some(&mut self.get_mut(chunk.node).as_mut()?.chunks[chunk.vertex])
+    }
+
+    pub fn get_chunk(&self, chunk: ChunkId) -> Option<&Chunk> {
+        Some(&self.get(chunk.node).as_ref()?.chunks[chunk.vertex])
+    }
+}
+
+impl Index<ChunkId> for DualGraph {
+    type Output = Chunk;
+
+    fn index(&self, chunk: ChunkId) -> &Chunk {
+        self.get_chunk(chunk).unwrap()
+    }
+}
+
+impl IndexMut<ChunkId> for DualGraph {
+    fn index_mut(&mut self, chunk: ChunkId) -> &mut Chunk {
+        self.get_chunk_mut(chunk).unwrap()
+    }
+}
 
 pub struct Node {
     pub state: NodeState,

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -30,6 +30,8 @@ pub struct SimConfigRaw {
     pub max_ground_speed: Option<f32>,
     /// Character acceleration while on the ground in m/s^2
     pub ground_acceleration: Option<f32>,
+    /// Radius of the character in meters
+    pub character_radius: Option<f32>,
 }
 
 /// Complete simulation config parameters
@@ -43,6 +45,7 @@ pub struct SimConfig {
     pub no_clip_movement_speed: f32,
     pub max_ground_speed: f32,
     pub ground_acceleration: f32,
+    pub character_radius: f32,
     /// Scaling factor converting meters to absolute units
     pub meters_to_absolute: f32,
 }
@@ -60,6 +63,7 @@ impl SimConfig {
             no_clip_movement_speed: x.no_clip_movement_speed.unwrap_or(12.0) * meters_to_absolute,
             max_ground_speed: x.max_ground_speed.unwrap_or(6.0) * meters_to_absolute,
             ground_acceleration: x.ground_acceleration.unwrap_or(30.0) * meters_to_absolute,
+            character_radius: x.character_radius.unwrap_or(0.4) * meters_to_absolute,
             meters_to_absolute,
         }
     }

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -164,8 +164,8 @@ impl Sim {
         // We want to load all chunks that a player can interact with in a single step, so chunk_generation_distance
         // is set up to cover that distance.
         // TODO: Use actual max speed instead of max ground speed.
-        // TODO: Account for the radius of the player's collision sphere
         let chunk_generation_distance = dodeca::BOUNDING_SPHERE_RADIUS
+            + self.cfg.character_radius as f64
             + self.cfg.max_ground_speed as f64 * self.cfg.step_interval.as_secs_f64()
             + 0.001;
 


### PR DESCRIPTION
This PR adds collision detection logic. There is a `shape_cast` method in the `common::collision` module that answers the question of "How far can a sphere of a given radius move in a given direction, up to a given distance, before colliding with a voxel? Does it collide at all?" If there is a collision, it also finds the normal, which can be used for collision resolution.

For testing purposes, a basic form of collision resolution is also included with these changes. As long as noclip is disabled by pressing "V", if a character collides with a wall, it will stop. This has the advantage of simplicity, but it has the disadvantage of making walls "sticky", so smoother movement is planned in a future PR.