### PR TITLE
Allow the character to slide against walls

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -265,7 +265,7 @@ impl Draw {
     ) {
         let draw_started = Instant::now();
         let view = sim.view();
-        let projection = frustum.projection(0.01);
+        let projection = frustum.projection(1.0e-4);
         let view_projection = projection.matrix() * math::mtranspose(&view.local);
         self.loader.drive();
 

--- a/client/src/graphics/frustum.rs
+++ b/client/src/graphics/frustum.rs
@@ -26,7 +26,8 @@ impl Frustum {
     /// This projection is applied to Beltrami-Klein vertices, which fall within a ball of radius 1
     /// around the viewpoint, so a far plane of 1.0 gives us ideal distribution of depth precision.
     pub fn projection(&self, znear: f32) -> na::Projective3<f32> {
-        // Based on http://dev.theomader.com/depth-precision/ + OpenVR docs
+        // Based on http://dev.theomader.com/depth-precision/ (broken link) + OpenVR docs
+        // Additional context at https://developer.nvidia.com/content/depth-precision-visualized
         let zfar = 1.0;
         let left = self.left.tan();
         let right = self.right.tan();
@@ -37,7 +38,7 @@ impl Frustum {
         let sx = right + left;
         let sy = down + up;
         // For an infinite far plane instead, za = 0 and zb = znear
-        let za = -zfar / (znear - zfar) - 1.0;
+        let za = -znear / (znear - zfar);
         let zb = -(znear * zfar) / (znear - zfar);
         na::Projective3::from_matrix_unchecked(
             na::Matrix4::new(

--- a/common/src/character_controller.rs
+++ b/common/src/character_controller.rs
@@ -1,4 +1,4 @@
-use tracing::{error, info};
+use tracing::{error, warn};
 
 use crate::{
     graph_collision, math,
@@ -67,17 +67,7 @@ impl CharacterControllerPass<'_> {
             //    stop moving after releasing a direction key.
             let estimated_average_velocity = (*self.velocity + old_velocity) * 0.5;
 
-            // Update position with collision checking
-            let expected_displacement = estimated_average_velocity * self.dt_seconds;
-            let collision_checking_result = self.check_collision(&expected_displacement);
-            self.position.local *= collision_checking_result.displacement_transform;
-            if let Some(collision) = collision_checking_result.collision {
-                *self.velocity = na::Vector3::zeros();
-                // We are not using collision normals yet, so print them to the console to allow
-                // sanity checking. Note that the "orientation" quaternion is not used here, so the
-                // numbers will only make sense if the character doesn't look around.
-                info!("Collision: normal = {:?}", collision.normal);
-            }
+            self.apply_velocity(&estimated_average_velocity);
         }
 
         // Renormalize
@@ -88,6 +78,46 @@ impl CharacterControllerPass<'_> {
         if next_node != self.position.node {
             self.position.node = next_node;
             self.position.local = transition_xf * self.position.local;
+        }
+    }
+
+    /// Updates the position based on the given average velocity while handling collisions. Also updates the velocity
+    /// based on collisions that occur.
+    fn apply_velocity(&mut self, estimated_average_velocity: &na::Vector3<f32>) {
+        // To prevent an unbounded runtime, we only allow a limited number of collisions to be processed in
+        // a single step. If the player encounters excessively complex geometry, it is possible to hit this limit,
+        // in which case further movement processing is delayed until the next time step.
+        const MAX_COLLISION_ITERATIONS: u32 = 5;
+
+        let mut expected_displacement = estimated_average_velocity * self.dt_seconds;
+        let mut active_normals = Vec::<na::UnitVector3<f32>>::with_capacity(3);
+
+        let mut all_collisions_resolved = false;
+
+        for _ in 0..MAX_COLLISION_ITERATIONS {
+            let collision_result = self.check_collision(&expected_displacement);
+            self.position.local *= collision_result.displacement_transform;
+
+            if let Some(collision) = collision_result.collision {
+                // We maintain a list of surface normals that should restrict player movement. We remove normals for
+                // surfaces the player is pushed away from and add the surface normal of the latest collision.
+                active_normals.retain(|n| n.dot(&collision.normal) < 0.0);
+                active_normals.push(collision.normal);
+
+                // Update the expected displacement to whatever is remaining.
+                expected_displacement -= collision_result.displacement_vector;
+                apply_normals(&active_normals, &mut expected_displacement);
+
+                // Also update the velocity to ensure that walls kill momentum.
+                apply_normals(&active_normals, self.velocity);
+            } else {
+                all_collisions_resolved = true;
+                break;
+            }
+        }
+
+        if !all_collisions_resolved {
+            warn!("A character entity processed too many collisions and collision resolution was cut short.");
         }
     }
 
@@ -149,10 +179,49 @@ impl CharacterControllerPass<'_> {
     }
 }
 
+/// Modifies the `subject` by a linear combination of the `normals` to ensure that it is approximately
+/// orthogonal to all the normals. The normals are assumed to be linearly independent, and, assuming the final
+/// result is nonzero, a small correction is applied to ensure that the subject is moving away from the surfaces
+/// the normals represent even when floating point approximation is involved.
+fn apply_normals(normals: &[na::UnitVector3<f32>], subject: &mut na::Vector3<f32>) {
+    if normals.len() >= 3 {
+        // The normals are assumed to be linearly independent, so applying all of them will zero out the subject.
+        // There is no need to do any extra logic to handle precision limitations in this case.
+        *subject = na::Vector3::zeros();
+    }
+
+    // Corrective term to ensure that normals face away from any potential collision surfaces
+    const RELATIVE_EPSILON: f32 = 1e-4;
+    apply_normals_internal(normals, subject, subject.magnitude() * RELATIVE_EPSILON);
+}
+
+/// Modifies the `subject` by a linear combination of the `normals` so that the dot product with each normal is
+/// `distance`. The `normals` must be linearly independent for this function to work as expected.
+fn apply_normals_internal(
+    normals: &[na::UnitVector3<f32>],
+    subject: &mut na::Vector3<f32>,
+    distance: f32,
+) {
+    let mut ortho_normals: Vec<na::Vector3<f32>> = normals.iter().map(|n| n.into_inner()).collect();
+    for i in 0..normals.len() {
+        // Perform the Gram-Schmidt process on `normals` to produce `ortho_normals`.
+        for j in i + 1..normals.len() {
+            ortho_normals[j] = (ortho_normals[j]
+                - ortho_normals[i] * ortho_normals[j].dot(&ortho_normals[i]))
+            .normalize();
+        }
+
+        // The following formula ensures that the dot product of `subject` and `normals[i]` is `distance.
+        // Because we only move the subject along `ortho_normals[i]`, this adjustment does not affect the
+        // subject's dot product with any earlier normals.
+        *subject += ortho_normals[i]
+            * ((distance - subject.dot(&normals[i])) / ortho_normals[i].dot(&normals[i]));
+    }
+}
+
 struct CollisionCheckingResult {
-    ///The displacement allowed by the character before hitting a wall. The result of
+    /// The displacement allowed for the character before hitting a wall. The result of
     /// `math::translate_along(&displacement_vector)` is `displacement_transform`.
-    #[allow(dead_code)]
     displacement_vector: na::Vector3<f32>,
 
     /// Multiplying the character's position by this matrix will move the character as far as it can up to its intended
@@ -177,6 +246,53 @@ impl CollisionCheckingResult {
             displacement_vector: na::Vector3::zeros(),
             displacement_transform: na::Matrix4::identity(),
             collision: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_abs_diff_eq;
+
+    use super::*;
+
+    #[test]
+    fn apply_normals_internal_examples() {
+        // Zero vectors (No-op but should not panic)
+        test_apply_normals_internal(&[], [0.60, -0.85, 0.90], 0.2);
+
+        // One vector
+        test_apply_normals_internal(&[[-0.48, -0.10, -0.67]], [0.85, -0.53, -0.61], 0.2);
+
+        // Two vectors
+        test_apply_normals_internal(
+            &[[-0.17, 0.07, -0.38], [-0.85, 0.19, -0.84]],
+            [0.19, -0.84, -0.62],
+            0.2,
+        );
+
+        // Three vectors (Not in use as of the creation of this test but should work anyways)
+        test_apply_normals_internal(
+            &[
+                [-0.24, 0.90, -0.06],
+                [-0.91, 0.01, 0.44],
+                [0.02, -0.65, -0.12],
+            ],
+            [0.91, -0.01, -0.61],
+            0.2,
+        );
+    }
+
+    fn test_apply_normals_internal(normals: &[[f32; 3]], subject: [f32; 3], distance: f32) {
+        let normals: Vec<na::UnitVector3<f32>> = normals
+            .iter()
+            .map(|n| na::UnitVector3::new_normalize(na::Vector3::new(n[0], n[1], n[2])))
+            .collect();
+        let mut subject = na::Vector3::new(subject[0], subject[1], subject[2]);
+
+        apply_normals_internal(&normals, &mut subject, distance);
+        for normal in normals {
+            assert_abs_diff_eq!(subject.dot(&normal), distance, epsilon = 1.0e-5);
         }
     }
 }


### PR DESCRIPTION
As a follow-up to https://github.com/Ralith/hypermine/pull/262, this PR improves the collision resolution logic of the character so that it slides against walls instead of getting stuck against them.

Unfortunately, the precision of the original collision logic was insufficient to avoid noticeable artifacts made visible by the updated collision resolution logic, so this PR also tweaks this collision logic to use more numerically stable formulas at the cost of being (hopefully only slightly) less efficient for sphere/vertex collisions.