### PR TITLE
Groundwork for saves

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,7 +71,7 @@ jobs:
           lfs: true
       - name: Install dependencies
         run: |
-          yum install -y alsa-lib-devel vulkan-devel python3 fontconfig-devel 
+          yum install -y alsa-lib-devel vulkan-devel python3 fontconfig-devel
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,3 +58,18 @@ jobs:
         with:
           command: clippy
           args: --workspace --all-targets -- -D warnings
+
+  check-protos:
+    name: Check protos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - run: sudo apt update && sudo apt-get -y install protobuf-compiler
+      - name: Generate Rust code from .proto files
+        run: cargo run -p gen-protos
+      - name: Check for uncommitted changes
+        run: git diff --exit-code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["client", "server", "common"]
+members = ["client", "server", "common", "save", "save/gen-protos"]
 
 [profile.dev]
 opt-level = 1

--- a/save/Cargo.toml
+++ b/save/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 prost = "0.11.8"
 redb = "0.13"
 thiserror = "1.0.38"
+zstd = { package = "zstd-safe", version = "6.0.4", features = ["std", "experimental"] }
 
 [dev-dependencies]
 tempfile = "3.4"

--- a/save/Cargo.toml
+++ b/save/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "save"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prost = "0.11.8"
+redb = "0.13"
+thiserror = "1.0.38"

--- a/save/Cargo.toml
+++ b/save/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 prost = "0.11.8"
 redb = "0.13"
 thiserror = "1.0.38"
+
+[dev-dependencies]
+tempfile = "3.4"

--- a/save/Cargo.toml
+++ b/save/Cargo.toml
@@ -12,3 +12,9 @@ thiserror = "1.0.38"
 
 [dev-dependencies]
 tempfile = "3.4"
+criterion = "0.4"
+rand = { version = "0.8.5", features = ["small_rng"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/save/benches/bench.rs
+++ b/save/benches/bench.rs
@@ -36,7 +36,7 @@ fn save(c: &mut Criterion) {
                     let mut tx = save.write().unwrap();
                     let mut writer = tx.get().unwrap();
                     for i in node_ids {
-                        writer.put(i, &node).unwrap();
+                        writer.put_node(i, &node).unwrap();
                     }
                     drop(writer);
                     tx.commit().unwrap();
@@ -63,7 +63,7 @@ fn save(c: &mut Criterion) {
                     let mut tx = save.write().unwrap();
                     let mut writer = tx.get().unwrap();
                     for &i in &node_ids {
-                        writer.put(i, &node).unwrap();
+                        writer.put_node(i, &node).unwrap();
                     }
                     drop(writer);
                     tx.commit().unwrap();
@@ -74,7 +74,7 @@ fn save(c: &mut Criterion) {
                     let read = save.read().unwrap();
                     let mut read = read.get().unwrap();
                     for i in node_ids {
-                        black_box(read.get(i).unwrap().unwrap());
+                        black_box(read.get_node(i).unwrap().unwrap());
                     }
                 },
                 BatchSize::SmallInput,

--- a/save/benches/bench.rs
+++ b/save/benches/bench.rs
@@ -1,0 +1,87 @@
+use save::Save;
+
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+fn save(c: &mut Criterion) {
+    let mut write = c.benchmark_group("write");
+    let node = save::Node {
+        archetypes: vec![save::Archetype {
+            entities: vec![1, 2, 3],
+            component_types: vec![4, 5, 6],
+            component_data: vec![Vec::new(), Vec::new(), Vec::new()],
+        }],
+        chunks: vec![save::Chunk {
+            vertex: 0,
+            voxels: vec![0; 12 * 12 * 12 * 2],
+        }],
+    };
+    let mut rng = SmallRng::from_entropy();
+    for count in [1, 100, 10000] {
+        write.throughput(Throughput::Elements(count));
+        write.bench_function(BenchmarkId::from_parameter(count), |b| {
+            b.iter_batched(
+                || {
+                    let file = tempfile::NamedTempFile::new().unwrap();
+                    let save = Save::open(file.path(), 12).unwrap();
+                    let node_ids = (&mut rng)
+                        .sample_iter(rand::distributions::Standard)
+                        .take(count as usize)
+                        .collect::<Vec<u128>>();
+                    (file, save, node_ids)
+                },
+                |(_file, mut save, node_ids)| {
+                    let mut tx = save.write().unwrap();
+                    let mut writer = tx.get().unwrap();
+                    for i in node_ids {
+                        writer.put(i, &node).unwrap();
+                    }
+                    drop(writer);
+                    tx.commit().unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    write.finish();
+
+    let mut read = c.benchmark_group("read");
+    for count in [1, 100, 10000] {
+        read.throughput(Throughput::Elements(count));
+        read.bench_function(BenchmarkId::from_parameter(count), |b| {
+            b.iter_batched(
+                || {
+                    let file = tempfile::NamedTempFile::new().unwrap();
+                    let mut save = Save::open(file.path(), 12).unwrap();
+                    let node_ids = (&mut rng)
+                        .sample_iter(rand::distributions::Standard)
+                        .take(count as usize)
+                        .collect::<Vec<u128>>();
+
+                    let mut tx = save.write().unwrap();
+                    let mut writer = tx.get().unwrap();
+                    for &i in &node_ids {
+                        writer.put(i, &node).unwrap();
+                    }
+                    drop(writer);
+                    tx.commit().unwrap();
+
+                    (file, save, node_ids)
+                },
+                |(_file, save, node_ids)| {
+                    let read = save.read().unwrap();
+                    let mut read = read.get().unwrap();
+                    for i in node_ids {
+                        black_box(read.get(i).unwrap().unwrap());
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, save);
+criterion_main!(benches);

--- a/save/gen-protos/Cargo.toml
+++ b/save/gen-protos/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gen-protos"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+prost-build = "0.11.8"

--- a/save/gen-protos/src/main.rs
+++ b/save/gen-protos/src/main.rs
@@ -1,0 +1,12 @@
+use std::{io::Result, path::Path};
+
+fn main() -> Result<()> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("src");
+
+    prost_build::Config::new()
+        .out_dir(&dir)
+        .compile_protos(&[dir.join("protos.proto")], &[dir])
+}

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -21,7 +21,11 @@ impl Save {
             match tx.open_table(META_TABLE) {
                 Ok(meta) => {
                     let Some(value) = meta.get(&[][..])? else { return Err(OpenError::MissingMeta); };
-                    Meta::decode(value.value())?
+                    let mut dctx = dctx();
+                    let mut buffer = Vec::new();
+                    decompress(&mut dctx, value.value(), &mut buffer)
+                        .map_err(OpenError::DecompressionFailed)?;
+                    Meta::decode(&*buffer)?
                 }
                 Err(redb::Error::TableDoesNotExist(_)) => {
                     let defaults = Meta {
@@ -29,7 +33,11 @@ impl Save {
                     };
                     let tx = db.begin_write()?;
                     let mut meta = tx.open_table(META_TABLE)?;
-                    meta.insert(&[][..], &*defaults.encode_to_vec())?;
+                    let mut cctx = cctx();
+                    let mut plain = Vec::new();
+                    let mut compressed = Vec::new();
+                    prepare(&mut cctx, &mut plain, &mut compressed, &defaults);
+                    meta.insert(&[][..], &*compressed)?;
                     drop(meta);
                     // Create the node table so `read` doesn't have to handle its possible absence
                     tx.open_table(NODE_TABLE)?;
@@ -65,18 +73,56 @@ pub struct ReaderGuard<'a> {
 impl ReaderGuard<'_> {
     pub fn get(&self) -> Result<Reader<'_>, redb::Error> {
         let table = self.tx.open_table(NODE_TABLE)?;
-        Ok(Reader { table })
+        Ok(Reader {
+            table,
+            dctx: dctx(),
+            accum: Vec::new(),
+        })
     }
+}
+
+fn dctx() -> zstd::DCtx<'static> {
+    let mut dctx = zstd::DCtx::create();
+    dctx.set_parameter(zstd::DParameter::Format(zstd::FrameFormat::Magicless))
+        .unwrap();
+    dctx
 }
 
 pub struct Reader<'a> {
     table: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
+    dctx: zstd::DCtx<'static>,
+    accum: Vec<u8>,
 }
 
 impl Reader<'_> {
     pub fn get(&mut self, node_id: u128) -> Result<Option<Node>, GetError> {
         let Some(node) = self.table.get(&node_id)? else { return Ok(None); };
-        Ok(Some(Node::decode(node.value())?))
+        self.accum.clear();
+        decompress(&mut self.dctx, node.value(), &mut self.accum)
+            .map_err(GetError::DecompressionFailed)?;
+        Ok(Some(Node::decode(&*self.accum)?))
+    }
+}
+
+fn decompress(
+    dctx: &mut zstd::DCtx<'_>,
+    compressed: &[u8],
+    out: &mut Vec<u8>,
+) -> Result<(), &'static str> {
+    dctx.init().map_err(zstd::get_error_name)?;
+    let mut input = zstd::InBuffer::around(compressed);
+    let mut out = zstd::OutBuffer::around(out);
+    let out_size = zstd::DCtx::out_size();
+    loop {
+        if out.dst.len() + out_size > out.dst.capacity() {
+            out.dst.reserve(out_size);
+        }
+        let n = dctx
+            .decompress_stream(&mut out, &mut input)
+            .map_err(zstd::get_error_name)?;
+        if n == 0 {
+            return Ok(());
+        }
     }
 }
 
@@ -88,7 +134,9 @@ impl<'a> WriterGuard<'a> {
     pub fn get(&mut self) -> Result<Writer<'a, '_>, redb::Error> {
         Ok(Writer {
             table: self.tx.open_table(NODE_TABLE)?,
+            cctx: cctx(),
             plain: Vec::new(),
+            compressed: Vec::new(),
         })
     }
 
@@ -97,18 +145,44 @@ impl<'a> WriterGuard<'a> {
     }
 }
 
+fn cctx() -> zstd::CCtx<'static> {
+    let mut cctx = zstd::CCtx::create();
+    cctx.set_parameter(zstd::CParameter::Format(zstd::FrameFormat::Magicless))
+        .unwrap();
+    cctx.set_parameter(zstd::CParameter::CompressionLevel(2))
+        .unwrap();
+    cctx
+}
+
 pub struct Writer<'save, 'guard> {
     table: redb::Table<'save, 'guard, u128, &'static [u8]>,
+    cctx: zstd::CCtx<'static>,
     plain: Vec<u8>,
+    compressed: Vec<u8>,
 }
 
 impl Writer<'_, '_> {
     pub fn put(&mut self, node_id: u128, state: &Node) -> Result<(), redb::Error> {
-        self.plain.clear();
-        state.encode(&mut self.plain).unwrap();
-        self.table.insert(node_id, &*self.plain)?;
+        prepare(&mut self.cctx, &mut self.plain, &mut self.compressed, state);
+        self.table.insert(node_id, &*self.compressed)?;
         Ok(())
     }
+}
+
+/// Buffer the compressed, encoded form of `msg` in `compressed`
+fn prepare<T: prost::Message>(
+    cctx: &mut zstd::CCtx<'_>,
+    plain: &mut Vec<u8>,
+    compressed: &mut Vec<u8>,
+    msg: &T,
+) {
+    plain.clear();
+    msg.encode(plain).unwrap();
+    compressed.clear();
+    compressed.reserve(zstd::compress_bound(plain.len()));
+    cctx.compress2(compressed, plain)
+        .map_err(zstd::get_error_name)
+        .unwrap();
 }
 
 const META_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("meta");
@@ -120,6 +194,8 @@ pub enum OpenError {
     Db(#[from] redb::Error),
     #[error("missing metadata")]
     MissingMeta,
+    #[error("decompression failed: {0}")]
+    DecompressionFailed(&'static str),
     #[error(transparent)]
     Corrupt(#[from] prost::DecodeError),
 }
@@ -128,6 +204,8 @@ pub enum OpenError {
 pub enum GetError {
     #[error(transparent)]
     Db(#[from] redb::Error),
+    #[error("decompression failed: {0}")]
+    DecompressionFailed(&'static str),
     #[error(transparent)]
     Corrupt(#[from] prost::DecodeError),
 }

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -47,18 +47,66 @@ impl Save {
         &self.meta
     }
 
-    pub fn get(&self, node_id: u128) -> Result<Option<Node>, GetError> {
+    pub fn read(&self) -> Result<ReaderGuard<'_>, redb::Error> {
         let tx = self.db.begin_read()?;
-        let nodes = tx.open_table(NODE_TABLE)?;
-        let Some(node) = nodes.get(&node_id)? else { return Ok(None); };
-        Ok(Some(Node::decode(node.value())?))
+        Ok(ReaderGuard { tx })
     }
 
-    pub fn put(&self, node_id: u128, node_state: Node) -> Result<(), redb::Error> {
-        let msg = node_state.encode_to_vec();
+    pub fn write(&mut self) -> Result<WriterGuard<'_>, redb::Error> {
         let tx = self.db.begin_write()?;
-        let mut nodes = tx.open_table(NODE_TABLE)?;
-        nodes.insert(node_id, &*msg)?;
+        Ok(WriterGuard { tx })
+    }
+}
+
+pub struct ReaderGuard<'a> {
+    tx: redb::ReadTransaction<'a>,
+}
+
+impl ReaderGuard<'_> {
+    pub fn get(&self) -> Result<Reader<'_>, redb::Error> {
+        let table = self.tx.open_table(NODE_TABLE)?;
+        Ok(Reader { table })
+    }
+}
+
+pub struct Reader<'a> {
+    table: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
+}
+
+impl Reader<'_> {
+    pub fn get(&mut self, node_id: u128) -> Result<Option<Node>, GetError> {
+        let Some(node) = self.table.get(&node_id)? else { return Ok(None); };
+        Ok(Some(Node::decode(node.value())?))
+    }
+}
+
+pub struct WriterGuard<'a> {
+    tx: redb::WriteTransaction<'a>,
+}
+
+impl<'a> WriterGuard<'a> {
+    pub fn get(&mut self) -> Result<Writer<'a, '_>, redb::Error> {
+        Ok(Writer {
+            table: self.tx.open_table(NODE_TABLE)?,
+            plain: Vec::new(),
+        })
+    }
+
+    pub fn commit(self) -> Result<(), redb::Error> {
+        self.tx.commit()
+    }
+}
+
+pub struct Writer<'save, 'guard> {
+    table: redb::Table<'save, 'guard, u128, &'static [u8]>,
+    plain: Vec<u8>,
+}
+
+impl Writer<'_, '_> {
+    pub fn put(&mut self, node_id: u128, state: &Node) -> Result<(), redb::Error> {
+        self.plain.clear();
+        state.encode(&mut self.plain).unwrap();
+        self.table.insert(node_id, &*self.plain)?;
         Ok(())
     }
 }

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -1,0 +1,68 @@
+mod protos;
+
+use std::path::Path;
+
+use prost::Message;
+use redb::{Database, ReadableTable, TableDefinition};
+use thiserror::Error;
+
+pub use protos::*;
+
+pub struct Save {
+    meta: Meta,
+    db: Database,
+}
+
+impl Save {
+    pub fn open(path: &Path) -> Result<Self, OpenError> {
+        let db = Database::open(path)?;
+        let meta = {
+            let tx = db.begin_read()?;
+            let meta = tx.open_table(META_TABLE)?;
+            let Some(value) = meta.get(&[][..])? else { return Err(OpenError::MissingMeta); };
+            proto::Meta::decode(value.value())?
+        };
+        Ok(Self { meta, db })
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        &self.meta
+    }
+
+    pub fn get(&self, node_id: u128) -> Result<Option<Node>, GetError> {
+        let tx = self.db.begin_read()?;
+        let nodes = tx.open_table(NODE_TABLE)?;
+        let Some(node) = nodes.get(&node_id)? else { return Ok(None); };
+        Ok(Some(Node::decode(node.value())?))
+    }
+
+    pub fn put(&self, node_id: u128, node_state: Node) -> Result<(), redb::Error> {
+        let msg = node_state.encode_to_vec();
+        let tx = self.db.begin_write()?;
+        let mut nodes = tx.open_table(NODE_TABLE)?;
+        nodes.insert(node_id, &*msg)?;
+        Ok(())
+    }
+}
+
+const META_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("meta");
+const NODE_TABLE: TableDefinition<u128, &[u8]> = TableDefinition::new("nodes");
+
+#[derive(Debug, Error)]
+pub enum OpenError {
+    #[error(transparent)]
+    Db(#[from] redb::Error),
+    #[error("missing metadata")]
+    MissingMeta,
+    #[error(transparent)]
+    Corrupt(#[from] prost::DecodeError),
+}
+
+#[derive(Debug, Error)]
+pub enum GetError {
+    #[error(transparent)]
+    Db(#[from] redb::Error),
+    #[error(transparent)]
+    Corrupt(#[from] prost::DecodeError),
+}

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -28,6 +28,7 @@ impl Save {
                     Meta::decode(&*buffer)?
                 }
                 Err(redb::Error::TableDoesNotExist(_)) => {
+                    // Must be an empty save file. Initialize the meta record and create the other tables.
                     let defaults = Meta {
                         chunk_size: default_chunk_size.into(),
                     };
@@ -39,8 +40,9 @@ impl Save {
                     prepare(&mut cctx, &mut plain, &mut compressed, &defaults);
                     meta.insert(&[][..], &*compressed)?;
                     drop(meta);
-                    // Create the node table so `read` doesn't have to handle its possible absence
+
                     tx.open_table(NODE_TABLE)?;
+                    tx.open_table(CHARACTERS_BY_NAME_TABLE)?;
                     tx.commit()?;
                     defaults.clone()
                 }
@@ -72,9 +74,9 @@ pub struct ReaderGuard<'a> {
 
 impl ReaderGuard<'_> {
     pub fn get(&self) -> Result<Reader<'_>, redb::Error> {
-        let table = self.tx.open_table(NODE_TABLE)?;
         Ok(Reader {
-            table,
+            nodes: self.tx.open_table(NODE_TABLE)?,
+            characters: self.tx.open_table(CHARACTERS_BY_NAME_TABLE)?,
             dctx: dctx(),
             accum: Vec::new(),
         })
@@ -89,18 +91,27 @@ fn dctx() -> zstd::DCtx<'static> {
 }
 
 pub struct Reader<'a> {
-    table: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
+    nodes: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
+    characters: redb::ReadOnlyTable<'a, &'static str, &'static [u8]>,
     dctx: zstd::DCtx<'static>,
     accum: Vec<u8>,
 }
 
 impl Reader<'_> {
-    pub fn get(&mut self, node_id: u128) -> Result<Option<Node>, GetError> {
-        let Some(node) = self.table.get(&node_id)? else { return Ok(None); };
+    pub fn get_node(&mut self, node_id: u128) -> Result<Option<Node>, GetError> {
+        let Some(node) = self.nodes.get(&node_id)? else { return Ok(None); };
         self.accum.clear();
         decompress(&mut self.dctx, node.value(), &mut self.accum)
             .map_err(GetError::DecompressionFailed)?;
         Ok(Some(Node::decode(&*self.accum)?))
+    }
+
+    pub fn get_character(&mut self, name: &str) -> Result<Option<Character>, GetError> {
+        let Some(node) = self.characters.get(name)? else { return Ok(None); };
+        self.accum.clear();
+        decompress(&mut self.dctx, node.value(), &mut self.accum)
+            .map_err(GetError::DecompressionFailed)?;
+        Ok(Some(Character::decode(&*self.accum)?))
     }
 }
 
@@ -133,7 +144,8 @@ pub struct WriterGuard<'a> {
 impl<'a> WriterGuard<'a> {
     pub fn get(&mut self) -> Result<Writer<'a, '_>, redb::Error> {
         Ok(Writer {
-            table: self.tx.open_table(NODE_TABLE)?,
+            nodes: self.tx.open_table(NODE_TABLE)?,
+            characters: self.tx.open_table(CHARACTERS_BY_NAME_TABLE)?,
             cctx: cctx(),
             plain: Vec::new(),
             compressed: Vec::new(),
@@ -155,16 +167,28 @@ fn cctx() -> zstd::CCtx<'static> {
 }
 
 pub struct Writer<'save, 'guard> {
-    table: redb::Table<'save, 'guard, u128, &'static [u8]>,
+    nodes: redb::Table<'save, 'guard, u128, &'static [u8]>,
+    characters: redb::Table<'save, 'guard, &'static str, &'static [u8]>,
     cctx: zstd::CCtx<'static>,
     plain: Vec<u8>,
     compressed: Vec<u8>,
 }
 
 impl Writer<'_, '_> {
-    pub fn put(&mut self, node_id: u128, state: &Node) -> Result<(), redb::Error> {
+    pub fn put_node(&mut self, node_id: u128, state: &Node) -> Result<(), redb::Error> {
         prepare(&mut self.cctx, &mut self.plain, &mut self.compressed, state);
-        self.table.insert(node_id, &*self.compressed)?;
+        self.nodes.insert(node_id, &*self.compressed)?;
+        Ok(())
+    }
+
+    pub fn put_character(&mut self, name: &str, character: &Character) -> Result<(), redb::Error> {
+        prepare(
+            &mut self.cctx,
+            &mut self.plain,
+            &mut self.compressed,
+            character,
+        );
+        self.characters.insert(name, &*self.compressed)?;
         Ok(())
     }
 }
@@ -187,6 +211,8 @@ fn prepare<T: prost::Message>(
 
 const META_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("meta");
 const NODE_TABLE: TableDefinition<u128, &[u8]> = TableDefinition::new("nodes");
+const CHARACTERS_BY_NAME_TABLE: TableDefinition<&str, &[u8]> =
+    TableDefinition::new("characters by name");
 
 #[derive(Debug, Error)]
 pub enum OpenError {

--- a/save/src/protos.proto
+++ b/save/src/protos.proto
@@ -7,6 +7,11 @@ message Meta {
     uint32 chunk_size = 1;
 }
 
+message Character {
+    // Graph edges to traverse from the origin to find the node containing the character's entity
+    repeated uint32 path = 1;
+}
+
 message Node {
     // Entities whose origins lie within this node
     repeated Archetype archetypes = 1;

--- a/save/src/protos.proto
+++ b/save/src/protos.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package protos;
+
+message Meta {
+    // Number of voxels along the edge of a chunk
+    uint32 chunk_size = 1;
+}
+
+message Node {
+    // Entities whose origins lie within this node
+    repeated Archetype archetypes = 1;
+
+    // Voxel data for each modified chunk
+    repeated Chunk chunks = 2;
+}
+
+// A set of entities, all of which have the same components
+message Archetype {
+    // Entity IDs
+    repeated fixed64 entities = 1;
+
+    // Type of components stored in each column
+    repeated ComponentType component_types = 2;
+
+    // Each data represents a dense column of component values of the type identified by the
+    // component_type at the same index as the column
+    repeated bytes component_data = 3;
+}
+
+message Chunk {
+    // Which dodecahedron vertex is associated with this chunk
+    uint32 vertex = 1;
+
+    // Dense 3D array of 16-bit material tags for all voxels in this chunk
+    bytes voxels = 2;
+}
+
+enum ComponentType {
+    POSITION = 0;
+}

--- a/save/src/protos.rs
+++ b/save/src/protos.rs
@@ -1,0 +1,65 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Meta {
+    /// Number of voxels along the edge of a chunk
+    #[prost(uint32, tag = "1")]
+    pub chunk_size: u32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Node {
+    /// Entities whose origins lie within this node
+    #[prost(message, repeated, tag = "1")]
+    pub archetypes: ::prost::alloc::vec::Vec<Archetype>,
+    /// Voxel data for each modified chunk
+    #[prost(message, repeated, tag = "2")]
+    pub chunks: ::prost::alloc::vec::Vec<Chunk>,
+}
+/// A set of entities, all of which have the same components
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Archetype {
+    /// Entity IDs
+    #[prost(fixed64, repeated, tag = "1")]
+    pub entities: ::prost::alloc::vec::Vec<u64>,
+    /// Type of components stored in each column
+    #[prost(enumeration = "ComponentType", repeated, tag = "2")]
+    pub component_types: ::prost::alloc::vec::Vec<i32>,
+    /// Each data represents a dense column of component values of the type identified by the
+    /// component_type at the same index as the column
+    #[prost(bytes = "vec", repeated, tag = "3")]
+    pub component_data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Chunk {
+    /// Which dodecahedron vertex is associated with this chunk
+    #[prost(uint32, tag = "1")]
+    pub vertex: u32,
+    /// Dense 3D array of 16-bit material tags for all voxels in this chunk
+    #[prost(bytes = "vec", tag = "2")]
+    pub voxels: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ComponentType {
+    Position = 0,
+}
+impl ComponentType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ComponentType::Position => "POSITION",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "POSITION" => Some(Self::Position),
+            _ => None,
+        }
+    }
+}

--- a/save/src/protos.rs
+++ b/save/src/protos.rs
@@ -7,6 +7,13 @@ pub struct Meta {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Character {
+    /// Graph edges to traverse from the origin to find the node containing the character's entity
+    #[prost(uint32, repeated, tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Node {
     /// Entities whose origins lie within this node
     #[prost(message, repeated, tag = "1")]

--- a/save/tests/heavy.rs
+++ b/save/tests/heavy.rs
@@ -28,7 +28,7 @@ fn write() {
         let mut writer_guard = save.write().unwrap();
         let mut writer = writer_guard.get().unwrap();
         for _ in 0..NODES {
-            writer.put(rng.gen(), &node).unwrap();
+            writer.put_node(rng.gen(), &node).unwrap();
         }
         drop(writer);
         writer_guard.commit().unwrap();

--- a/save/tests/heavy.rs
+++ b/save/tests/heavy.rs
@@ -1,0 +1,42 @@
+use std::time::Instant;
+
+use save::Save;
+
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+#[test]
+fn write() {
+    let mut rng = SmallRng::from_entropy();
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let mut save = Save::open(file.path(), 12).unwrap();
+    let node = save::Node {
+        archetypes: vec![save::Archetype {
+            entities: vec![1, 2, 3],
+            component_types: vec![4, 5, 6],
+            component_data: vec![Vec::new(), Vec::new(), Vec::new()],
+        }],
+        chunks: vec![save::Chunk {
+            vertex: 0,
+            voxels: vec![0; 12 * 12 * 12 * 2],
+        }],
+    };
+
+    let start = Instant::now();
+    const PASSES: u32 = 100;
+    const NODES: u32 = 1_000;
+    for _ in 0..PASSES {
+        let mut writer_guard = save.write().unwrap();
+        let mut writer = writer_guard.get().unwrap();
+        for _ in 0..NODES {
+            writer.put(rng.gen(), &node).unwrap();
+        }
+        drop(writer);
+        writer_guard.commit().unwrap();
+    }
+    let dt = start.elapsed();
+    println!(
+        "{:?} per pass, {:?} per node",
+        dt / PASSES,
+        dt / (PASSES * NODES)
+    );
+}

--- a/save/tests/tests.rs
+++ b/save/tests/tests.rs
@@ -1,0 +1,11 @@
+use save::Save;
+
+#[test]
+fn persist_meta() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let save = Save::open(file.path(), 12).unwrap();
+    assert_eq!(save.meta().chunk_size, 12);
+    drop(save);
+    let save = Save::open(file.path(), 8).unwrap();
+    assert_eq!(save.meta().chunk_size, 12);
+}

--- a/save/tests/tests.rs
+++ b/save/tests/tests.rs
@@ -9,3 +9,27 @@ fn persist_meta() {
     let save = Save::open(file.path(), 8).unwrap();
     assert_eq!(save.meta().chunk_size, 12);
 }
+
+#[test]
+fn persist_node() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let mut save = Save::open(file.path(), 12).unwrap();
+    let node = save::Node {
+        archetypes: vec![save::Archetype {
+            entities: vec![1, 2, 3],
+            component_types: vec![4, 5, 6],
+            component_data: vec![Vec::new(), Vec::new(), Vec::new()],
+        }],
+        chunks: vec![save::Chunk {
+            vertex: 0,
+            voxels: vec![0; 12 * 12 * 12 * 2],
+        }],
+    };
+    let mut writer_guard = save.write().unwrap();
+    writer_guard.get().unwrap().put(0, &node).unwrap();
+    writer_guard.commit().unwrap();
+    assert_eq!(
+        node,
+        save.read().unwrap().get().unwrap().get(0).unwrap().unwrap()
+    );
+}


### PR DESCRIPTION
This PR defines a stand-alone library with a simple API for persisting world state to disk, including both edited voxels and other entity states. It is motivated by these goals:

- Fast random reads to any spatial neighborhood, to allow streaming large saves (e.g. highly-edited worlds) on-demand for consistent performance
- Fast random writes of the same, allowing only modified parts of the world to be written when saving, minimizing gameplay disruption regardless of total save size
- Consistency even in the face of crashes or power loss
- Compactness, to support large worlds and minimize required disk I/O
- Forwards-compatibility to minimize the odds of old saves becoming unusable after an update
- Loose coupling with the rest of the game

The design space is large, and this proposal therefore makes some interesting choices:

### [redb](https://github.com/cberner/redb) as storage backend
Key-value stores provide fast random access to binary keys, which we can derive for nodes per https://github.com/Ralith/hypermine/issues/253. They also tend to offer strong durability guarantees. Several other implementations were considered:
- lmdb is highly mature, but has a legacy of second-class Windows support and historically poor Rust bindings. A good fallback option.
- RocksDB has strong industry backing, but poor Rust bindings, requiring libclang at build-time and requiring minutes(!) to build the underlying C++ library. It also may be more complex than our requirements merit.
- LevelDB is less actively developed than RocksDB, and appears to have no maintained Rust bindings.
- sled is pure-rust, but is immature, and has a history of data loss issues, cavalier attitudes to memory safety, and maintainer hostility. Maintenance also appears to be dropping off.

redb is immature, but is native Rust, actively developed, claims competitive performance, and has a simple API. Migration to another key-value store should be straightforward if necessary, but if redb proves up to the task it's an ideal solution--and we can afford to weather some issues and work with upstream to address them while hypermine itself is in early days.

Other alternatives considered:
- sqlite: extremely mature, would certainly never be a cause of data loss. However, it solves a lot of problems we don't have and hence is expected to have relatively poor performance.
- A custom key-value format with hand-rolled consistency mechanisms: Difficult to implement. In particular, supporting random writes while efficiently reusing space and guaranteeing consistency is complex. Higher risk of data loss bugs and likely inferior performance.

### Protocol Buffers for value encoding

Protocol Buffers are a mature, reasonably compact binary encoding with strong support for schema evolution. Fields can be added freely without compromising the capability to decode older values, or even the capability of older games to decode newer values. The prost crate provides an ergonomic interface for Rust.

These benefits come at the cost of slightly more space use than a minimal binary encoding, and requiring the foreign protoc compiler to be present in the build environment to process the schema. That requirement could be relaxed in the future by switching to manual, rather than build script driven, compilation of the schema.

Encoding schemes with similar features include Cap'n Proto, Apache Thrift, and Flatbuffers. Any would be basically adequate, but protobufs are the best supported.

### Opaque entity component storage

The protobuf schema makes no attempt to explicitly model component data like positions, instead storing them as opaque columns of binary data, one per type of component, each associated with a type tag. This allows these potentially small and large-volume values to be stored without per-field protobuf encoding overhead, while preserving forwards compatibility. If the representation of a component is changed, it will therefore need to be allocated a new ID.

### Flat voxel storage

A chunk's voxels are either not represented, or represented in full by a dense u16 array. Compared to more complex mechanisms like an explicit diff, this is trivial for the game to provide (by merely marking chunks as dirty when edited, and saving all dirty chunks). The enclosing layer of compression is expected to make this more than adequately compact, but the use of protobufs leaves the door open to backwards-compatibly introducing other representations in the future if desired.

### [zstd](https://github.com/facebook/zstd) compression

It's just the best general-purpose compression algorithm by a huge margin. Initial profiling shows time spent doing compression for writes is less than a quarter of the time spent inside redb. The current implementation uses the built-in zstd frame format, which adds ~2 bytes of overhead per node; this could be reduced to 1 byte with some additional effort using the raw zstd block API.