### PR TITLE
Derive Default to fix Rust 1.68.0 clippy lint

### DIFF
--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -54,19 +54,15 @@ pub struct Node {
     pub chunks: Chunks<Chunk>,
 }
 
+#[derive(Default)]
 pub enum Chunk {
+    #[default]
     Fresh,
     Generating,
     Populated {
         voxels: VoxelData,
         surface: Option<SlotId>,
     },
-}
-
-impl Default for Chunk {
-    fn default() -> Self {
-        Chunk::Fresh
-    }
 }
 
 pub enum VoxelData {

--- a/common/src/world.rs
+++ b/common/src/world.rs
@@ -1,6 +1,7 @@
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u16)]
 pub enum Material {
+    #[default]
     Void = 0,
     Dirt = 1,
     Sand = 2,
@@ -45,10 +46,4 @@ pub enum Material {
 
 impl Material {
     pub const COUNT: usize = 40;
-}
-
-impl Default for Material {
-    fn default() -> Self {
-        Material::Void
-    }
 }


### PR DESCRIPTION
Fortunately, the most recent Rust update's new lints don't seem to have any real downsides.