### PR TITLE
Path-hashed node identifiers

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0 OR Zlib"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+blake3 = "1.3.3"
 serde = { version = "1.0.104", features = ["derive"] }
 nalgebra = { version = "0.31.2", features = ["libm-force", "rand", "serde-serialize"] }
 bincode = "1.2.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,3 +27,9 @@ rand_distr = "0.4.3"
 
 [dev-dependencies]
 approx = "0.5.1"
+criterion = "0.4"
+
+
+[[bench]]
+name = "bench"
+harness = false

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -1,8 +1,13 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use common::{
-    dodeca::Side,
+    dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
+    node::Chunk,
+    node::{populate_fresh_nodes, ChunkId, DualGraph},
+    proto::Position,
+    traversal::ensure_nearby,
+    worldgen::ChunkParams,
 };
 
 fn build_graph(c: &mut Criterion) {
@@ -15,6 +20,42 @@ fn build_graph(c: &mut Criterion) {
                 n = graph.ensure_neighbor(n, Side::J);
             }
             assert_eq!(graph.len(), 1001);
+        })
+    });
+
+    c.bench_function("nodegen 1000", |b| {
+        b.iter(|| {
+            let mut graph = DualGraph::new();
+            let mut n = NodeId::ROOT;
+            for _ in 0..500 {
+                n = graph.ensure_neighbor(n, Side::A);
+                n = graph.ensure_neighbor(n, Side::J);
+            }
+            assert_eq!(graph.len(), 1001);
+            populate_fresh_nodes(&mut graph);
+        })
+    });
+
+    c.bench_function("worldgen", |b| {
+        b.iter(|| {
+            let mut graph = DualGraph::new();
+            ensure_nearby(&mut graph, &Position::origin(), 3.0);
+            let fresh = graph.fresh().to_vec();
+            populate_fresh_nodes(&mut graph);
+            let mut n = 0;
+            for node in fresh {
+                for vertex in Vertex::iter() {
+                    let chunk = ChunkId::new(node, vertex);
+                    if let Some(params) = ChunkParams::new(12, &graph, chunk) {
+                        graph[chunk] = Chunk::Populated {
+                            voxels: params.generate_voxels(),
+                            surface: None,
+                        };
+                        n += 1;
+                    }
+                }
+            }
+            assert_eq!(n, 640);
         })
     });
 }

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -1,0 +1,23 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use common::{
+    dodeca::Side,
+    graph::{Graph, NodeId},
+};
+
+fn build_graph(c: &mut Criterion) {
+    c.bench_function("build_graph 1000", |b| {
+        b.iter(|| {
+            let mut graph = Graph::<()>::new();
+            let mut n = NodeId::ROOT;
+            for _ in 0..500 {
+                n = graph.ensure_neighbor(n, Side::A);
+                n = graph.ensure_neighbor(n, Side::J);
+            }
+            assert_eq!(graph.len(), 1001);
+        })
+    });
+}
+
+criterion_group!(benches, build_graph);
+criterion_main!(benches);


### PR DESCRIPTION
Fixes #253.

It occurs to me that, while blake2b is known to be fast in bulk operation, our branching byte-at-a-time use case is unusual and might not be well studied/optimized for. Could be worth benchmarking and experimenting with other hash functions (maybe including less cryptographic ones) but this is probably not the worst place to start.