### PR TITLE
Isolate entity and voxel data in saves

### DIFF
--- a/save/benches/bench.rs
+++ b/save/benches/bench.rs
@@ -7,12 +7,7 @@ use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 fn save(c: &mut Criterion) {
     let mut write = c.benchmark_group("write");
-    let node = save::Node {
-        archetypes: vec![save::Archetype {
-            entities: vec![1, 2, 3],
-            component_types: vec![4, 5, 6],
-            component_data: vec![Vec::new(), Vec::new(), Vec::new()],
-        }],
+    let node = save::VoxelNode {
         chunks: vec![save::Chunk {
             vertex: 0,
             voxels: vec![0; 12 * 12 * 12 * 2],
@@ -36,7 +31,7 @@ fn save(c: &mut Criterion) {
                     let mut tx = save.write().unwrap();
                     let mut writer = tx.get().unwrap();
                     for i in node_ids {
-                        writer.put_node(i, &node).unwrap();
+                        writer.put_voxel_node(i, &node).unwrap();
                     }
                     drop(writer);
                     tx.commit().unwrap();
@@ -63,7 +58,7 @@ fn save(c: &mut Criterion) {
                     let mut tx = save.write().unwrap();
                     let mut writer = tx.get().unwrap();
                     for &i in &node_ids {
-                        writer.put_node(i, &node).unwrap();
+                        writer.put_voxel_node(i, &node).unwrap();
                     }
                     drop(writer);
                     tx.commit().unwrap();
@@ -74,7 +69,7 @@ fn save(c: &mut Criterion) {
                     let read = save.read().unwrap();
                     let mut read = read.get().unwrap();
                     for i in node_ids {
-                        black_box(read.get_node(i).unwrap().unwrap());
+                        black_box(read.get_voxel_node(i).unwrap().unwrap());
                     }
                 },
                 BatchSize::SmallInput,

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -41,7 +41,8 @@ impl Save {
                     meta.insert(&[][..], &*compressed)?;
                     drop(meta);
 
-                    tx.open_table(NODE_TABLE)?;
+                    tx.open_table(VOXEL_NODE_TABLE)?;
+                    tx.open_table(ENTITY_NODE_TABLE)?;
                     tx.open_table(CHARACTERS_BY_NAME_TABLE)?;
                     tx.commit()?;
                     defaults.clone()
@@ -75,7 +76,8 @@ pub struct ReaderGuard<'a> {
 impl ReaderGuard<'_> {
     pub fn get(&self) -> Result<Reader<'_>, DbError> {
         Ok(Reader {
-            nodes: self.tx.open_table(NODE_TABLE)?,
+            voxel_nodes: self.tx.open_table(VOXEL_NODE_TABLE)?,
+            entity_nodes: self.tx.open_table(ENTITY_NODE_TABLE)?,
             characters: self.tx.open_table(CHARACTERS_BY_NAME_TABLE)?,
             dctx: dctx(),
             accum: Vec::new(),
@@ -91,19 +93,28 @@ fn dctx() -> zstd::DCtx<'static> {
 }
 
 pub struct Reader<'a> {
-    nodes: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
+    voxel_nodes: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
+    entity_nodes: redb::ReadOnlyTable<'a, u128, &'static [u8]>,
     characters: redb::ReadOnlyTable<'a, &'static str, &'static [u8]>,
     dctx: zstd::DCtx<'static>,
     accum: Vec<u8>,
 }
 
 impl Reader<'_> {
-    pub fn get_node(&mut self, node_id: u128) -> Result<Option<Node>, GetError> {
-        let Some(node) = self.nodes.get(&node_id)? else { return Ok(None); };
+    pub fn get_voxel_node(&mut self, node_id: u128) -> Result<Option<VoxelNode>, GetError> {
+        let Some(node) = self.voxel_nodes.get(&node_id)? else { return Ok(None); };
         self.accum.clear();
         decompress(&mut self.dctx, node.value(), &mut self.accum)
             .map_err(GetError::DecompressionFailed)?;
-        Ok(Some(Node::decode(&*self.accum)?))
+        Ok(Some(VoxelNode::decode(&*self.accum)?))
+    }
+
+    pub fn get_entity_node(&mut self, node_id: u128) -> Result<Option<EntityNode>, GetError> {
+        let Some(node) = self.entity_nodes.get(&node_id)? else { return Ok(None); };
+        self.accum.clear();
+        decompress(&mut self.dctx, node.value(), &mut self.accum)
+            .map_err(GetError::DecompressionFailed)?;
+        Ok(Some(EntityNode::decode(&*self.accum)?))
     }
 
     pub fn get_character(&mut self, name: &str) -> Result<Option<Character>, GetError> {
@@ -144,7 +155,8 @@ pub struct WriterGuard<'a> {
 impl<'a> WriterGuard<'a> {
     pub fn get(&mut self) -> Result<Writer<'a, '_>, DbError> {
         Ok(Writer {
-            nodes: self.tx.open_table(NODE_TABLE)?,
+            voxel_nodes: self.tx.open_table(VOXEL_NODE_TABLE)?,
+            entity_nodes: self.tx.open_table(ENTITY_NODE_TABLE)?,
             characters: self.tx.open_table(CHARACTERS_BY_NAME_TABLE)?,
             cctx: cctx(),
             plain: Vec::new(),
@@ -168,7 +180,8 @@ fn cctx() -> zstd::CCtx<'static> {
 }
 
 pub struct Writer<'save, 'guard> {
-    nodes: redb::Table<'save, 'guard, u128, &'static [u8]>,
+    voxel_nodes: redb::Table<'save, 'guard, u128, &'static [u8]>,
+    entity_nodes: redb::Table<'save, 'guard, u128, &'static [u8]>,
     characters: redb::Table<'save, 'guard, &'static str, &'static [u8]>,
     cctx: zstd::CCtx<'static>,
     plain: Vec<u8>,
@@ -176,9 +189,15 @@ pub struct Writer<'save, 'guard> {
 }
 
 impl Writer<'_, '_> {
-    pub fn put_node(&mut self, node_id: u128, state: &Node) -> Result<(), DbError> {
+    pub fn put_voxel_node(&mut self, node_id: u128, state: &VoxelNode) -> Result<(), DbError> {
         prepare(&mut self.cctx, &mut self.plain, &mut self.compressed, state);
-        self.nodes.insert(node_id, &*self.compressed)?;
+        self.voxel_nodes.insert(node_id, &*self.compressed)?;
+        Ok(())
+    }
+
+    pub fn put_entity_node(&mut self, node_id: u128, state: &EntityNode) -> Result<(), DbError> {
+        prepare(&mut self.cctx, &mut self.plain, &mut self.compressed, state);
+        self.entity_nodes.insert(node_id, &*self.compressed)?;
         Ok(())
     }
 
@@ -211,7 +230,8 @@ fn prepare<T: prost::Message>(
 }
 
 const META_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("meta");
-const NODE_TABLE: TableDefinition<u128, &[u8]> = TableDefinition::new("nodes");
+const VOXEL_NODE_TABLE: TableDefinition<u128, &[u8]> = TableDefinition::new("voxel nodes");
+const ENTITY_NODE_TABLE: TableDefinition<u128, &[u8]> = TableDefinition::new("entity nodes");
 const CHARACTERS_BY_NAME_TABLE: TableDefinition<&str, &[u8]> =
     TableDefinition::new("characters by name");
 

--- a/save/src/protos.proto
+++ b/save/src/protos.proto
@@ -12,12 +12,9 @@ message Character {
     repeated uint32 path = 1;
 }
 
-message Node {
+message EntityNode {
     // Entities whose origins lie within this node
     repeated Archetype archetypes = 1;
-
-    // Voxel data for each modified chunk
-    repeated Chunk chunks = 2;
 }
 
 // A set of entities, all of which have the same components
@@ -31,6 +28,11 @@ message Archetype {
     // Each data represents a dense column of component values of the type identified by the
     // component_type at the same index as the column
     repeated bytes component_data = 3;
+}
+
+message VoxelNode {
+    // Voxel data for each modified chunk
+    repeated Chunk chunks = 1;
 }
 
 message Chunk {

--- a/save/src/protos.rs
+++ b/save/src/protos.rs
@@ -14,13 +14,10 @@ pub struct Character {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Node {
+pub struct EntityNode {
     /// Entities whose origins lie within this node
     #[prost(message, repeated, tag = "1")]
     pub archetypes: ::prost::alloc::vec::Vec<Archetype>,
-    /// Voxel data for each modified chunk
-    #[prost(message, repeated, tag = "2")]
-    pub chunks: ::prost::alloc::vec::Vec<Chunk>,
 }
 /// A set of entities, all of which have the same components
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -36,6 +33,13 @@ pub struct Archetype {
     /// component_type at the same index as the column
     #[prost(bytes = "vec", repeated, tag = "3")]
     pub component_data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VoxelNode {
+    /// Voxel data for each modified chunk
+    #[prost(message, repeated, tag = "1")]
+    pub chunks: ::prost::alloc::vec::Vec<Chunk>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/save/tests/heavy.rs
+++ b/save/tests/heavy.rs
@@ -9,12 +9,7 @@ fn write() {
     let mut rng = SmallRng::from_entropy();
     let file = tempfile::NamedTempFile::new().unwrap();
     let mut save = Save::open(file.path(), 12).unwrap();
-    let node = save::Node {
-        archetypes: vec![save::Archetype {
-            entities: vec![1, 2, 3],
-            component_types: vec![4, 5, 6],
-            component_data: vec![Vec::new(), Vec::new(), Vec::new()],
-        }],
+    let node = save::VoxelNode {
         chunks: vec![save::Chunk {
             vertex: 0,
             voxels: vec![0; 12 * 12 * 12 * 2],
@@ -28,7 +23,7 @@ fn write() {
         let mut writer_guard = save.write().unwrap();
         let mut writer = writer_guard.get().unwrap();
         for _ in 0..NODES {
-            writer.put_node(rng.gen(), &node).unwrap();
+            writer.put_voxel_node(rng.gen(), &node).unwrap();
         }
         drop(writer);
         writer_guard.commit().unwrap();

--- a/save/tests/tests.rs
+++ b/save/tests/tests.rs
@@ -16,19 +16,18 @@ fn persist_meta() {
 fn persist_node() {
     let file = tempfile::NamedTempFile::new().unwrap();
     let mut save = Save::open(file.path(), 12).unwrap();
-    let node = save::Node {
-        archetypes: vec![save::Archetype {
-            entities: vec![1, 2, 3],
-            component_types: vec![4, 5, 6],
-            component_data: vec![Vec::new(), Vec::new(), Vec::new()],
-        }],
+    let node = save::VoxelNode {
         chunks: vec![save::Chunk {
             vertex: 0,
             voxels: vec![0; 12 * 12 * 12 * 2],
         }],
     };
     let mut writer_guard = save.write().unwrap();
-    writer_guard.get().unwrap().put_node(0, &node).unwrap();
+    writer_guard
+        .get()
+        .unwrap()
+        .put_voxel_node(0, &node)
+        .unwrap();
     writer_guard.commit().unwrap();
     assert_eq!(
         node,
@@ -36,7 +35,7 @@ fn persist_node() {
             .unwrap()
             .get()
             .unwrap()
-            .get_node(0)
+            .get_voxel_node(0)
             .unwrap()
             .unwrap()
     );


### PR DESCRIPTION
Allows e.g. entity movements to be persisted without rewriting up to 67.5KiB (for a full node of 12-voxel chunks, uncompressed).

We could take this a step further and store each chunk separately, but that might reduce read performance, and voxel edits are expected to be infrequent.