### PR TITLE
Seed worldgen per-node RNG from node hash

### DIFF
--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -86,7 +86,7 @@ impl Sim {
         info!(%id, name = %hello.name, "spawning character");
         let position = Position {
             node: NodeId::ROOT,
-            local: math::translate_along(&(na::Vector3::y() * 1.1)),
+            local: math::translate_along(&(na::Vector3::y() * 1.4)),
         };
         let character = Character {
             name: hello.name,


### PR DESCRIPTION
Minor simplification and optimization.

Spawn point is now atop a small hill, requiring a slight altitude adjustment.