### PR TITLE
Fix clone implementation to honor clippy lint and apply cargo fmt to let-else statements

### DIFF
--- a/client/src/loader.rs
+++ b/client/src/loader.rs
@@ -301,11 +301,7 @@ pub struct Asset<T: 'static> {
 
 impl<T: 'static> Clone for Asset<T> {
     fn clone(&self) -> Self {
-        Self {
-            table: self.table,
-            index: self.index,
-            _marker: PhantomData,
-        }
+        *self
     }
 }
 

--- a/common/src/chunk_collision.rs
+++ b/common/src/chunk_collision.rs
@@ -28,12 +28,9 @@ pub fn chunk_sphere_cast(
 ) -> Option<ChunkCastHit> {
     let mut hit: Option<ChunkCastHit> = None;
 
-    let Some(bounding_box) = VoxelAABB::from_ray_segment_and_radius(
-        layout,
-        ray,
-        tanh_distance,
-        collider_radius,
-    ) else {
+    let Some(bounding_box) =
+        VoxelAABB::from_ray_segment_and_radius(layout, ray, tanh_distance, collider_radius)
+    else {
         return None;
     };
 
@@ -101,9 +98,10 @@ fn find_face_collision(
         ));
 
         let Some(new_tanh_distance) =
-            solve_sphere_plane_intersection(ray, &normal, collider_radius.sinh()) else {
-                continue;
-            };
+            solve_sphere_plane_intersection(ray, &normal, collider_radius.sinh())
+        else {
+            continue;
+        };
 
         // If new_tanh_distance is out of range, no collision occurred.
         if new_tanh_distance >= hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance) {
@@ -263,10 +261,15 @@ fn find_vertex_collision(
                 - vertex_normal1 * math::mip(&vertex_normal1, &vertex_normal2)),
         );
 
-        let Some(new_tanh_distance) =
-            solve_sphere_point_intersection(ray, &vertex_normal0, &vertex_normal1, &vertex_normal2, collider_radius.sinh()) else {
-                continue;
-            };
+        let Some(new_tanh_distance) = solve_sphere_point_intersection(
+            ray,
+            &vertex_normal0,
+            &vertex_normal1,
+            &vertex_normal2,
+            collider_radius.sinh(),
+        ) else {
+            continue;
+        };
 
         // If new_tanh_distance is out of range, no collision occurred.
         if new_tanh_distance >= hit.as_ref().map_or(tanh_distance, |hit| hit.tanh_distance) {

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -59,12 +59,13 @@ pub fn sphere_cast(
     // Breadth-first search loop
     while let Some((chunk, node_transform)) = chunk_queue.pop_front() {
         let Chunk::Populated {
-                voxels: ref voxel_data,
-                ..
-            } = graph[chunk] else {
-                // Collision checking on unpopulated chunk
-                return Err(SphereCastError::OutOfBounds);
-            };
+            voxels: ref voxel_data,
+            ..
+        } = graph[chunk]
+        else {
+            // Collision checking on unpopulated chunk
+            return Err(SphereCastError::OutOfBounds);
+        };
         let local_ray = chunk.vertex.node_to_dual().cast::<f32>() * node_transform * ray;
 
         // Check collision within a single chunk
@@ -352,7 +353,10 @@ mod tests {
                     }),
                 voxel_location.vertex,
             );
-            let Chunk::Populated { voxels: voxel_data, .. } = graph.get_chunk_mut(chunk).unwrap() else {
+            let Chunk::Populated {
+                voxels: voxel_data, ..
+            } = graph.get_chunk_mut(chunk).unwrap()
+            else {
                 panic!("All chunks should be populated.");
             };
 

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -111,7 +111,9 @@ pub struct Reader<'a> {
 
 impl Reader<'_> {
     pub fn get_voxel_node(&mut self, node_id: u128) -> Result<Option<VoxelNode>, GetError> {
-        let Some(node) = self.voxel_nodes.get(&node_id)? else { return Ok(None); };
+        let Some(node) = self.voxel_nodes.get(&node_id)? else {
+            return Ok(None);
+        };
         self.accum.clear();
         decompress(&mut self.dctx, node.value(), &mut self.accum)
             .map_err(GetError::DecompressionFailed)?;
@@ -119,7 +121,9 @@ impl Reader<'_> {
     }
 
     pub fn get_entity_node(&mut self, node_id: u128) -> Result<Option<EntityNode>, GetError> {
-        let Some(node) = self.entity_nodes.get(&node_id)? else { return Ok(None); };
+        let Some(node) = self.entity_nodes.get(&node_id)? else {
+            return Ok(None);
+        };
         self.accum.clear();
         decompress(&mut self.dctx, node.value(), &mut self.accum)
             .map_err(GetError::DecompressionFailed)?;
@@ -127,7 +131,9 @@ impl Reader<'_> {
     }
 
     pub fn get_character(&mut self, name: &str) -> Result<Option<Character>, GetError> {
-        let Some(node) = self.characters.get(name)? else { return Ok(None); };
+        let Some(node) = self.characters.get(name)? else {
+            return Ok(None);
+        };
         self.accum.clear();
         decompress(&mut self.dctx, node.value(), &mut self.accum)
             .map_err(GetError::DecompressionFailed)?;

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -104,7 +104,9 @@ impl Sim {
                 .world
                 .query_one::<(&EntityId, &Position, &Character)>(entity)
                 .unwrap();
-            let Some((id, pos, ch)) = q.get() else { continue; };
+            let Some((id, pos, ch)) = q.get() else {
+                continue;
+            };
             ids.push(id.to_bits());
             postcard_helpers::serialize(pos.local.as_ref(), &mut character_transforms).unwrap();
             postcard_helpers::serialize(&ch.name, &mut character_names).unwrap();


### PR DESCRIPTION
This PR has two unrelated changes bundled together, as both need to be done for CI to accept this PR.

# Clippy lint for clone implementation
This fixes an error reported by `#[deny(clippy::incorrect_clone_impl_on_copy_type)]`:

```
error: incorrect implementation of `clone` on a `Copy` type
   --> client\src\loader.rs:303:29
    |
303 |       fn clone(&self) -> Self {
    |  _____________________________^
304 | |         Self {
305 | |             table: self.table,
306 | |             index: self.index,
307 | |             _marker: PhantomData,
308 | |         }
309 | |     }
    | |_____^ help: change this to: `{ *self }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_clone_impl_on_copy_type
    = note: `#[deny(clippy::incorrect_clone_impl_on_copy_type)]` on by default
```

I did try deriving `Clone` and `Copy` instead, but that doesn't work, and it seems to be related to the type parameter `T` needing to also be `Clone` and `Copy`, which is too restrictive.

Given that the current `Clone` implementation looks equivalent to me to just copying the bytes, I believe this change does not result in any bugs.

# Cargo fmt
While let-else statements have been around for a while, they only recently got included in `cargo fmt`, and previously, `cargo fmt` simply skipped any code that used let-else statements. This PR also applies `cargo fmt` to the codebase to fix this inconsistent formatting.