### PR TITLE
Fix server crash on client disconnect due to incomplete entity removal

### DIFF
--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -163,6 +163,9 @@ impl Sim {
     pub fn destroy(&mut self, entity: Entity) {
         let id = *self.world.get::<&EntityId>(entity).unwrap();
         self.entity_ids.remove(&id);
+        if let Ok(position) = self.world.get::<&Position>(entity) {
+            self.graph_entities.remove(position.node, entity);
+        }
         self.world.despawn(entity).unwrap();
         self.despawns.push(id);
     }


### PR DESCRIPTION
There is an `unwrap` error when setting `q` in `snapshot_node`, since it uses `graph_entities` as the source of truth of entities that exist, but `graph_entities` was never updated on entity removal.