### PR TITLE
Delay client Sim creation until server parameters are received

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use client::{graphics, metrics, net, Config, Sim};
+use client::{graphics, metrics, net, Config};
 use save::Save;
 
 use ash::extensions::khr;
@@ -65,10 +65,9 @@ fn main() {
 
     // Kick off networking
     let net = net::spawn(config.clone());
-    let sim = Sim::new(net);
 
     // Finish creating the window, including the Vulkan resources used to render to it
-    let window = graphics::Window::new(window, core.clone(), config, metrics, sim);
+    let window = graphics::Window::new(window, core.clone(), config, metrics, net);
 
     // Initialize widely-shared graphics resources
     let gfx = Arc::new(


### PR DESCRIPTION
This allows the client's `Sim` to store a `SimConfig` without wrapping it in an `Option`. The main downside is that it slightly complicates `window.rs` and `draw.rs`, but such complication is likely temporary and would go away in a future refactor (such as if a "connecting" screen is created, diverting control flow earlier pre-ServerHello).