### PR TITLE
Replace generic Graph with concrete implemetation and include ChunkLayout

### DIFF
--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use common::{
     character_controller,
-    node::DualGraph,
+    graph::Graph,
     proto::{CharacterInput, Position},
     SimConfig,
 };
@@ -35,7 +35,7 @@ impl PredictedMotion {
 
     /// Update for input about to be sent to the server, returning the generation it should be
     /// tagged with
-    pub fn push(&mut self, cfg: &SimConfig, graph: &DualGraph, input: &CharacterInput) -> u16 {
+    pub fn push(&mut self, cfg: &SimConfig, graph: &Graph, input: &CharacterInput) -> u16 {
         character_controller::run_character_step(
             cfg,
             graph,
@@ -54,7 +54,7 @@ impl PredictedMotion {
     pub fn reconcile(
         &mut self,
         cfg: &SimConfig,
-        graph: &DualGraph,
+        graph: &Graph,
         generation: u16,
         position: Position,
         velocity: na::Vector3<f32>,
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn wraparound() {
         let mock_cfg = SimConfig::from_raw(&common::SimConfigRaw::default());
-        let mut mock_graph = DualGraph::new();
+        let mut mock_graph = Graph::new();
         common::node::populate_fresh_nodes(&mut mock_graph);
         let mock_character_input = CharacterInput {
             movement: na::Vector3::x(),

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn wraparound() {
         let mock_cfg = SimConfig::from_raw(&common::SimConfigRaw::default());
-        let mut mock_graph = Graph::new();
+        let mut mock_graph = Graph::new(1);
         common::node::populate_fresh_nodes(&mut mock_graph);
         let mock_character_input = CharacterInput {
             movement: na::Vector3::x(),

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -53,7 +53,7 @@ pub struct Sim {
 
 impl Sim {
     pub fn new(cfg: SimConfig, local_character_id: EntityId) -> Self {
-        let mut graph = Graph::new();
+        let mut graph = Graph::new(cfg.chunk_size as usize);
         populate_fresh_nodes(&mut graph);
         Self {
             graph,

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 use common::{
     character_controller,
-    graph::NodeId,
-    node::{populate_fresh_nodes, DualGraph},
+    graph::{Graph, NodeId},
+    node::populate_fresh_nodes,
     proto::{self, Character, CharacterInput, CharacterState, Command, Component, Position},
     sanitize_motion_input, EntityId, GraphEntities, SimConfig, Step,
 };
@@ -18,7 +18,7 @@ use common::{
 /// Game state
 pub struct Sim {
     // World state
-    pub graph: DualGraph,
+    pub graph: Graph,
     pub graph_entities: GraphEntities,
     entity_ids: FxHashMap<EntityId, Entity>,
     pub world: hecs::World,
@@ -53,7 +53,7 @@ pub struct Sim {
 
 impl Sim {
     pub fn new(cfg: SimConfig, local_character_id: EntityId) -> Self {
-        let mut graph = DualGraph::new();
+        let mut graph = Graph::new();
         populate_fresh_nodes(&mut graph);
         Self {
             graph,

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -13,7 +13,7 @@ use common::{
 fn build_graph(c: &mut Criterion) {
     c.bench_function("build_graph 1000", |b| {
         b.iter(|| {
-            let mut graph = Graph::<()>::new();
+            let mut graph = Graph::new();
             let mut n = NodeId::ROOT;
             for _ in 0..500 {
                 n = graph.ensure_neighbor(n, Side::A);

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -13,7 +13,7 @@ use common::{
 fn build_graph(c: &mut Criterion) {
     c.bench_function("build_graph 1000", |b| {
         b.iter(|| {
-            let mut graph = Graph::new();
+            let mut graph = Graph::new(12);
             let mut n = NodeId::ROOT;
             for _ in 0..500 {
                 n = graph.ensure_neighbor(n, Side::A);
@@ -25,7 +25,7 @@ fn build_graph(c: &mut Criterion) {
 
     c.bench_function("nodegen 1000", |b| {
         b.iter(|| {
-            let mut graph = Graph::new();
+            let mut graph = Graph::new(12);
             let mut n = NodeId::ROOT;
             for _ in 0..500 {
                 n = graph.ensure_neighbor(n, Side::A);
@@ -38,7 +38,7 @@ fn build_graph(c: &mut Criterion) {
 
     c.bench_function("worldgen", |b| {
         b.iter(|| {
-            let mut graph = Graph::new();
+            let mut graph = Graph::new(12);
             ensure_nearby(&mut graph, &Position::origin(), 3.0);
             let fresh = graph.fresh().to_vec();
             populate_fresh_nodes(&mut graph);

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -4,7 +4,7 @@ use common::{
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
     node::Chunk,
-    node::{populate_fresh_nodes, ChunkId, DualGraph},
+    node::{populate_fresh_nodes, ChunkId},
     proto::Position,
     traversal::ensure_nearby,
     worldgen::ChunkParams,
@@ -25,7 +25,7 @@ fn build_graph(c: &mut Criterion) {
 
     c.bench_function("nodegen 1000", |b| {
         b.iter(|| {
-            let mut graph = DualGraph::new();
+            let mut graph = Graph::new();
             let mut n = NodeId::ROOT;
             for _ in 0..500 {
                 n = graph.ensure_neighbor(n, Side::A);
@@ -38,7 +38,7 @@ fn build_graph(c: &mut Criterion) {
 
     c.bench_function("worldgen", |b| {
         b.iter(|| {
-            let mut graph = DualGraph::new();
+            let mut graph = Graph::new();
             ensure_nearby(&mut graph, &Position::origin(), 3.0);
             let fresh = graph.fresh().to_vec();
             populate_fresh_nodes(&mut graph);

--- a/common/src/character_controller/collision.rs
+++ b/common/src/character_controller/collision.rs
@@ -2,11 +2,7 @@
 
 use tracing::error;
 
-use crate::{
-    graph_collision, math,
-    node::{ChunkLayout, DualGraph},
-    proto::Position,
-};
+use crate::{graph::Graph, graph_collision, math, node::ChunkLayout, proto::Position};
 
 /// Checks for collisions when a character moves with a character-relative displacement vector of `relative_displacement`.
 pub fn check_collision(
@@ -71,7 +67,7 @@ pub fn check_collision(
 
 /// Contains information about the character and the world that is only relevant for collision checking
 pub struct CollisionContext<'a> {
-    pub graph: &'a DualGraph,
+    pub graph: &'a Graph,
     pub chunk_layout: ChunkLayout,
     pub radius: f32,
 }

--- a/common/src/character_controller/collision.rs
+++ b/common/src/character_controller/collision.rs
@@ -2,7 +2,7 @@
 
 use tracing::error;
 
-use crate::{graph::Graph, graph_collision, math, node::ChunkLayout, proto::Position};
+use crate::{graph::Graph, graph_collision, math, proto::Position};
 
 /// Checks for collisions when a character moves with a character-relative displacement vector of `relative_displacement`.
 pub fn check_collision(
@@ -28,7 +28,6 @@ pub fn check_collision(
     let cast_hit = graph_collision::sphere_cast(
         collision_context.radius,
         collision_context.graph,
-        &collision_context.chunk_layout,
         position,
         &ray,
         tanh_distance,
@@ -68,7 +67,6 @@ pub fn check_collision(
 /// Contains information about the character and the world that is only relevant for collision checking
 pub struct CollisionContext<'a> {
     pub graph: &'a Graph,
-    pub chunk_layout: ChunkLayout,
     pub radius: f32,
 }
 

--- a/common/src/character_controller/mod.rs
+++ b/common/src/character_controller/mod.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     graph::Graph,
     math,
-    node::ChunkLayout,
     proto::{CharacterInput, Position},
     sanitize_motion_input,
     sim_config::CharacterConfig,
@@ -33,7 +32,6 @@ pub fn run_character_step(
         cfg: &sim_config.character,
         collision_context: CollisionContext {
             graph,
-            chunk_layout: ChunkLayout::new(sim_config.chunk_size as usize),
             radius: sim_config.character.character_radius,
         },
         up: graph.get_relative_up(position).unwrap(),

--- a/common/src/character_controller/mod.rs
+++ b/common/src/character_controller/mod.rs
@@ -10,8 +10,9 @@ use crate::{
         collision::{check_collision, Collision, CollisionContext},
         vector_bounds::{BoundedVectors, VectorBound},
     },
+    graph::Graph,
     math,
-    node::{ChunkLayout, DualGraph},
+    node::ChunkLayout,
     proto::{CharacterInput, Position},
     sanitize_motion_input,
     sim_config::CharacterConfig,
@@ -21,7 +22,7 @@ use crate::{
 /// Runs a single step of character movement
 pub fn run_character_step(
     sim_config: &SimConfig,
-    graph: &DualGraph,
+    graph: &Graph,
     position: &mut Position,
     velocity: &mut na::Vector3<f32>,
     on_ground: &mut bool,

--- a/common/src/cursor.rs
+++ b/common/src/cursor.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn cursor_identities() {
-        let mut graph = Graph::new();
+        let mut graph = Graph::new(1);
         ensure_nearby(&mut graph, &Position::origin(), 3.0);
         let start = Cursor::from_vertex(NodeId::ROOT, Vertex::A);
         let wiggle = |dir| {

--- a/common/src/cursor.rs
+++ b/common/src/cursor.rs
@@ -21,7 +21,7 @@ impl Cursor {
     }
 
     /// Get the neighbor towards `dir`
-    pub fn step<N>(self, graph: &Graph<N>, dir: Dir) -> Option<Self> {
+    pub fn step(self, graph: &Graph, dir: Dir) -> Option<Self> {
         // For a cube identified by three dodecahedral faces sharing a vertex, we identify its
         // cubical neighbors by taking each vertex incident to exactly two of the faces and the face
         // of the three it's not incident to, and selecting the cube represented by the new vertex
@@ -50,7 +50,7 @@ impl Cursor {
     }
 
     /// Node and dodecahedral vertex that contains the representation for this cube in the graph
-    pub fn canonicalize<N>(self, graph: &Graph<N>) -> Option<ChunkId> {
+    pub fn canonicalize(self, graph: &Graph) -> Option<ChunkId> {
         graph.canonicalize(ChunkId::new(
             self.node,
             Vertex::from_sides(self.a, self.b, self.c).unwrap(),
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn cursor_identities() {
-        let mut graph = Graph::<()>::new();
+        let mut graph = Graph::new();
         ensure_nearby(&mut graph, &Position::origin(), 3.0);
         let start = Cursor::from_vertex(NodeId::ROOT, Vertex::A);
         let wiggle = |dir| {

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -33,6 +33,11 @@ impl Graph {
     }
 
     #[inline]
+    pub fn layout(&self) -> &ChunkLayout {
+        &self.layout
+    }
+
+    #[inline]
     pub fn len(&self) -> u32 {
         self.nodes.len() as u32
     }

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -261,7 +261,7 @@ mod tests {
         fn execute(self) {
             let dimension: usize = 12;
             let layout = ChunkLayout::new(dimension);
-            let mut graph = Graph::new();
+            let mut graph = Graph::new(dimension);
             let graph_radius = 3.0;
 
             // Set up a graph with void chunks
@@ -514,7 +514,7 @@ mod tests {
     fn sphere_cast_near_unloaded_chunk() {
         let dimension: usize = 12;
         let layout = ChunkLayout::new(dimension);
-        let mut graph = Graph::new();
+        let mut graph = Graph::new(dimension);
 
         let sides = Vertex::A.canonical_sides();
 

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -5,12 +5,13 @@ use fxhash::FxHashSet;
 use crate::{
     chunk_collision::chunk_sphere_cast,
     dodeca::{self, Vertex},
+    graph::Graph,
     math,
-    node::{Chunk, ChunkId, ChunkLayout, DualGraph},
+    node::{Chunk, ChunkId, ChunkLayout},
     proto::Position,
 };
 
-/// Performs sphere casting (swept collision query) against the voxels in the `DualGraph`
+/// Performs sphere casting (swept collision query) against the voxels in the `Graph`
 ///
 /// The `ray` parameter and any resulting hit normals are given in the local coordinate system of `position`.
 ///
@@ -21,7 +22,7 @@ use crate::{
 /// the closest node with ungenerated chunks is greater than `cast_distance + collider_radius + dodeca::BOUNDING_SPHERE_RADIUS`
 pub fn sphere_cast(
     collider_radius: f32,
-    graph: &DualGraph,
+    graph: &Graph,
     layout: &ChunkLayout,
     position: &Position,
     ray: &Ray,
@@ -201,7 +202,7 @@ impl std::ops::Mul<&Ray> for na::Matrix4<f32> {
 mod tests {
     use crate::{
         dodeca::{Side, Vertex},
-        graph::NodeId,
+        graph::{Graph, NodeId},
         node::{populate_fresh_nodes, VoxelData},
         proto::Position,
         traversal::{ensure_nearby, nearby_nodes},
@@ -260,7 +261,7 @@ mod tests {
         fn execute(self) {
             let dimension: usize = 12;
             let layout = ChunkLayout::new(dimension);
-            let mut graph = DualGraph::new();
+            let mut graph = Graph::new();
             let graph_radius = 3.0;
 
             // Set up a graph with void chunks
@@ -342,7 +343,7 @@ mod tests {
             }
         }
 
-        fn populate_voxel(graph: &mut DualGraph, dimension: usize, voxel_location: &VoxelLocation) {
+        fn populate_voxel(graph: &mut Graph, dimension: usize, voxel_location: &VoxelLocation) {
             // Find the ChunkId of the given chunk
             let chunk = ChunkId::new(
                 voxel_location
@@ -366,7 +367,7 @@ mod tests {
                 + voxel_location.coords[2] * (dimension + 2).pow(2)] = Material::Dirt;
         }
 
-        fn get_voxel_chunk(graph: &DualGraph, voxel_location: &VoxelLocation) -> ChunkId {
+        fn get_voxel_chunk(graph: &Graph, voxel_location: &VoxelLocation) -> ChunkId {
             ChunkId::new(
                 voxel_location
                     .node_path
@@ -513,7 +514,7 @@ mod tests {
     fn sphere_cast_near_unloaded_chunk() {
         let dimension: usize = 12;
         let layout = ChunkLayout::new(dimension);
-        let mut graph = DualGraph::new();
+        let mut graph = Graph::new();
 
         let sides = Vertex::A.canonical_sides();
 

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -10,7 +10,7 @@ use crate::world::Material;
 use crate::worldgen::NodeState;
 use crate::{math, Chunks};
 
-pub type DualGraph = Graph<Node>;
+pub type DualGraph = Graph;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ChunkId {

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -10,8 +10,6 @@ use crate::world::Material;
 use crate::worldgen::NodeState;
 use crate::{math, Chunks};
 
-pub type DualGraph = Graph;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ChunkId {
     pub node: NodeId,
@@ -24,7 +22,7 @@ impl ChunkId {
     }
 }
 
-impl DualGraph {
+impl Graph {
     pub fn get_chunk_mut(&mut self, chunk: ChunkId) -> Option<&mut Chunk> {
         Some(&mut self.get_mut(chunk.node).as_mut()?.chunks[chunk.vertex])
     }
@@ -43,7 +41,7 @@ impl DualGraph {
     }
 }
 
-impl Index<ChunkId> for DualGraph {
+impl Index<ChunkId> for Graph {
     type Output = Chunk;
 
     fn index(&self, chunk: ChunkId) -> &Chunk {
@@ -51,7 +49,7 @@ impl Index<ChunkId> for DualGraph {
     }
 }
 
-impl IndexMut<ChunkId> for DualGraph {
+impl IndexMut<ChunkId> for Graph {
     fn index_mut(&mut self, chunk: ChunkId) -> &mut Chunk {
         self.get_chunk_mut(chunk).unwrap()
     }
@@ -147,9 +145,9 @@ impl ChunkLayout {
     }
 }
 
-/// Ensures that every new node of the given DualGraph is populated with a [Node] and is
+/// Ensures that every new node of the given Graph is populated with a [Node] and is
 /// ready for world generation.
-pub fn populate_fresh_nodes(graph: &mut DualGraph) {
+pub fn populate_fresh_nodes(graph: &mut Graph) {
     let fresh = graph.fresh().to_vec();
     graph.clear_fresh();
     for &node in &fresh {
@@ -157,7 +155,7 @@ pub fn populate_fresh_nodes(graph: &mut DualGraph) {
     }
 }
 
-fn populate_node(graph: &mut DualGraph, node: NodeId) {
+fn populate_node(graph: &mut Graph, node: NodeId) {
     *graph.get_mut(node) = Some(Node {
         state: graph
             .parent(node)

--- a/common/src/traversal.rs
+++ b/common/src/traversal.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Ensure all nodes within `distance` of `start` exist
-pub fn ensure_nearby<N>(graph: &mut Graph<N>, start: &Position, distance: f64) {
+pub fn ensure_nearby(graph: &mut Graph, start: &Position, distance: f64) {
     let mut pending = Vec::<(NodeId, na::Matrix4<f64>)>::new();
     let mut visited = FxHashSet::<NodeId>::default();
 
@@ -35,8 +35,8 @@ pub fn ensure_nearby<N>(graph: &mut Graph<N>, start: &Position, distance: f64) {
 
 /// Compute `start.node`-relative transforms of all nodes whose origins lie within `distance` of
 /// `start`
-pub fn nearby_nodes<N>(
-    graph: &Graph<N>,
+pub fn nearby_nodes(
+    graph: &Graph,
     start: &Position,
     distance: f64,
 ) -> Vec<(NodeId, na::Matrix4<f32>)> {

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -3,9 +3,9 @@ use rand_distr::Normal;
 
 use crate::{
     dodeca::{Side, Vertex},
-    graph::NodeId,
+    graph::{Graph, NodeId},
     math,
-    node::{ChunkId, DualGraph, VoxelData},
+    node::{ChunkId, VoxelData},
     terraingen::VoronoiInfo,
     world::Material,
     Plane,
@@ -82,7 +82,7 @@ impl NodeState {
         }
     }
 
-    pub fn child(&self, graph: &DualGraph, node: NodeId, side: Side) -> Self {
+    pub fn child(&self, graph: &Graph, node: NodeId, side: Side) -> Self {
         let mut d = graph
             .descenders(node)
             .map(|(s, n)| (s, &graph.get(n).as_ref().unwrap().state));
@@ -181,7 +181,7 @@ impl ChunkParams {
     /// Extract data necessary to generate a chunk
     ///
     /// Returns `None` if an unpopulated node is needed.
-    pub fn new(dimension: u8, graph: &DualGraph, chunk: ChunkId) -> Option<Self> {
+    pub fn new(dimension: u8, graph: &Graph, chunk: ChunkId) -> Option<Self> {
         let state = &graph.get(chunk.node).as_ref()?.state;
         Some(Self {
             dimension,
@@ -516,7 +516,7 @@ struct ChunkIncidentEnviroFactors {
 ///
 /// Returns `None` if not all incident nodes are populated.
 fn chunk_incident_enviro_factors(
-    graph: &DualGraph,
+    graph: &Graph,
     chunk: ChunkId,
 ) -> Option<ChunkIncidentEnviroFactors> {
     let mut i = chunk
@@ -613,7 +613,7 @@ fn hash(a: u64, b: u64) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::node::{DualGraph, Node};
+    use crate::node::Node;
     use crate::Chunks;
     use approx::*;
 
@@ -676,7 +676,7 @@ mod test {
 
     #[test]
     fn check_chunk_incident_max_elevations() {
-        let mut g = DualGraph::new();
+        let mut g = Graph::new();
         for (i, path) in Vertex::A.dual_vertices().map(|(_, p)| p).enumerate() {
             let new_node = path.fold(NodeId::ROOT, |node, side| g.ensure_neighbor(node, side));
 

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -676,7 +676,7 @@ mod test {
 
     #[test]
     fn check_chunk_incident_max_elevations() {
-        let mut g = Graph::new();
+        let mut g = Graph::new(1);
         for (i, path) in Vertex::A.dual_vertices().map(|(_, p)| p).enumerate() {
             let new_node = path.fold(NodeId::ROOT, |node, side| g.ensure_neighbor(node, side));
 

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -11,7 +11,7 @@ use common::{
     character_controller, dodeca,
     graph::{Graph, NodeId},
     math,
-    node::{populate_fresh_nodes, Chunk, DualGraph},
+    node::{populate_fresh_nodes, Chunk},
     proto::{
         Character, CharacterInput, CharacterState, ClientHello, Command, Component, FreshNode,
         Position, Spawns, StateDelta,
@@ -29,7 +29,7 @@ pub struct Sim {
     step: Step,
     entity_ids: FxHashMap<EntityId, Entity>,
     world: hecs::World,
-    graph: DualGraph,
+    graph: Graph,
     spawns: Vec<Entity>,
     despawns: Vec<EntityId>,
     graph_entities: GraphEntities,
@@ -60,7 +60,7 @@ impl Sim {
     }
 
     pub fn save(&mut self, save: &mut save::Save) -> Result<(), save::DbError> {
-        fn path_from_origin(graph: &DualGraph, mut node: NodeId) -> Vec<u32> {
+        fn path_from_origin(graph: &Graph, mut node: NodeId) -> Vec<u32> {
             let mut result = Vec::new();
             while let Some(parent) = graph.parent(node) {
                 result.push(parent as u32);

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -39,16 +39,16 @@ pub struct Sim {
 impl Sim {
     pub fn new(cfg: Arc<SimConfig>) -> Self {
         let mut result = Self {
-            cfg,
             rng: SmallRng::from_entropy(),
             step: 0,
             entity_ids: FxHashMap::default(),
             world: hecs::World::new(),
-            graph: Graph::new(),
+            graph: Graph::new(cfg.chunk_size as usize),
             spawns: Vec::new(),
             despawns: Vec::new(),
             graph_entities: GraphEntities::new(),
             dirty_nodes: FxHashSet::default(),
+            cfg,
         };
 
         ensure_nearby(


### PR DESCRIPTION
Currently, outside of tests, the only implementation of `Graph` is `DualGraph`. This used to not be true, as the server used a `Graph<()>` instead, but to allow server-side collision checking, this has changed. In the spirit of only using generics when necessary, this PR gets rid of the `Graph`/`DualGraph` distinction.

As part of this change, this PR also attaches `ChunkLayout` data to `Graph`, as it arguably makes sense for this data to live together, but it was harder to do something like this cleanly when `Graph` was generic. This can enable additional helper methods, such as one that takes a `ChunkId` and a set of coordinates and alters corresponding voxel, taking care of adjacent chunk margins and surface invalidation (without needing to repeatedly pass in the dimension as a parameter).

This PR doesn't refactor most code to use the `ChunkLayout` in `Graph` instead of the `chunk_size` in `SimConfig`, as there isn't a clear benefit. However, to ensure there is at least one usage of this new functionality, this PR alters the collision checking code to use the `ChunkLayout` in `Graph` instead of taking it in as a parameter.