### PR TITLE
Fix clippy warning unwrap_or_default

### DIFF
--- a/common/src/graph_entities.rs
+++ b/common/src/graph_entities.rs
@@ -20,7 +20,7 @@ impl GraphEntities {
     }
 
     pub fn insert(&mut self, node: NodeId, entity: Entity) {
-        let vec = self.map.entry(node).or_insert_with(Vec::new);
+        let vec = self.map.entry(node).or_default();
         debug_assert!(!vec.contains(&entity), "redundant insert");
         vec.push(entity);
     }


### PR DESCRIPTION
```
warning: use of `or_insert_with` to construct default value
  --> common\src\graph_entities.rs:23:40
   |
23 |         let vec = self.map.entry(node).or_insert_with(Vec::new);
   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default
   = note: `#[warn(clippy::unwrap_or_default)]` on by default
```