### PR TITLE
Update quinn and rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["client", "server", "common", "save", "save/gen-protos"]
 [workspace.dependencies]
 hecs = "0.10.0"
 nalgebra = { version = "0.32.1", features = ["libm-force"] }
-quinn = "0.8.3"
+quinn = "0.10.2"
 toml = { version = "0.8.0", default-features = false, features = ["parse"] }
 
 [profile.dev]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -31,7 +31,7 @@ fxhash = "0.2.1"
 downcast-rs = "1.1.1"
 quinn = { workspace = true }
 futures-util = "0.3.1"
-rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
+rustls = { version = "0.21.7", features = ["dangerous_configuration"] }
 webpki = "0.22.0"
 hecs = { workspace = true }
 rcgen = { version = "0.11.0", default-features = false }

--- a/common/src/codec.rs
+++ b/common/src/codec.rs
@@ -47,7 +47,7 @@ pub async fn send_whole<T: Serialize + ?Sized>(
 /// Receive the entirety of `stream` as a `T`
 pub async fn recv_whole<T: DeserializeOwned>(
     size_limit: usize,
-    stream: quinn::RecvStream,
+    mut stream: quinn::RecvStream,
 ) -> Result<T> {
     let buf = stream.read_to_end(size_limit).await?;
     Ok(bincode::deserialize(&buf)?)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,6 @@ fxhash = "0.2.1"
 nalgebra = { workspace = true }
 libm = "0.2.6"
 slotmap = "1.0.6"
-rustls = "0.20.6"
+rustls = "0.21.7"
 rustls-pemfile = "1.0.0"
 save = { path = "../save" }


### PR DESCRIPTION
Update rustls from 0.20.6 to 0.21.7.
Update quinn from 0.8.3 to 0.10.2.

Most changes are simple compatibility fixes, mostly involving turning previously-quinn-provided streams into loops with task spawns.

One small but potentially important change is that the `ClientEvent::Lost` message will always be sent when an error occurs, even if the connection was already closed from some other logic and the client was already cleaned up. To be robust to this kind of redundancy and potential race conditions, the `on_client_event` method is set up to skip messages received from clients that were already cleaned up.