### PR TITLE
Fix issue where the server wasn't processing orientation info

### DIFF
--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -159,6 +159,8 @@ impl Sim {
     ) -> Result<(), hecs::ComponentError> {
         let mut input = self.world.get::<&mut CharacterInput>(entity)?;
         *input = command.character_input;
+        let mut ch = self.world.get::<&mut Character>(entity)?;
+        ch.state.orientation = command.orientation;
         Ok(())
     }
 


### PR DESCRIPTION
This fixes a regression I introduced in 7b558b5448cea257d661ee728110a7a2ebcad553, where player's couldn't see which way other players were facing.

It's still a little tricky to see which way other players are facing because the origin of the player model is at the feet, but my understanding is that this model is a placeholder, so improving this doesn't need to be a priority.