### PR TITLE
Update winit to 0.29.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ quinn = "0.10.2"
 toml = { version = "0.8.0", default-features = false, features = ["parse"] }
 
 [profile.dev]
+lto = true
 opt-level = 1
 debug-assertions = true
 
 [profile.dev.package."*"]
 opt-level = 2
+
+[profile.release]
+lto = true
 
 [profile.release.build-override]
 opt-level = 0

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,9 +14,9 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.37.1", features = ["loaded"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "88abd75e41d04c3a4199d95f581cb135f5962844" }
-winit = "0.28.1"
+winit = { version = "0.29.3", features = ["rwh_05"] }
 ash-window = "0.12.0"
-raw-window-handle = "0.5.0"
+raw-window-handle = { version = "0.5.0", features = ["std"] }
 directories = "5.0.1"
 vk-shader-macros = "0.2.5"
 nalgebra = { workspace = true }

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -6,12 +6,12 @@ use ash::{extensions::khr, vk};
 use lahar::DedicatedImage;
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use tracing::{error, info};
+use winit::event::KeyEvent;
+use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::{
     dpi::PhysicalSize,
-    event::{
-        DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent,
-    },
-    event_loop::{ControlFlow, EventLoop},
+    event::{DeviceEvent, ElementState, Event, MouseButton, WindowEvent},
+    event_loop::EventLoop,
     window::{CursorGrabMode, Window as WinitWindow, WindowBuilder},
 };
 
@@ -27,7 +27,7 @@ pub struct EarlyWindow {
 
 impl EarlyWindow {
     pub fn new() -> Self {
-        let event_loop = EventLoop::new();
+        let event_loop = EventLoop::new().unwrap();
         let window = WindowBuilder::new()
             .with_title("hypermine")
             .build(&event_loop)
@@ -105,7 +105,7 @@ impl Window {
     }
 
     /// Run the event loop until process exit
-    pub fn run(mut self, gfx: Arc<Base>) -> ! {
+    pub fn run(mut self, gfx: Arc<Base>) {
         // Allocate the presentable images we'll be rendering to
         self.swapchain = Some(SwapchainMgr::new(
             &self,
@@ -128,34 +128,9 @@ impl Window {
         self.event_loop
             .take()
             .unwrap()
-            .run(move |event, _, control_flow| match event {
-                Event::MainEventsCleared => {
-                    while let Ok(msg) = self.net.incoming.try_recv() {
-                        self.handle_net(msg);
-                    }
-
-                    if let Some(sim) = self.sim.as_mut() {
-                        let this_frame = Instant::now();
-                        let dt = this_frame - last_frame;
-                        sim.set_movement_input(na::Vector3::new(
-                            right as u8 as f32 - left as u8 as f32,
-                            up as u8 as f32 - down as u8 as f32,
-                            back as u8 as f32 - forward as u8 as f32,
-                        ));
-                        sim.set_jump_held(jump);
-
-                        sim.look(
-                            0.0,
-                            0.0,
-                            2.0 * (anticlockwise as u8 as f32 - clockwise as u8 as f32)
-                                * dt.as_secs_f32(),
-                        );
-
-                        sim.step(dt, &mut self.net);
-                        last_frame = this_frame;
-                    }
-
-                    self.draw();
+            .run(move |event, window_target| match event {
+                Event::AboutToWait => {
+                    self.window.request_redraw();
                 }
                 Event::DeviceEvent { event, .. } => match event {
                     DeviceEvent::MouseMotion { delta } if mouse_captured => {
@@ -171,6 +146,34 @@ impl Window {
                     _ => {}
                 },
                 Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::RedrawRequested => {
+                        while let Ok(msg) = self.net.incoming.try_recv() {
+                            self.handle_net(msg);
+                        }
+
+                        if let Some(sim) = self.sim.as_mut() {
+                            let this_frame = Instant::now();
+                            let dt = this_frame - last_frame;
+                            sim.set_movement_input(na::Vector3::new(
+                                right as u8 as f32 - left as u8 as f32,
+                                up as u8 as f32 - down as u8 as f32,
+                                back as u8 as f32 - forward as u8 as f32,
+                            ));
+                            sim.set_jump_held(jump);
+
+                            sim.look(
+                                0.0,
+                                0.0,
+                                2.0 * (anticlockwise as u8 as f32 - clockwise as u8 as f32)
+                                    * dt.as_secs_f32(),
+                            );
+
+                            sim.step(dt, &mut self.net);
+                            last_frame = this_frame;
+                        }
+
+                        self.draw();
+                    }
                     WindowEvent::Resized(_) => {
                         // Some environments may not emit the vulkan signals that recommend or
                         // require surface reconstruction, so we need to check for messages from the
@@ -180,7 +183,7 @@ impl Window {
                     }
                     WindowEvent::CloseRequested => {
                         info!("exiting due to closed window");
-                        *control_flow = ControlFlow::Exit;
+                        window_target.exit();
                     }
                     WindowEvent::MouseInput {
                         button: MouseButton::Left,
@@ -195,39 +198,39 @@ impl Window {
                         mouse_captured = true;
                     }
                     WindowEvent::KeyboardInput {
-                        input:
-                            KeyboardInput {
+                        event:
+                            KeyEvent {
                                 state,
-                                virtual_keycode: Some(key),
+                                physical_key: PhysicalKey::Code(key),
                                 ..
                             },
                         ..
                     } => match key {
-                        VirtualKeyCode::W => {
+                        KeyCode::KeyW => {
                             forward = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::A => {
+                        KeyCode::KeyA => {
                             left = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::S => {
+                        KeyCode::KeyS => {
                             back = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::D => {
+                        KeyCode::KeyD => {
                             right = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::Q => {
+                        KeyCode::KeyQ => {
                             anticlockwise = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::E => {
+                        KeyCode::KeyE => {
                             clockwise = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::R => {
+                        KeyCode::KeyR => {
                             up = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::F => {
+                        KeyCode::KeyF => {
                             down = state == ElementState::Pressed;
                         }
-                        VirtualKeyCode::Space => {
+                        KeyCode::Space => {
                             if let Some(sim) = self.sim.as_mut() {
                                 if !jump && state == ElementState::Pressed {
                                     sim.set_jump_pressed_true();
@@ -235,12 +238,12 @@ impl Window {
                                 jump = state == ElementState::Pressed;
                             }
                         }
-                        VirtualKeyCode::V if state == ElementState::Pressed => {
+                        KeyCode::KeyV if state == ElementState::Pressed => {
                             if let Some(sim) = self.sim.as_mut() {
                                 sim.toggle_no_clip();
                             }
                         }
-                        VirtualKeyCode::Escape => {
+                        KeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);
                             mouse_captured = false;
@@ -256,11 +259,12 @@ impl Window {
                     }
                     _ => {}
                 },
-                Event::LoopDestroyed => {
+                Event::LoopExiting => {
                     self.metrics.report();
                 }
                 _ => {}
-            });
+            })
+            .unwrap();
     }
 
     fn handle_net(&mut self, msg: net::Message) {


### PR DESCRIPTION
winit now defaults to raw-window-handle 0.6, but ash-window is not yet compatible with this version of raw-window-handle. Fortunately, the `rwh_05` feature allows the use of the older version of raw-window-handle.

A few notable changes:
- winit did an overhaul of keyboard input, so the use of `virtual_keycode` had to be replaced with `physical_key` or `logical_key`. I guessed that `physical_key` was better.
- `Event::MainEventsCleared` was removed from winit, so I needed to switch to `AboutToWait`. However, I used https://github.com/rust-windowing/winit/blob/7bed5eecfdcbde16e5619fd137f0229e8e7e8ed4/examples/request_redraw.rs as an example, which had me make the additional change of putting all the frame logic in `WindowEvent::RedrawRequested` and using `self.window.request_redraw` in `Event::AboutToWait`. I'm not certain this is what we want for Hypermine, but I didn't notice any issues on my end when testing it.