### PR TITLE
Save and load all modified chunks

### DIFF
--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -105,7 +105,7 @@ impl Voxels {
 
             // Now that the block is populated, we can apply any pending block updates the server
             // provided that the client couldn't apply.
-            if let Some(block_updates) = sim.pending_modified_chunks.remove(&chunk_id) {
+            if let Some(block_updates) = sim.preloaded_block_updates.remove(&chunk_id) {
                 for block_update in block_updates {
                     // The chunk was just populated, so a block update should always succeed.
                     assert!(sim.graph.update_block(&block_update));

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -331,8 +331,7 @@ impl Sim {
             }
         }
         for (chunk_id, voxel_data) in msg.modified_chunks {
-            let Some(voxel_data) = VoxelData::from_serializable(&voxel_data, self.cfg.chunk_size)
-            else {
+            let Some(voxel_data) = VoxelData::deserialize(&voxel_data, self.cfg.chunk_size) else {
                 tracing::error!("Voxel data received from server is of incorrect dimension");
                 continue;
             };

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -38,7 +38,8 @@ const MATERIAL_PALETTE: [Material; 10] = [
 pub struct Sim {
     // World state
     pub graph: Graph,
-    pub pending_modified_chunks: FxHashMap<ChunkId, Vec<BlockUpdate>>,
+    /// Voxel data that have been downloaded from the server for chunks not yet introduced to the graph
+    pub preloaded_block_updates: FxHashMap<ChunkId, Vec<BlockUpdate>>,
     pub graph_entities: GraphEntities,
     entity_ids: FxHashMap<EntityId, Entity>,
     pub world: hecs::World,
@@ -84,7 +85,7 @@ impl Sim {
         populate_fresh_nodes(&mut graph);
         Self {
             graph,
-            pending_modified_chunks: FxHashMap::default(),
+            preloaded_block_updates: FxHashMap::default(),
             graph_entities: GraphEntities::new(),
             entity_ids: FxHashMap::default(),
             world: hecs::World::new(),
@@ -324,13 +325,13 @@ impl Sim {
         populate_fresh_nodes(&mut self.graph);
         for block_update in msg.block_updates.into_iter() {
             if !self.graph.update_block(&block_update) {
-                self.pending_modified_chunks
+                self.preloaded_block_updates
                     .entry(block_update.chunk_id)
                     .or_default()
                     .push(block_update);
             }
         }
-        for (chunk_id, voxel_data) in msg.modified_chunks {
+        for (chunk_id, voxel_data) in msg.voxel_data {
             let Some(voxel_data) = VoxelData::deserialize(&voxel_data, self.cfg.chunk_size) else {
                 tracing::error!("Voxel data received from server is of incorrect dimension");
                 continue;

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -226,6 +226,11 @@ impl Graph {
         node.0
     }
 
+    #[inline]
+    pub fn from_hash(&self, hash: u128) -> NodeId {
+        NodeId(hash)
+    }
+
     /// Ensure all shorter neighbors of a not-yet-created child node exist and return them, excluding the given parent node
     fn populate_shorter_neighbors_of_child(
         &mut self,

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -57,7 +57,7 @@ pub struct Spawns {
     pub despawns: Vec<EntityId>,
     pub nodes: Vec<FreshNode>,
     pub block_updates: Vec<BlockUpdate>,
-    pub modified_chunks: Vec<(ChunkId, SerializableVoxelData)>,
+    pub modified_chunks: Vec<(ChunkId, SerializedVoxelData)>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -84,8 +84,9 @@ pub struct BlockUpdate {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SerializableVoxelData {
-    pub voxels: Vec<Material>,
+pub struct SerializedVoxelData {
+    /// Dense 3D array of 16-bit material tags for all voxels in this chunk
+    pub inner: Vec<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -57,7 +57,7 @@ pub struct Spawns {
     pub despawns: Vec<EntityId>,
     pub nodes: Vec<FreshNode>,
     pub block_updates: Vec<BlockUpdate>,
-    pub modified_chunks: Vec<(ChunkId, SerializedVoxelData)>,
+    pub voxel_data: Vec<(ChunkId, SerializedVoxelData)>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/world.rs
+++ b/common/src/world.rs
@@ -51,3 +51,68 @@ pub enum Material {
 impl Material {
     pub const COUNT: usize = 40;
 }
+
+impl TryFrom<u16> for Material {
+    type Error = ();
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Material::Void,
+            1 => Material::Dirt,
+            2 => Material::Sand,
+            3 => Material::Silt,
+            4 => Material::Clay,
+            5 => Material::Mud,
+            6 => Material::SandyLoam,
+            7 => Material::SiltyLoam,
+            8 => Material::ClayLoam,
+            9 => Material::RedSand,
+            10 => Material::Limestone,
+            11 => Material::Shale,
+            12 => Material::Dolomite,
+            13 => Material::Sandstone,
+            14 => Material::RedSandstone,
+            15 => Material::Marble,
+            16 => Material::Slate,
+            17 => Material::Granite,
+            18 => Material::Diorite,
+            19 => Material::Andesite,
+            20 => Material::Gabbro,
+            21 => Material::Basalt,
+            22 => Material::Olivine,
+            23 => Material::Water,
+            24 => Material::Lava,
+            25 => Material::Wood,
+            26 => Material::Leaves,
+            27 => Material::WoodPlanks,
+            28 => Material::GreyBrick,
+            29 => Material::WhiteBrick,
+            30 => Material::Ice,
+            31 => Material::IceSlush,
+            32 => Material::Gravel,
+            33 => Material::Snow,
+            34 => Material::CoarseGrass,
+            35 => Material::TanGrass,
+            36 => Material::LushGrass,
+            37 => Material::MudGrass,
+            38 => Material::Grass,
+            39 => Material::CaveGrass,
+            _ => Err(())?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Material;
+
+    #[test]
+    fn u16_to_material_consistency_check() {
+        for i in 0..Material::COUNT {
+            let index = u16::try_from(i).unwrap();
+            let material =
+                Material::try_from(index).expect("no missing entries in try_from match statement");
+            assert_eq!(index, material as u16);
+        }
+    }
+}

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -139,6 +139,16 @@ impl Reader<'_> {
             .map_err(GetError::DecompressionFailed)?;
         Ok(Some(Character::decode(&*self.accum)?))
     }
+
+    /// Temporary function to load all voxel-related save data at once.
+    /// TODO: Replace this implementation with a streaming implementation
+    /// that does not require loading everything at once
+    pub fn get_all_voxel_node_ids(&self) -> Result<Vec<u128>, GetError> {
+        self.voxel_nodes
+            .iter()?
+            .map(|n| Ok(n.map_err(GetError::from)?.0.value()))
+            .collect()
+    }
 }
 
 fn decompress(

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -56,7 +56,7 @@ impl Server {
     fn new(params: SimConfig, save: Save) -> Self {
         let cfg = Arc::new(params);
         Self {
-            sim: Sim::new(cfg.clone()),
+            sim: Sim::new(cfg.clone(), &save),
             cfg,
             clients: DenseSlotMap::default(),
             save,
@@ -125,7 +125,7 @@ impl Server {
                     || !spawns.despawns.is_empty()
                     || !spawns.nodes.is_empty()
                     || !spawns.block_updates.is_empty()
-                    || !spawns.modified_chunks.is_empty()
+                    || !spawns.voxel_data.is_empty()
                 {
                     handles.ordered.try_send(spawns.clone())
                 } else {

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -208,7 +208,7 @@ impl Sim {
 
             spawns
                 .modified_chunks
-                .push((chunk_id, voxels.to_serializable(self.cfg.chunk_size)));
+                .push((chunk_id, voxels.serialize(self.cfg.chunk_size)));
         }
         spawns
     }


### PR DESCRIPTION
Whenever a block is updated, ensure that an updated version of the relevant node is written to the save file. When a world is initialized on the server-side, all modified chunks are loaded from the save file and stored in memory, to be retrieved whenever the relevant node is to be added to the graph.

This is a temporary implementation, as it does not properly scale for larger worlds, where we may not want to store all modified chunks in RAM.

Note that while this implements loading save data, it only loads voxels. Entity locations, such as the player's location, are ignored.