### PR TITLE
Allow for number keys to select type of block to be placed

### DIFF
--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -256,6 +256,16 @@ impl Window {
                                 sim.toggle_no_clip();
                             }
                         }
+                        VirtualKeyCode::Key1 | VirtualKeyCode::Key2 | VirtualKeyCode::Key3
+                        | VirtualKeyCode::Key4 | VirtualKeyCode::Key5 | VirtualKeyCode::Key6
+                        | VirtualKeyCode::Key7 | VirtualKeyCode::Key8 | VirtualKeyCode::Key9
+                        | VirtualKeyCode::Key0 => {
+                            if state == ElementState::Pressed {
+                                if let Some(sim) = self.sim.as_mut() {
+                                    sim.select_material(number_key_to_index(key));
+                                }
+                            }
+                        }
                         VirtualKeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);
@@ -353,6 +363,22 @@ impl Window {
                 Err(e) => panic!("queue_present: {e}"),
             };
         }
+    }
+}
+
+fn number_key_to_index(key: VirtualKeyCode) -> usize {
+    match key {
+        VirtualKeyCode::Key1 => 0,
+        VirtualKeyCode::Key2 => 1,
+        VirtualKeyCode::Key3 => 2,
+        VirtualKeyCode::Key4 => 3,
+        VirtualKeyCode::Key5 => 4,
+        VirtualKeyCode::Key6 => 5,
+        VirtualKeyCode::Key7 => 6,
+        VirtualKeyCode::Key8 => 7,
+        VirtualKeyCode::Key9 => 8,
+        VirtualKeyCode::Key0 => 9,
+        _ => 0,
     }
 }
 

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -256,22 +256,20 @@ impl Window {
                                 sim.toggle_no_clip();
                             }
                         }
-                        VirtualKeyCode::Key1 | VirtualKeyCode::Key2 | VirtualKeyCode::Key3
-                        | VirtualKeyCode::Key4 | VirtualKeyCode::Key5 | VirtualKeyCode::Key6
-                        | VirtualKeyCode::Key7 | VirtualKeyCode::Key8 | VirtualKeyCode::Key9
-                        | VirtualKeyCode::Key0 => {
-                            if state == ElementState::Pressed {
-                                if let Some(sim) = self.sim.as_mut() {
-                                    sim.select_material(number_key_to_index(key));
-                                }
-                            }
-                        }
                         VirtualKeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);
                             mouse_captured = false;
                         }
-                        _ => {}
+                        _ => {
+                            if let Some(material_idx) = number_key_to_index(key) {
+                                if state == ElementState::Pressed {
+                                    if let Some(sim) = self.sim.as_mut() {
+                                        sim.select_material(material_idx);
+                                    }
+                                }
+                            }
+                        }
                     },
                     WindowEvent::Focused(focused) => {
                         if !focused {
@@ -366,19 +364,19 @@ impl Window {
     }
 }
 
-fn number_key_to_index(key: VirtualKeyCode) -> usize {
+fn number_key_to_index(key: VirtualKeyCode) -> Option<usize> {
     match key {
-        VirtualKeyCode::Key1 => 0,
-        VirtualKeyCode::Key2 => 1,
-        VirtualKeyCode::Key3 => 2,
-        VirtualKeyCode::Key4 => 3,
-        VirtualKeyCode::Key5 => 4,
-        VirtualKeyCode::Key6 => 5,
-        VirtualKeyCode::Key7 => 6,
-        VirtualKeyCode::Key8 => 7,
-        VirtualKeyCode::Key9 => 8,
-        VirtualKeyCode::Key0 => 9,
-        _ => 0,
+        VirtualKeyCode::Key1 => Some(0),
+        VirtualKeyCode::Key2 => Some(1),
+        VirtualKeyCode::Key3 => Some(2),
+        VirtualKeyCode::Key4 => Some(3),
+        VirtualKeyCode::Key5 => Some(4),
+        VirtualKeyCode::Key6 => Some(5),
+        VirtualKeyCode::Key7 => Some(6),
+        VirtualKeyCode::Key8 => Some(7),
+        VirtualKeyCode::Key9 => Some(8),
+        VirtualKeyCode::Key0 => Some(9),
+        _ => None,
     }
 }
 

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -58,6 +58,10 @@ pub struct Sim {
     place_block_pressed: bool,
     /// Whether the break-block button has been pressed since the last step
     break_block_pressed: bool,
+
+    selected_material: Material,
+    material_palette: [Material; 10],
+
     prediction: PredictedMotion,
     local_character_controller: LocalCharacterController,
 }
@@ -87,6 +91,10 @@ impl Sim {
             jump_held: false,
             place_block_pressed: false,
             break_block_pressed: false,
+            selected_material: Material::WoodPlanks,
+            material_palette: [Material::WoodPlanks, Material::Grass, Material::Dirt,
+                Material::Sand, Material::Snow, Material::WhiteBrick,
+                Material::GreyBrick, Material::Basalt, Material::Water, Material::Lava],
             prediction: PredictedMotion::new(proto::Position {
                 node: NodeId::ROOT,
                 local: na::one(),
@@ -136,6 +144,14 @@ impl Sim {
 
     pub fn set_place_block_pressed_true(&mut self) {
         self.place_block_pressed = true;
+    }
+
+    pub fn select_material(&mut self, idx: usize) {
+        self.selected_material = if idx < self.material_palette.len() {
+            self.material_palette[idx]
+        } else {
+            self.material_palette[0]
+        };
     }
 
     pub fn set_break_block_pressed_true(&mut self) {
@@ -476,7 +492,7 @@ impl Sim {
         };
 
         let material = if placing {
-            Material::WoodPlanks
+            self.selected_material
         } else {
             Material::Void
         };

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -21,6 +21,19 @@ use common::{
     EntityId, GraphEntities, SimConfig, Step,
 };
 
+const MATERIAL_PALETTE: [Material; 10] = [
+    Material::WoodPlanks,
+    Material::Grass,
+    Material::Dirt,
+    Material::Sand,
+    Material::Snow,
+    Material::WhiteBrick,
+    Material::GreyBrick,
+    Material::Basalt,
+    Material::Water,
+    Material::Lava,
+];
+
 /// Game state
 pub struct Sim {
     // World state
@@ -60,7 +73,6 @@ pub struct Sim {
     break_block_pressed: bool,
 
     selected_material: Material,
-    material_palette: [Material; 10],
 
     prediction: PredictedMotion,
     local_character_controller: LocalCharacterController,
@@ -92,9 +104,6 @@ impl Sim {
             place_block_pressed: false,
             break_block_pressed: false,
             selected_material: Material::WoodPlanks,
-            material_palette: [Material::WoodPlanks, Material::Grass, Material::Dirt,
-                Material::Sand, Material::Snow, Material::WhiteBrick,
-                Material::GreyBrick, Material::Basalt, Material::Water, Material::Lava],
             prediction: PredictedMotion::new(proto::Position {
                 node: NodeId::ROOT,
                 local: na::one(),
@@ -147,11 +156,7 @@ impl Sim {
     }
 
     pub fn select_material(&mut self, idx: usize) {
-        self.selected_material = if idx < self.material_palette.len() {
-            self.material_palette[idx]
-        } else {
-            self.material_palette[0]
-        };
+        self.selected_material = *MATERIAL_PALETTE.get(idx).unwrap_or(&MATERIAL_PALETTE[0]);
     }
 
     pub fn set_break_block_pressed_true(&mut self) {

--- a/common/src/character_controller/mod.rs
+++ b/common/src/character_controller/mod.rs
@@ -34,7 +34,7 @@ pub fn run_character_step(
             graph,
             radius: sim_config.character.character_radius,
         },
-        up: graph.get_relative_up(position).unwrap(), // up: graph.get_relative_up(position).unwrap_or(na::Vector3::x_axis()),
+        up: graph.get_relative_up(position).unwrap(),
         dt_seconds,
         movement_input: sanitize_motion_input(input.movement),
         jump_input: input.jump,

--- a/common/src/character_controller/mod.rs
+++ b/common/src/character_controller/mod.rs
@@ -34,7 +34,7 @@ pub fn run_character_step(
             graph,
             radius: sim_config.character.character_radius,
         },
-        up: graph.get_relative_up(position).unwrap(),
+        up: graph.get_relative_up(position).unwrap(), // up: graph.get_relative_up(position).unwrap_or(na::Vector3::x_axis()),
         dt_seconds,
         movement_input: sanitize_motion_input(input.movement),
         jump_input: input.jump,


### PR DESCRIPTION
The ten materials that can be selected can be edited by changing the field material_palette in client/src/sim.rs.

The change in common/src/character_controller/mod.rs was necessary for the server not to crash when running on my machine.

As of now, the number keys map to the following materials:
1: Wood Planks
2: Grass
3: Dirt
4: Sand
5: Snow
6: White Brick
7: Grey Brick
8: Basalt
9: Water
0: Lava