### PR TITLE
Define a simpler row-major entity encoding for saves

### DIFF
--- a/save/src/protos.proto
+++ b/save/src/protos.proto
@@ -13,21 +13,9 @@ message Character {
 }
 
 message EntityNode {
-    // Entities whose origins lie within this node
-    repeated Archetype archetypes = 1;
-}
-
-// A set of entities, all of which have the same components
-message Archetype {
-    // Entity IDs
-    repeated fixed64 entities = 1;
-
-    // Type of components stored in each column
-    repeated ComponentType component_types = 2;
-
-    // Each data represents a dense column of component values of the type identified by the
-    // component_type at the same index as the column
-    repeated bytes component_data = 3;
+    // Entities whose origins lie within this node, each encoded as:
+    // { entity: u64, component_count: varint, components: [{ type: varint, length: varint, data: [u8] }] }
+    repeated bytes entities = 1;
 }
 
 message VoxelNode {
@@ -46,6 +34,6 @@ message Chunk {
 enum ComponentType {
     // 4x4 matrix of f32s
     POSITION = 0;
-    // Varint length tag followed by UTF-8 text
+    // UTF-8 text
     NAME = 1;
 }

--- a/save/src/protos.rs
+++ b/save/src/protos.rs
@@ -15,24 +15,10 @@ pub struct Character {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EntityNode {
-    /// Entities whose origins lie within this node
-    #[prost(message, repeated, tag = "1")]
-    pub archetypes: ::prost::alloc::vec::Vec<Archetype>,
-}
-/// A set of entities, all of which have the same components
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Archetype {
-    /// Entity IDs
-    #[prost(fixed64, repeated, tag = "1")]
-    pub entities: ::prost::alloc::vec::Vec<u64>,
-    /// Type of components stored in each column
-    #[prost(enumeration = "ComponentType", repeated, tag = "2")]
-    pub component_types: ::prost::alloc::vec::Vec<i32>,
-    /// Each data represents a dense column of component values of the type identified by the
-    /// component_type at the same index as the column
-    #[prost(bytes = "vec", repeated, tag = "3")]
-    pub component_data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// Entities whose origins lie within this node, each encoded as:
+    /// { entity: u64, component_count: varint, components: \[{ type: varint, length: varint, data: [u8\] }] }
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub entities: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -56,7 +42,7 @@ pub struct Chunk {
 pub enum ComponentType {
     /// 4x4 matrix of f32s
     Position = 0,
-    /// Varint length tag followed by UTF-8 text
+    /// UTF-8 text
     Name = 1,
 }
 impl ComponentType {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR Zlib"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-postcard = { version = "1.0.4", default-features = false }
+postcard = { version = "1.0.4", default-features = false, features = ["use-std"] }
 common = { path = "../common" }
 tracing = "0.1.10"
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "time", "macros", "sync"] }

--- a/server/src/postcard_helpers.rs
+++ b/server/src/postcard_helpers.rs
@@ -25,3 +25,10 @@ impl postcard::ser_flavors::Flavor for ExtendVec<'_> {
         Ok(())
     }
 }
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SaveEntity {
+    /// [`EntityId`] value, represented as an array to avoid wastefully varint encoding random bytes
+    pub entity: [u8; 8],
+    pub components: Vec<(u64, Vec<u8>)>,
+}


### PR DESCRIPTION
Nodes are unlikely to ever have enough entities in them for column-major representation to be worth the trouble to implement. As a bonus, this representation should be compatible with postcard.

We can easily switch this up again in the future if needed thanks to protobuf schema evolution.