### PR TITLE
Move camera to the top of the player's collider

### DIFF
--- a/client/src/local_character_controller.rs
+++ b/client/src/local_character_controller.rs
@@ -21,12 +21,8 @@ impl LocalCharacterController {
         }
     }
 
-    /// Get the current position with orientation applied to it
-    pub fn oriented_position(&self) -> Position {
-        Position {
-            node: self.position.node,
-            local: self.position.local * self.orientation.to_homogeneous(),
-        }
+    pub fn position(&self) -> Position {
+        self.position
     }
 
     pub fn orientation(&self) -> na::UnitQuaternion<f32> {

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -437,7 +437,15 @@ impl Sim {
     }
 
     pub fn view(&self) -> Position {
-        self.local_character_controller.oriented_position()
+        let mut pos = self.local_character_controller.position();
+        let up = self.graph.get_relative_up(&pos).unwrap();
+        pos.local *= common::math::translate_along(
+            &(up.as_ref() * (self.cfg.character.character_radius - 1e-3)),
+        ) * self
+            .local_character_controller
+            .orientation()
+            .to_homogeneous();
+        pos
     }
 
     /// Destroy all aspects of an entity


### PR DESCRIPTION
~This moves the viewpoint before applying orientation, so looking down is equivalent to face-planting, which isn't ideal.~ Adjusting the viewpoint by `Graph::get_relative_up` after rotation so the camera rotates in-place makes more sense, but suffers from sharp discontinuities when crossing between nodes, presumably due to relying on the discrete `NodeState::up_direction`. We should come up with a properly smooth notion of "up".