### PR TITLE
Use `c_char` instead of `i8` where necessary

### DIFF
--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -1,6 +1,6 @@
 //! Common state shared throughout the graphics system
 
-use std::ffi::CStr;
+use std::ffi::{c_char, CStr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{fs, io, ptr};
@@ -111,7 +111,7 @@ impl Base {
                     .device_name
                     .iter()
                     .position(|&x| x == 0)
-                    .unwrap()] as *const [i8] as *const [u8]),
+                    .unwrap()] as *const [c_char] as *const [u8]),
             )
             .unwrap();
             info!(name, "selected device");

--- a/client/src/graphics/voxels/surface_extraction.rs
+++ b/client/src/graphics/voxels/surface_extraction.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_char;
 use std::{mem, ptr};
 
 use ash::{vk, Device};
@@ -109,7 +110,7 @@ impl SurfaceExtraction {
                 .map_entries(&specialization_map_entries)
                 .data(as_bytes(&WORKGROUP_SIZE));
 
-            let p_name = b"main\0".as_ptr() as *const i8;
+            let p_name = b"main\0".as_ptr() as *const c_char;
             let mut pipelines = device
                 .create_compute_pipelines(
                     gfx.pipeline_cache,


### PR DESCRIPTION
Aarch64 Linux has [`c_char` as `u8` rather than `i8`](https://doc.rust-lang.org/1.75.0/src/core/ffi/mod.rs.html#99) as the code expects. This fixes the build there.