### PR TITLE
Add a cursor to make placing/breaking blocks easier

### DIFF
--- a/client/shaders/fog.frag
+++ b/client/shaders/fog.frag
@@ -16,6 +16,12 @@ void main() {
     float view_length = length(view_pos);
     // Convert to true hyperbolic distance, taking care to respect atanh's domain
     float dist = view_length >= 1.0 ? INFINITY : atanh(view_length);
-    // Exponential^k fog
-    fog = vec4(0.5, 0.65, 0.9, exp(-pow(dist * fog_density, 5)));
+    if (dot(scaled_view_pos.xy, scaled_view_pos.xy) < 0.0001) {
+        // Temporary code to add a cursor in the center of the window for placing/breaking blocks
+        // TODO: Replace with a UI element when UI exists
+        fog = vec4(0.0, 0.0, 0.0, 0.0);
+    } else {
+        // Exponential^k fog
+        fog = vec4(0.5, 0.65, 0.9, exp(-pow(dist * fog_density, 5)));
+    }
 }


### PR DESCRIPTION
This PR hijacks the fog shader to also add a cursor in the center of the viewport to allow players to target where they place and break blocks.

This introduces an `if` statement to the fragment shader, and branching in shaders is generally bad for performance in my understanding, but given its simplicity, I believe that the shader compiler should be smart enough to optimize this in a way that acts as though such branching basically does not exist.