### PR TITLE
Add the list of Vulkan instance layers to the log

### DIFF
--- a/client/src/graphics/core.rs
+++ b/client/src/graphics/core.rs
@@ -52,6 +52,15 @@ impl Core {
                 info!("vulkan debugging unavailable");
             }
 
+            let instance_layers = entry.enumerate_instance_layer_properties().unwrap();
+            tracing::info!(
+                "Vulkan instance layers: {:?}",
+                instance_layers
+                    .iter()
+                    .map(|layer| CStr::from_ptr(layer.layer_name.as_ptr()).to_str().unwrap())
+                    .collect::<Vec<_>>()
+            );
+
             let name = cstr!("hypermine");
 
             let app_info = vk::ApplicationInfo::builder()


### PR DESCRIPTION
A potential failure case that prevents Hypermine from loading is the use of Vulkan layers that violate the Vulkan specifications. To assist in debugging, we add the list of Vulkan instance layers to the console log while Hypermine is running.

While device layers may also exist, they have been deprecated for a long enough time that I'm hopeful we won't have to include these in the logs as well, although this does run the risk of a buggy device layer going unnoticed.