### PR TITLE
Update winit to 0.29.10

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,9 +14,9 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.37.1", features = ["loaded"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "88abd75e41d04c3a4199d95f581cb135f5962844" }
-winit = "0.28.1"
+winit = { version = "0.29.10", features = ["rwh_05"] }
 ash-window = "0.12.0"
-raw-window-handle = "0.5.0"
+raw-window-handle = { version = "0.5.0", features = ["std"] }
 directories = "5.0.1"
 vk-shader-macros = "0.2.5"
 nalgebra = { workspace = true }


### PR DESCRIPTION
winit now defaults to raw-window-handle 0.6, but ash-window is not yet compatible with this version of raw-window-handle. Fortunately, the `rwh_05` feature allows the use of the older version of raw-window-handle.

A few notable changes:
- winit did an overhaul of keyboard input, so the use of `virtual_keycode` had to be replaced with `physical_key` or `logical_key`. I guessed that `physical_key` was better.
- `Event::MainEventsCleared` was removed from winit, so I needed to switch to `AboutToWait`. However, I used https://github.com/rust-windowing/winit/blob/7bed5eecfdcbde16e5619fd137f0229e8e7e8ed4/examples/request_redraw.rs as an example, which had me make the additional change of putting all the frame logic in `WindowEvent::RedrawRequested` and using `self.window.request_redraw` in `Event::AboutToWait`. I'm not certain this is what we want for Hypermine, but I didn't notice any issues on my end when testing it.

(I meant to re-open #325, but GitHub disallowed it. If it still has problems, I might leave this PR open as a draft instead of closing it.)

EDIT: It looks like all CI checks have passed this time. This PR should be ready to review.