### PR TITLE
Update metrics crate to 0.22.1

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,7 +37,7 @@ hecs = { workspace = true }
 rcgen = { version = "0.11.0", default-features = false }
 memoffset = "0.9"
 gltf = { version = "1.0.0", default-features = false, features = ["utils"] }
-metrics = { version = "0.21.0" }
+metrics = "0.22.1"
 hdrhistogram = { version = "7", default-features = false }
 save = { path = "../save" }
 

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -314,8 +314,8 @@ impl Draw {
                 self.gfx.limits.timestamp_period as f64 * 1e-9 * (queries[1] - queries[0]) as f64;
             let after_seconds =
                 self.gfx.limits.timestamp_period as f64 * 1e-9 * (queries[2] - queries[1]) as f64;
-            histogram!("frame.gpu.draw", draw_seconds);
-            histogram!("frame.gpu.after_draw", after_seconds);
+            histogram!("frame.gpu.draw").record(draw_seconds);
+            histogram!("frame.gpu.after_draw").record(after_seconds);
         }
 
         device
@@ -516,7 +516,7 @@ impl Draw {
             .unwrap();
         state.used = true;
         state.in_flight = true;
-        histogram!("frame.cpu", draw_started.elapsed());
+        histogram!("frame.cpu").record(draw_started.elapsed());
     }
 
     /// Wait for all drawing to complete

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -126,10 +126,7 @@ impl Voxels {
             &view,
             f64::from(self.config.local_simulation.view_distance),
         );
-        histogram!(
-            "frame.cpu.voxels.graph_traversal",
-            graph_traversal_started.elapsed()
-        );
+        histogram!("frame.cpu.voxels.graph_traversal").record(graph_traversal_started.elapsed());
         // Sort nodes by distance to the view to prioritize loading closer data and improve early Z
         // performance
         let view_pos = view.local * math::origin();
@@ -252,7 +249,7 @@ impl Voxels {
             cmd,
             &extractions,
         );
-        histogram!("frame.cpu.voxels.node_scan", node_scan_started.elapsed());
+        histogram!("frame.cpu.voxels.node_scan").record(node_scan_started.elapsed());
     }
 
     pub unsafe fn draw(
@@ -277,7 +274,7 @@ impl Voxels {
         for chunk in &frame.drawn {
             self.draw.draw(device, cmd, &self.surfaces, chunk.0);
         }
-        histogram!("frame.cpu.voxels.draw", started.elapsed());
+        histogram!("frame.cpu.voxels.draw").record(started.elapsed());
     }
 
     pub unsafe fn destroy(&mut self, device: &Device) {

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -11,7 +11,7 @@ pub fn init() -> Arc<Recorder> {
     let recorder = Arc::new(Recorder {
         histograms: RwLock::new(HashMap::new()),
     });
-    metrics::set_boxed_recorder(Box::new(ArcRecorder(recorder.clone()))).unwrap();
+    metrics::set_global_recorder(ArcRecorder(recorder.clone())).unwrap();
     recorder
 }
 
@@ -68,15 +68,27 @@ impl metrics::Recorder for ArcRecorder {
         todo!()
     }
 
-    fn register_counter(&self, _key: &metrics::Key) -> metrics::Counter {
+    fn register_counter(
+        &self,
+        _key: &metrics::Key,
+        _metadata: &metrics::Metadata<'_>,
+    ) -> metrics::Counter {
         todo!()
     }
 
-    fn register_gauge(&self, _key: &metrics::Key) -> metrics::Gauge {
+    fn register_gauge(
+        &self,
+        _key: &metrics::Key,
+        _metadata: &metrics::Metadata<'_>,
+    ) -> metrics::Gauge {
         todo!()
     }
 
-    fn register_histogram(&self, key: &metrics::Key) -> metrics::Histogram {
+    fn register_histogram(
+        &self,
+        key: &metrics::Key,
+        _metadata: &metrics::Metadata<'_>,
+    ) -> metrics::Histogram {
         metrics::Histogram::from_arc(Arc::new(Handle {
             recorder: self.0.clone(),
             key: key.clone(),


### PR DESCRIPTION
This PR was mainly created by comparing https://github.com/metrics-rs/metrics/blob/metrics-v0.21.1/metrics/examples/basic.rs to https://github.com/metrics-rs/metrics/blob/metrics-v0.22.1/metrics/examples/basic.rs whenever there were compiler errors.