### PR TITLE
Update rcgen to 0.12.1

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,7 +34,7 @@ futures-util = "0.3.1"
 rustls = { version = "0.21.7", features = ["dangerous_configuration"] }
 webpki = "0.22.0"
 hecs = { workspace = true }
-rcgen = { version = "0.11.0", default-features = false }
+rcgen = { version = "0.12.1", default-features = false, features = ["ring"] }
 memoffset = "0.9"
 gltf = { version = "1.0.0", default-features = false, features = ["utils"] }
 metrics = { version = "0.21.0" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,7 @@ quinn = { workspace = true }
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 toml = { workspace = true }
 anyhow = "1.0.26"
-rcgen = { version = "0.11.0", default-features = false }
+rcgen = { version = "0.12.1", default-features = false, features = ["ring"] }
 hostname = "0.3.0"
 futures = "0.3.1"
 hecs = { workspace = true }


### PR DESCRIPTION
Based on https://github.com/rustls/rcgen/blob/main/rcgen/CHANGELOG.md, `ring` was made into an optional dependency with `aws-lc-rs` as an alternative choice. The create now requires either `ring` or `aws-lc-rs` to be specified as a feature (with `ring` as a default feature).

To be consistent with previous functionality, this PR uses `ring`.