### PR TITLE
Implement accurate margins between adjacent chunks

### DIFF
--- a/client/shaders/surface-extraction/extract.comp
+++ b/client/shaders/surface-extraction/extract.comp
@@ -76,6 +76,9 @@ bool find_face(out Face info) {
     // Flip face around if the neighbor is the solid one
     info.inward = self_mat == 0;
     info.material = self_mat | neighbor_mat;
+    // If self or neighbor is a void margin, then no surface should be generated, as any surface
+    // that would be rendered is the responsibility of the adjacent chunk.
+    if ((self_mat == 0 && info.voxel[info.axis] == dimension) || (neighbor_mat == 0 && neighbor[info.axis] == -1)) return false;
     return (neighbor_mat == 0) != (self_mat == 0);
 }
 

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -495,7 +495,7 @@ impl Sim {
                 hit.chunk,
                 hit.voxel_coords,
                 hit.face_axis,
-                hit.face_direction,
+                hit.face_sign,
             )?
         } else {
             (hit.chunk, hit.voxel_coords)

--- a/common/src/chunk_collision.rs
+++ b/common/src/chunk_collision.rs
@@ -1,7 +1,8 @@
 use crate::{
     collision_math::Ray,
     math,
-    node::{ChunkLayout, Coords, VoxelAABB, VoxelData},
+    node::{ChunkLayout, VoxelAABB, VoxelData},
+    voxel_math::Coords,
     world::Material,
 };
 

--- a/common/src/chunk_ray_casting.rs
+++ b/common/src/chunk_ray_casting.rs
@@ -1,7 +1,8 @@
 use crate::{
     collision_math::Ray,
     math,
-    node::{ChunkLayout, CoordAxis, CoordDirection, Coords, VoxelAABB, VoxelData},
+    node::{ChunkLayout, VoxelAABB, VoxelData},
+    voxel_math::{CoordAxis, CoordDirection, Coords},
     world::Material,
 };
 

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -88,9 +88,10 @@ mod tests {
         collision_math::Ray,
         dodeca::{self, Side, Vertex},
         graph::{Graph, NodeId},
-        node::{populate_fresh_nodes, Coords, VoxelData},
+        node::{populate_fresh_nodes, VoxelData},
         proto::Position,
         traversal::{ensure_nearby, nearby_nodes},
+        voxel_math::Coords,
         world::Material,
     };
 

--- a/common/src/graph_ray_casting.rs
+++ b/common/src/graph_ray_casting.rs
@@ -5,7 +5,7 @@ use crate::{
     node::{Chunk, ChunkId},
     proto::Position,
     traversal::RayTraverser,
-    voxel_math::{CoordAxis, CoordDirection, Coords},
+    voxel_math::{CoordAxis, CoordSign, Coords},
 };
 
 /// Performs ray casting against the voxels in the `DualGraph`
@@ -55,7 +55,7 @@ pub fn ray_cast(
                 chunk,
                 voxel_coords: hit.voxel_coords,
                 face_axis: hit.face_axis,
-                face_direction: hit.face_direction,
+                face_sign: hit.face_sign,
             })
         });
     }
@@ -82,5 +82,5 @@ pub struct GraphCastHit {
     pub face_axis: CoordAxis,
 
     /// The direction along `face_axis` corresponding to the outside of the face that was hit.
-    pub face_direction: CoordDirection,
+    pub face_sign: CoordSign,
 }

--- a/common/src/graph_ray_casting.rs
+++ b/common/src/graph_ray_casting.rs
@@ -2,9 +2,10 @@ use crate::{
     chunk_ray_casting::chunk_ray_cast,
     collision_math::Ray,
     graph::Graph,
-    node::{Chunk, ChunkId, CoordAxis, CoordDirection, Coords},
+    node::{Chunk, ChunkId},
     proto::Position,
     traversal::RayTraverser,
+    voxel_math::{CoordAxis, CoordDirection, Coords},
 };
 
 /// Performs ray casting against the voxels in the `DualGraph`

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod graph_collision;
 mod graph_entities;
 pub mod graph_ray_casting;
 pub mod lru_slab;
+mod margins;
 pub mod math;
 pub mod node;
 mod plane;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -29,6 +29,7 @@ pub mod proto;
 mod sim_config;
 pub mod terraingen;
 pub mod traversal;
+pub mod voxel_math;
 pub mod world;
 pub mod worldgen;
 

--- a/common/src/margins.rs
+++ b/common/src/margins.rs
@@ -1,0 +1,224 @@
+use crate::{
+    dodeca::Vertex,
+    math,
+    node::VoxelData,
+    voxel_math::{ChunkAxisPermutation, ChunkDirection, CoordAxis, CoordSign, Coords},
+};
+
+/// Updates the margins of both `voxels` and `neighbor_voxels` at the side they meet at.
+/// It is assumed that `voxels` corresponds to a chunk that lies at `vertex` and that
+/// `neighbor_voxels` is at direction `direction` from `voxels`.
+pub fn fix_margins(
+    dimension: u8,
+    vertex: Vertex,
+    voxels: &mut VoxelData,
+    direction: ChunkDirection,
+    neighbor_voxels: &mut VoxelData,
+) {
+    let neighbor_axis_permutation = neighbor_axis_permutation(vertex, direction);
+
+    let margin_coord = CoordsWithMargins::margin_coord(dimension, direction.sign);
+    let edge_coord = CoordsWithMargins::edge_coord(dimension, direction.sign);
+    let voxel_data = voxels.data_mut(dimension);
+    let neighbor_voxel_data = neighbor_voxels.data_mut(dimension);
+    for j in 0..dimension {
+        for i in 0..dimension {
+            // Determine coordinates of the edge voxel (to read from) and the margin voxel (to write to)
+            // in voxel_data's perspective. To convert to neighbor_voxel_data's perspective, left-multiply
+            // by neighbor_axis_permutation.
+            let coords_of_edge_voxel = CoordsWithMargins(math::tuv_to_xyz(
+                direction.axis as usize,
+                [edge_coord, i + 1, j + 1],
+            ));
+            let coords_of_margin_voxel = CoordsWithMargins(math::tuv_to_xyz(
+                direction.axis as usize,
+                [margin_coord, i + 1, j + 1],
+            ));
+
+            // Use neighbor_voxel_data to set margins of voxel_data
+            voxel_data[coords_of_margin_voxel.to_index(dimension)] = neighbor_voxel_data
+                [(neighbor_axis_permutation * coords_of_edge_voxel).to_index(dimension)];
+
+            // Use voxel_data to set margins of neighbor_voxel_data
+            neighbor_voxel_data
+                [(neighbor_axis_permutation * coords_of_margin_voxel).to_index(dimension)] =
+                voxel_data[coords_of_edge_voxel.to_index(dimension)];
+        }
+    }
+}
+
+/// Updates the margins of a given VoxelData to match the voxels they're next to. This is a good assumption to start
+/// with before taking into account neighboring chunks because it means that no surface will be present on the boundaries
+/// of the chunk, resulting in the least rendering. This is also generally accurate when the neighboring chunks are solid.
+pub fn initialize_margins(dimension: u8, voxels: &mut VoxelData) {
+    // If voxels is solid, the margins are already set up the way they should be.
+    if voxels.is_solid() {
+        return;
+    }
+
+    for direction in ChunkDirection::iter() {
+        let margin_coord = CoordsWithMargins::margin_coord(dimension, direction.sign);
+        let edge_coord = CoordsWithMargins::edge_coord(dimension, direction.sign);
+        let chunk_data = voxels.data_mut(dimension);
+        for j in 0..dimension {
+            for i in 0..dimension {
+                // Determine coordinates of the edge voxel (to read from) and the margin voxel (to write to).
+                let coords_of_edge_voxel = CoordsWithMargins(math::tuv_to_xyz(
+                    direction.axis as usize,
+                    [edge_coord, i + 1, j + 1],
+                ));
+                let coords_of_margin_voxel = CoordsWithMargins(math::tuv_to_xyz(
+                    direction.axis as usize,
+                    [margin_coord, i + 1, j + 1],
+                ));
+
+                chunk_data[coords_of_margin_voxel.to_index(dimension)] =
+                    chunk_data[coords_of_edge_voxel.to_index(dimension)];
+            }
+        }
+    }
+}
+
+fn neighbor_axis_permutation(vertex: Vertex, direction: ChunkDirection) -> ChunkAxisPermutation {
+    match direction.sign {
+        CoordSign::Plus => vertex.chunk_axis_permutations()[direction.axis as usize],
+        CoordSign::Minus => ChunkAxisPermutation::IDENTITY,
+    }
+}
+
+/// Coordinates for a discrete voxel within a chunk, including margins
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CoordsWithMargins(pub [u8; 3]);
+
+impl CoordsWithMargins {
+    /// Returns the array index in `VoxelData` corresponding to these coordinates
+    pub fn to_index(self, chunk_size: u8) -> usize {
+        let chunk_size_with_margin = chunk_size as usize + 2;
+        (self.0[0] as usize)
+            + (self.0[1] as usize) * chunk_size_with_margin
+            + (self.0[2] as usize) * chunk_size_with_margin.pow(2)
+    }
+
+    /// Returns the x, y, or z coordinate that would correspond to the margin in the direction of `sign`
+    pub fn margin_coord(chunk_size: u8, sign: CoordSign) -> u8 {
+        match sign {
+            CoordSign::Plus => chunk_size + 1,
+            CoordSign::Minus => 0,
+        }
+    }
+
+    /// Returns the x, y, or z coordinate that would correspond to the voxel meeting the chunk boundary in the direction of `sign`
+    pub fn edge_coord(chunk_size: u8, sign: CoordSign) -> u8 {
+        match sign {
+            CoordSign::Plus => chunk_size,
+            CoordSign::Minus => 1,
+        }
+    }
+}
+
+impl From<Coords> for CoordsWithMargins {
+    #[inline]
+    fn from(value: Coords) -> Self {
+        CoordsWithMargins([value.0[0] + 1, value.0[1] + 1, value.0[2] + 1])
+    }
+}
+
+impl std::ops::Index<CoordAxis> for CoordsWithMargins {
+    type Output = u8;
+
+    #[inline]
+    fn index(&self, coord_axis: CoordAxis) -> &u8 {
+        self.0.index(coord_axis as usize)
+    }
+}
+
+impl std::ops::IndexMut<CoordAxis> for CoordsWithMargins {
+    #[inline]
+    fn index_mut(&mut self, coord_axis: CoordAxis) -> &mut u8 {
+        self.0.index_mut(coord_axis as usize)
+    }
+}
+
+impl std::ops::Mul<CoordsWithMargins> for ChunkAxisPermutation {
+    type Output = CoordsWithMargins;
+
+    fn mul(self, rhs: CoordsWithMargins) -> Self::Output {
+        let mut result = CoordsWithMargins([0; 3]);
+        for axis in CoordAxis::iter() {
+            result[self[axis]] = rhs[axis];
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{dodeca::Vertex, voxel_math::Coords, world::Material};
+
+    use super::*;
+
+    #[test]
+    fn test_fix_margins() {
+        // This test case can set up empirically by placing blocks and printing their coordinates to confirm which
+        // coordinates are adjacent to each other.
+
+        // `voxels` lives at vertex F
+        let mut voxels = VoxelData::Solid(Material::Void);
+        voxels.data_mut(12)[Coords([11, 2, 10]).to_index(12)] = Material::WoodPlanks;
+
+        // `neighbor_voxels` lives at vertex J
+        let mut neighbor_voxels = VoxelData::Solid(Material::Void);
+        neighbor_voxels.data_mut(12)[Coords([2, 10, 11]).to_index(12)] = Material::Grass;
+
+        // Sanity check that voxel adjacencies are as expected. If the test fails here, it's likely that "dodeca.rs" was
+        // redesigned, and the test itself will have to be fixed, rather than the code being tested.
+        assert_eq!(Vertex::F.adjacent_vertices()[0], Vertex::J);
+        assert_eq!(Vertex::J.adjacent_vertices()[2], Vertex::F);
+
+        // Sanity check that voxels are populated as expected, using `CoordsWithMargins` for consistency with the actual
+        // test case.
+        assert_eq!(
+            voxels.get(CoordsWithMargins([12, 3, 11]).to_index(12)),
+            Material::WoodPlanks
+        );
+        assert_eq!(
+            neighbor_voxels.get(CoordsWithMargins([3, 11, 12]).to_index(12)),
+            Material::Grass
+        );
+
+        fix_margins(
+            12,
+            Vertex::F,
+            &mut voxels,
+            ChunkDirection::PLUS_X,
+            &mut neighbor_voxels,
+        );
+
+        // Actual verification: Check that the margins were set correctly
+        assert_eq!(
+            voxels.get(CoordsWithMargins([13, 3, 11]).to_index(12)),
+            Material::Grass
+        );
+        assert_eq!(
+            neighbor_voxels.get(CoordsWithMargins([3, 11, 13]).to_index(12)),
+            Material::WoodPlanks
+        );
+    }
+
+    #[test]
+    fn test_initialize_margins() {
+        let mut voxels = VoxelData::Solid(Material::Void);
+        voxels.data_mut(12)[Coords([11, 2, 10]).to_index(12)] = Material::WoodPlanks;
+        assert_eq!(
+            voxels.get(CoordsWithMargins([12, 3, 11]).to_index(12)),
+            Material::WoodPlanks
+        );
+
+        initialize_margins(12, &mut voxels);
+
+        assert_eq!(
+            voxels.get(CoordsWithMargins([13, 3, 11]).to_index(12)),
+            Material::WoodPlanks
+        );
+    }
+}

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -9,6 +9,7 @@ use crate::dodeca::Vertex;
 use crate::graph::{Graph, NodeId};
 use crate::lru_slab::SlotId;
 use crate::proto::{BlockUpdate, Position, SerializedVoxelData};
+use crate::voxel_math::{CoordAxis, CoordDirection, Coords};
 use crate::world::Material;
 use crate::worldgen::NodeState;
 use crate::{math, Chunks};
@@ -227,34 +228,6 @@ impl IndexMut<ChunkId> for Graph {
     }
 }
 
-/// Coordinates for a discrete voxel within a chunk, not including margins
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Coords(pub [u8; 3]);
-
-impl Coords {
-    /// Returns the array index in `VoxelData` corresponding to these coordinates
-    pub fn to_index(&self, chunk_size: u8) -> usize {
-        let chunk_size_with_margin = chunk_size as usize + 2;
-        (self.0[0] as usize + 1)
-            + (self.0[1] as usize + 1) * chunk_size_with_margin
-            + (self.0[2] as usize + 1) * chunk_size_with_margin.pow(2)
-    }
-}
-
-impl Index<CoordAxis> for Coords {
-    type Output = u8;
-
-    fn index(&self, coord_axis: CoordAxis) -> &u8 {
-        self.0.index(coord_axis as usize)
-    }
-}
-
-impl IndexMut<CoordAxis> for Coords {
-    fn index_mut(&mut self, coord_axis: CoordAxis) -> &mut u8 {
-        self.0.index_mut(coord_axis as usize)
-    }
-}
-
 pub struct Node {
     pub state: NodeState,
     /// We can only populate chunks which lie within a cube of populated nodes, so nodes on the edge
@@ -447,66 +420,6 @@ fn populate_node(graph: &mut Graph, node: NodeId) {
             .unwrap_or_else(NodeState::root),
         chunks: Chunks::default(),
     });
-}
-
-/// Represents a particular axis in a voxel grid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CoordAxis {
-    X = 0,
-    Y = 1,
-    Z = 2,
-}
-
-/// Trying to convert a `usize` to a `CoordAxis` returns this struct if the provided
-/// `usize` is out-of-bounds
-#[derive(Debug, Clone, Copy)]
-pub struct CoordAxisOutOfBounds;
-
-impl CoordAxis {
-    /// Iterates through the the axes in ascending order
-    pub fn iter() -> impl ExactSizeIterator<Item = Self> {
-        [Self::X, Self::Y, Self::Z].into_iter()
-    }
-
-    /// Returns the pair axes orthogonal to the current axis
-    pub fn other_axes(self) -> [Self; 2] {
-        match self {
-            Self::X => [Self::Y, Self::Z],
-            Self::Y => [Self::Z, Self::X],
-            Self::Z => [Self::X, Self::Y],
-        }
-    }
-}
-
-impl TryFrom<usize> for CoordAxis {
-    type Error = CoordAxisOutOfBounds;
-
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::X),
-            1 => Ok(Self::Y),
-            2 => Ok(Self::Z),
-            _ => Err(CoordAxisOutOfBounds),
-        }
-    }
-}
-
-/// Represents a direction in a particular axis. This struct is meant to be used with a coordinate axis,
-/// so when paired with the X-axis, it represents the postitive X-direction when set to Plus and the
-/// negative X-direction when set to Minus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CoordDirection {
-    Plus = 1,
-    Minus = -1,
-}
-
-impl CoordDirection {
-    /// Iterates through the two possible coordinate directions
-    pub fn iter() -> impl ExactSizeIterator<Item = Self> {
-        [CoordDirection::Plus, CoordDirection::Minus]
-            .iter()
-            .copied()
-    }
 }
 
 /// Represents a discretized region in the voxel grid contained by an axis-aligned bounding box.

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -1,11 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dodeca,
-    graph::NodeId,
-    node::{ChunkId, Coords},
-    world::Material,
-    EntityId, SimConfig, Step,
+    dodeca, graph::NodeId, node::ChunkId, voxel_math::Coords, world::Material, EntityId, SimConfig,
+    Step,
 };
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/voxel_math.rs
+++ b/common/src/voxel_math.rs
@@ -1,0 +1,89 @@
+use std::ops::{Index, IndexMut};
+
+use serde::{Deserialize, Serialize};
+
+/// Represents a particular axis in a voxel grid
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoordAxis {
+    X = 0,
+    Y = 1,
+    Z = 2,
+}
+
+/// Trying to convert a `usize` to a `CoordAxis` returns this struct if the provided
+/// `usize` is out-of-bounds
+#[derive(Debug, Clone, Copy)]
+pub struct CoordAxisOutOfBounds;
+
+impl CoordAxis {
+    /// Iterates through the the axes in ascending order
+    pub fn iter() -> impl ExactSizeIterator<Item = Self> {
+        [Self::X, Self::Y, Self::Z].into_iter()
+    }
+
+    /// Returns the pair axes orthogonal to the current axis
+    pub fn other_axes(self) -> [Self; 2] {
+        match self {
+            Self::X => [Self::Y, Self::Z],
+            Self::Y => [Self::Z, Self::X],
+            Self::Z => [Self::X, Self::Y],
+        }
+    }
+}
+
+impl TryFrom<usize> for CoordAxis {
+    type Error = CoordAxisOutOfBounds;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::X),
+            1 => Ok(Self::Y),
+            2 => Ok(Self::Z),
+            _ => Err(CoordAxisOutOfBounds),
+        }
+    }
+}
+
+/// Represents a direction in a particular axis. This struct is meant to be used with a coordinate axis,
+/// so when paired with the X-axis, it represents the postitive X-direction when set to Plus and the
+/// negative X-direction when set to Minus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoordDirection {
+    Plus = 1,
+    Minus = -1,
+}
+
+impl CoordDirection {
+    /// Iterates through the two possible coordinate directions
+    pub fn iter() -> impl ExactSizeIterator<Item = Self> {
+        [CoordDirection::Plus, CoordDirection::Minus].into_iter()
+    }
+}
+
+/// Coordinates for a discrete voxel within a chunk, not including margins
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Coords(pub [u8; 3]);
+
+impl Coords {
+    /// Returns the array index in `VoxelData` corresponding to these coordinates
+    pub fn to_index(&self, chunk_size: u8) -> usize {
+        let chunk_size_with_margin = chunk_size as usize + 2;
+        (self.0[0] as usize + 1)
+            + (self.0[1] as usize + 1) * chunk_size_with_margin
+            + (self.0[2] as usize + 1) * chunk_size_with_margin.pow(2)
+    }
+}
+
+impl Index<CoordAxis> for Coords {
+    type Output = u8;
+
+    fn index(&self, coord_axis: CoordAxis) -> &u8 {
+        self.0.index(coord_axis as usize)
+    }
+}
+
+impl IndexMut<CoordAxis> for Coords {
+    fn index_mut(&mut self, coord_axis: CoordAxis) -> &mut u8 {
+        self.0.index_mut(coord_axis as usize)
+    }
+}

--- a/common/src/voxel_math.rs
+++ b/common/src/voxel_math.rs
@@ -48,15 +48,15 @@ impl TryFrom<usize> for CoordAxis {
 /// so when paired with the X-axis, it represents the postitive X-direction when set to Plus and the
 /// negative X-direction when set to Minus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CoordDirection {
+pub enum CoordSign {
     Plus = 1,
     Minus = -1,
 }
 
-impl CoordDirection {
+impl CoordSign {
     /// Iterates through the two possible coordinate directions
     pub fn iter() -> impl ExactSizeIterator<Item = Self> {
-        [CoordDirection::Plus, CoordDirection::Minus].into_iter()
+        [CoordSign::Plus, CoordSign::Minus].into_iter()
     }
 }
 

--- a/common/src/voxel_math.rs
+++ b/common/src/voxel_math.rs
@@ -2,6 +2,8 @@ use std::ops::{Index, IndexMut};
 
 use serde::{Deserialize, Serialize};
 
+use crate::dodeca::Side;
+
 /// Represents a particular axis in a voxel grid
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoordAxis {
@@ -60,30 +62,256 @@ impl CoordSign {
     }
 }
 
+impl std::ops::Mul for CoordSign {
+    type Output = CoordSign;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        match self == rhs {
+            true => CoordSign::Plus,
+            false => CoordSign::Minus,
+        }
+    }
+}
+
+impl std::ops::MulAssign for CoordSign {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
 /// Coordinates for a discrete voxel within a chunk, not including margins
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Coords(pub [u8; 3]);
 
 impl Coords {
     /// Returns the array index in `VoxelData` corresponding to these coordinates
-    pub fn to_index(&self, chunk_size: u8) -> usize {
+    pub fn to_index(self, chunk_size: u8) -> usize {
         let chunk_size_with_margin = chunk_size as usize + 2;
         (self.0[0] as usize + 1)
             + (self.0[1] as usize + 1) * chunk_size_with_margin
             + (self.0[2] as usize + 1) * chunk_size_with_margin.pow(2)
+    }
+
+    /// Returns the x, y, or z coordinate that would correspond to the voxel meeting the chunk boundary in the direction of `sign`
+    pub fn edge_coord(chunk_size: u8, sign: CoordSign) -> u8 {
+        match sign {
+            CoordSign::Plus => chunk_size - 1,
+            CoordSign::Minus => 0,
+        }
     }
 }
 
 impl Index<CoordAxis> for Coords {
     type Output = u8;
 
+    #[inline]
     fn index(&self, coord_axis: CoordAxis) -> &u8 {
         self.0.index(coord_axis as usize)
     }
 }
 
 impl IndexMut<CoordAxis> for Coords {
+    #[inline]
     fn index_mut(&mut self, coord_axis: CoordAxis) -> &mut u8 {
         self.0.index_mut(coord_axis as usize)
+    }
+}
+
+/// Represents one of the six main directions within a chunk: positive or negative x, y, and z.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkDirection {
+    pub axis: CoordAxis,
+    pub sign: CoordSign,
+}
+
+impl ChunkDirection {
+    pub const PLUS_X: Self = ChunkDirection {
+        axis: CoordAxis::X,
+        sign: CoordSign::Plus,
+    };
+    pub const PLUS_Y: Self = ChunkDirection {
+        axis: CoordAxis::Y,
+        sign: CoordSign::Plus,
+    };
+    pub const PLUS_Z: Self = ChunkDirection {
+        axis: CoordAxis::Z,
+        sign: CoordSign::Plus,
+    };
+    pub const MINUS_X: Self = ChunkDirection {
+        axis: CoordAxis::X,
+        sign: CoordSign::Minus,
+    };
+    pub const MINUS_Y: Self = ChunkDirection {
+        axis: CoordAxis::Y,
+        sign: CoordSign::Minus,
+    };
+    pub const MINUS_Z: Self = ChunkDirection {
+        axis: CoordAxis::Z,
+        sign: CoordSign::Minus,
+    };
+
+    pub fn iter() -> impl ExactSizeIterator<Item = ChunkDirection> {
+        [
+            Self::PLUS_X,
+            Self::PLUS_Y,
+            Self::PLUS_Z,
+            Self::MINUS_X,
+            Self::MINUS_Y,
+            Self::MINUS_Z,
+        ]
+        .into_iter()
+    }
+}
+
+/// Represents one of the 6 possible permutations a chunk's axes can have, useful for comparing the canonical sides of one chunk to an adjacent chunk.
+/// This is analogous to a 3x3 rotation/reflection matrix with a restricted domain.
+/// Note that it may make sense to define a more general `ChunkOrientation` class that takes three `ChunkDirection`s, to represent
+/// any cube rotation/reflection, but no use exists for it yet, so it has not yet been implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkAxisPermutation {
+    axes: [CoordAxis; 3],
+}
+
+impl ChunkAxisPermutation {
+    pub const IDENTITY: Self = ChunkAxisPermutation {
+        axes: [CoordAxis::X, CoordAxis::Y, CoordAxis::Z],
+    };
+
+    /// Constructs a `ChunkAxisPermutation` that, when left-multiplying a set of coordinates, moves from `from`'s reference
+    /// frame to `to`'s reference frame, where `from` and `to` are represented as three dodeca sides incident to a vertex
+    /// that determine the orientation of a chunk.
+    pub fn from_permutation(from: [Side; 3], to: [Side; 3]) -> Self {
+        assert!(from[0] != from[1] && from[0] != from[2] && from[1] != from[2]);
+        assert!(to[0] != to[1] && to[0] != to[2] && to[1] != to[2]);
+        ChunkAxisPermutation {
+            axes: from.map(|f| {
+                CoordAxis::try_from(
+                    to.iter()
+                        .position(|&t| f == t)
+                        .expect("from and to must have same set of sides"),
+                )
+                .unwrap()
+            }),
+        }
+    }
+}
+
+impl Index<CoordAxis> for ChunkAxisPermutation {
+    type Output = CoordAxis;
+
+    fn index(&self, index: CoordAxis) -> &Self::Output {
+        &self.axes[index as usize]
+    }
+}
+
+impl std::ops::Mul<Coords> for ChunkAxisPermutation {
+    type Output = Coords;
+
+    fn mul(self, rhs: Coords) -> Self::Output {
+        let mut result = Coords([0; 3]);
+        for axis in CoordAxis::iter() {
+            result[self[axis]] = rhs[axis];
+        }
+        result
+    }
+}
+
+impl std::ops::Mul<ChunkDirection> for ChunkAxisPermutation {
+    type Output = ChunkDirection;
+
+    fn mul(self, rhs: ChunkDirection) -> Self::Output {
+        ChunkDirection {
+            axis: self[rhs.axis],
+            sign: rhs.sign,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dodeca::Vertex;
+
+    use super::*;
+
+    fn coords_to_vector3(coords: Coords) -> na::Vector3<i32> {
+        na::Vector3::new(
+            coords[CoordAxis::X] as i32,
+            coords[CoordAxis::Y] as i32,
+            coords[CoordAxis::Z] as i32,
+        )
+    }
+
+    fn coord_axis_to_vector3(coord_axis: CoordAxis) -> na::Vector3<i32> {
+        let mut vector = na::Vector3::new(0, 0, 0);
+        vector[coord_axis as usize] = 1;
+        vector
+    }
+
+    fn chunk_direction_to_vector3(chunk_direction: ChunkDirection) -> na::Vector3<i32> {
+        let mut vector = na::Vector3::new(0, 0, 0);
+        vector[chunk_direction.axis as usize] = chunk_direction.sign as i32;
+        vector
+    }
+
+    fn chunk_axis_permutation_to_matrix3(
+        chunk_axis_permutation: ChunkAxisPermutation,
+    ) -> na::Matrix3<i32> {
+        na::Matrix::from_columns(&chunk_axis_permutation.axes.map(coord_axis_to_vector3))
+    }
+
+    // Helper function to return all permutations as a list of ordered triples
+    fn get_all_permutations() -> Vec<(usize, usize, usize)> {
+        let mut permutations = vec![];
+        for i in 0..3 {
+            for j in 0..3 {
+                if j == i {
+                    continue;
+                }
+                for k in 0..3 {
+                    if k == i || k == j {
+                        continue;
+                    }
+                    permutations.push((i, j, k));
+                }
+            }
+        }
+        permutations
+    }
+
+    #[test]
+    fn test_chunk_axis_permutation() {
+        let sides = Vertex::A.canonical_sides();
+
+        let example_coords = Coords([3, 5, 9]);
+
+        for (i, j, k) in get_all_permutations() {
+            let permutation = ChunkAxisPermutation::from_permutation(
+                [sides[0], sides[1], sides[2]],
+                [sides[i], sides[j], sides[k]],
+            );
+
+            // Test that the permutation goes in the expected direction
+            assert_eq!(
+                permutation * example_coords,
+                Coords([
+                    example_coords.0[i],
+                    example_coords.0[j],
+                    example_coords.0[k]
+                ])
+            );
+
+            // Test that the multiplication operations are consistent with matrix multiplication
+            assert_eq!(
+                coords_to_vector3(permutation * example_coords),
+                chunk_axis_permutation_to_matrix3(permutation) * coords_to_vector3(example_coords)
+            );
+            for chunk_direction in ChunkDirection::iter() {
+                assert_eq!(
+                    chunk_direction_to_vector3(permutation * chunk_direction),
+                    chunk_axis_permutation_to_matrix3(permutation)
+                        * chunk_direction_to_vector3(chunk_direction)
+                )
+            }
+        }
     }
 }

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -4,7 +4,7 @@ use rand_distr::Normal;
 use crate::{
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
-    math,
+    margins, math,
     node::{ChunkId, VoxelData},
     terraingen::VoronoiInfo,
     world::Material,
@@ -246,6 +246,7 @@ impl ChunkParams {
             self.generate_trees(&mut voxels, &mut rng);
         }
 
+        margins::initialize_margins(self.dimension, &mut voxels);
         voxels
     }
 


### PR DESCRIPTION
Fixes #41 (Although ambient occlusion won't be 100% accurate due to ignored edge ~and corner~ margins)
Fixes #330 (Necessary to avoid noticeable z-fighting after this change)

This PR ensures that the chunk margins that affect which surfaces are extracted are accurate, ensuring that no surfaces between two solid voxels are rendered, which should result in better draw performance and a clearer view when no-clipping beneath the terrain.

After a chunk is ready to be added to the world (which could be from terrain generation, loading saves, or downloading chunks from a server), the margins of that chunk and its adjacent chunks are modified to be consistent with each other. Then, whenever a block update occurs, margins in adjacent chunks are updated to be consistent with that block update.

To help facilitate this feature, a few additional chunk-coordinate-related math functions have been added to make it easier to reason about how adjacent chunks interact with each other, especially given that different vertices have (necessarily) inconsistent orientations.

A small change has been made to the "extract.comp" shader to prevent the wrong chunk from rendering a particular surface.