### PR TITLE
Replace .iter().copied() on arrays with .into_iter()

### DIFF
--- a/common/src/cursor.rs
+++ b/common/src/cursor.rs
@@ -70,7 +70,7 @@ pub enum Dir {
 impl Dir {
     pub fn iter() -> impl ExactSizeIterator<Item = Self> + Clone {
         use Dir::*;
-        [Left, Right, Down, Up, Forward, Back].iter().cloned()
+        [Left, Right, Down, Up, Forward, Back].into_iter()
     }
 
     /// Returns the unit vector corresponding to the direction.

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -32,7 +32,7 @@ impl Side {
 
     pub fn iter() -> impl ExactSizeIterator<Item = Self> {
         use Side::*;
-        [A, B, C, D, E, F, G, H, I, J, K, L].iter().cloned()
+        [A, B, C, D, E, F, G, H, I, J, K, L].into_iter()
     }
 
     /// Whether `self` and `other` share an edge

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -64,7 +64,7 @@ impl Graph {
     ///
     /// A node's length is defined as a its distance from the root node.
     pub fn canonicalize(&self, mut chunk: ChunkId) -> Option<ChunkId> {
-        for side in chunk.vertex.canonical_sides().iter().cloned() {
+        for side in chunk.vertex.canonical_sides().into_iter() {
             // missing neighbors are always longer
             if let Some(neighbor) = self.neighbor(chunk.node, side) {
                 if self.length(neighbor) < self.length(chunk.node) {
@@ -392,7 +392,7 @@ mod tests {
             "both the root and some other node are common neighbors"
         );
         assert!(common.contains(&NodeId::ROOT));
-        let other = common.iter().cloned().find(|&x| x != NodeId::ROOT).unwrap();
+        let other = common.into_iter().find(|&x| x != NodeId::ROOT).unwrap();
         assert_eq!(graph.nodes[&other].length, 2);
     }
 

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -465,7 +465,7 @@ pub struct CoordAxisOutOfBounds;
 impl CoordAxis {
     /// Iterates through the the axes in ascending order
     pub fn iter() -> impl ExactSizeIterator<Item = Self> {
-        [Self::X, Self::Y, Self::Z].iter().copied()
+        [Self::X, Self::Y, Self::Z].into_iter()
     }
 
     /// Returns the pair axes orthogonal to the current axis

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -693,7 +693,7 @@ mod test {
 
         let enviros =
             chunk_incident_enviro_factors(&g, ChunkId::new(NodeId::ROOT, Vertex::A)).unwrap();
-        for (i, max_elevation) in enviros.max_elevations.iter().cloned().enumerate() {
+        for (i, max_elevation) in enviros.max_elevations.into_iter().enumerate() {
             println!("{i}, {max_elevation}");
             assert_abs_diff_eq!(max_elevation, (i + 1) as f64, epsilon = 1e-8);
         }

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -283,9 +283,9 @@ impl Sim {
         populate_fresh_nodes(&mut self.graph);
 
         let mut fresh_voxel_data = vec![];
-        for fresh_node in (&fresh_nodes).into_iter() {
+        for fresh_node in fresh_nodes.iter().cloned() {
             for vertex in Vertex::iter() {
-                let chunk = ChunkId::new(*fresh_node, vertex);
+                let chunk = ChunkId::new(fresh_node, vertex);
                 if let Some(voxel_data) = self.preloaded_voxel_data.remove(&chunk) {
                     fresh_voxel_data.push((chunk, voxel_data.serialize(self.cfg.chunk_size)));
                     self.modified_chunks.insert(chunk);

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -283,9 +283,9 @@ impl Sim {
         populate_fresh_nodes(&mut self.graph);
 
         let mut fresh_voxel_data = vec![];
-        for fresh_node in fresh_nodes.iter().copied() {
+        for fresh_node in (&fresh_nodes).into_iter() {
             for vertex in Vertex::iter() {
-                let chunk = ChunkId::new(fresh_node, vertex);
+                let chunk = ChunkId::new(*fresh_node, vertex);
                 if let Some(voxel_data) = self.preloaded_voxel_data.remove(&chunk) {
                     fresh_voxel_data.push((chunk, voxel_data.serialize(self.cfg.chunk_size)));
                     self.modified_chunks.insert(chunk);


### PR DESCRIPTION
ref #381 