### PR TITLE
Make saves configurable for the client

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -13,6 +13,7 @@ use common::{SimConfig, SimConfigRaw};
 pub struct Config {
     pub name: Arc<str>,
     pub data_dirs: Vec<PathBuf>,
+    pub save: PathBuf,
     pub chunk_load_parallelism: u32,
     pub server: Option<SocketAddr>,
     pub local_simulation: SimConfig,
@@ -26,6 +27,7 @@ impl Config {
         let RawConfig {
             name,
             data_dir,
+            save,
             local_simulation,
             chunk_load_parallelism,
             server,
@@ -75,6 +77,7 @@ impl Config {
         Config {
             name: name.unwrap_or_else(|| whoami::username().into()),
             data_dirs,
+            save: save.unwrap_or("default.save".into()),
             chunk_load_parallelism: chunk_load_parallelism.unwrap_or(256),
             server,
             local_simulation: SimConfig::from_raw(&local_simulation),
@@ -99,6 +102,7 @@ impl Config {
 struct RawConfig {
     name: Option<Arc<str>>,
     data_dir: Option<PathBuf>,
+    save: Option<PathBuf>,
     chunk_load_parallelism: Option<u32>,
     server: Option<SocketAddr>,
     #[serde(default)]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
         let cert = certified_key.cert.der().to_vec();
         let sim_cfg = config.local_simulation.clone();
 
-        let save = dirs.data_local_dir().join("default.save");
+        let save = dirs.data_local_dir().join(&config.save);
         info!("using save file {}", save.display());
         std::fs::create_dir_all(save.parent().unwrap()).unwrap();
         let save = match Save::open(&save, config.local_simulation.chunk_size) {


### PR DESCRIPTION
Having the ability to choose which save file is active would allow me to swap between them when, for instance, trying out different chunk sizes or switching between an older and newer version of Hypermine. It would also make it easier to test save files on an HDD to make sure that doesn't become an important bottleneck.

Fortunately, it looks like the implementation for this is quite simple. I chose to call the configuration option `save` for consistency with the server. If you give it a full path, it will save at that path, but if you give it a partial path, it will save in the data directory. All of this functionality comes for free with the `PathBuf::join` function.