### PR TITLE
Fix inconsistencies with margin reconciliation logic

### DIFF
--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -101,7 +101,7 @@ impl Voxels {
         }
         while let Some(chunk) = self.worldgen.poll() {
             let chunk_id = ChunkId::new(chunk.node, chunk.chunk);
-            sim.graph.populate_chunk(chunk_id, chunk.voxels, false);
+            sim.graph.populate_chunk(chunk_id, chunk.voxels);
 
             // Now that the block is populated, we can apply any pending block updates the server
             // provided that the client couldn't apply.
@@ -175,7 +175,6 @@ impl Voxels {
                         ref mut surface,
                         ref mut old_surface,
                         ref voxels,
-                        ..
                     } => {
                         if let Some(slot) = surface.or(*old_surface) {
                             // Render an already-extracted surface

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -336,7 +336,7 @@ impl Sim {
                 tracing::error!("Voxel data received from server is of incorrect dimension");
                 continue;
             };
-            self.graph.populate_chunk(chunk_id, voxel_data, true);
+            self.graph.populate_chunk(chunk_id, voxel_data);
         }
     }
 

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -49,7 +49,6 @@ fn build_graph(c: &mut Criterion) {
                     if let Some(params) = ChunkParams::new(12, &graph, chunk) {
                         graph[chunk] = Chunk::Populated {
                             voxels: params.generate_voxels(),
-                            modified: false,
                             surface: None,
                             old_surface: None,
                         };

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -156,7 +156,6 @@ mod tests {
                 for vertex in dodeca::Vertex::iter() {
                     graph[ChunkId::new(node, vertex)] = Chunk::Populated {
                         voxels: VoxelData::Solid(Material::Void),
-                        modified: false,
                         surface: None,
                         old_surface: None,
                     };
@@ -428,7 +427,6 @@ mod tests {
             for vertex in dodeca::Vertex::iter() {
                 graph[ChunkId::new(node, vertex)] = Chunk::Populated {
                     voxels: VoxelData::Solid(Material::Void),
-                    modified: false,
                     surface: None,
                     old_surface: None,
                 };

--- a/common/src/margins.rs
+++ b/common/src/margins.rs
@@ -192,7 +192,6 @@ pub fn reconcile_margin_voxels(
         voxels: neighbor_voxels,
         surface: neighbor_surface,
         old_surface: neighbor_old_surface,
-        ..
     } = &mut graph[neighbor_chunk]
     else {
         unreachable!();
@@ -213,7 +212,6 @@ pub fn reconcile_margin_voxels(
         voxels,
         surface,
         old_surface,
-        ..
     } = &mut graph[chunk]
     else {
         unreachable!();
@@ -383,7 +381,6 @@ mod tests {
         for chunk in [current_chunk, node_neighbor_chunk, vertex_neighbor_chunk] {
             *graph.get_chunk_mut(chunk).unwrap() = Chunk::Populated {
                 voxels: VoxelData::Solid(Material::Void),
-                modified: false,
                 surface: None,
                 old_surface: None,
             };

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -153,12 +153,11 @@ impl Graph {
         *old_surface = surface.take().or(*old_surface);
 
         for chunk_direction in ChunkDirection::iter() {
-            margins::update_margin_voxel(
+            margins::reconcile_margin_voxels(
                 self,
                 block_update.chunk_id,
                 block_update.coords,
                 chunk_direction,
-                block_update.new_material,
             )
         }
         true

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -92,37 +92,30 @@ impl Graph {
         Some((chunk, coords))
     }
 
-    /// Populates a chunk with the given voxel data and ensures that margins are correctly fixed up if necessary.
+    /// Populates a chunk with the given voxel data and ensures that margins are correctly fixed up.
     pub fn populate_chunk(&mut self, chunk: ChunkId, mut voxels: VoxelData, modified: bool) {
         let dimension = self.layout().dimension;
         // Fix up margins for the chunk we're inserting along with any neighboring chunks
         for chunk_direction in ChunkDirection::iter() {
             let Some(Chunk::Populated {
-                modified: neighbor_modified,
                 voxels: neighbor_voxels,
                 surface: neighbor_surface,
                 old_surface: neighbor_old_surface,
+                ..
             }) = self
                 .get_chunk_neighbor(chunk, chunk_direction.axis, chunk_direction.sign)
                 .map(|chunk_id| &mut self[chunk_id])
             else {
                 continue;
             };
-            // We need to fix up margins between the current chunk and the neighboring chunk if and only if
-            // there's a potential surface between them. This can occur if either is modified or if neither
-            // is designated as solid. Note that if one is designated as solid, that means that it's deep enough
-            // in the terrain or up in the air that there will be no surface between them.
-            if (!voxels.is_solid() && !neighbor_voxels.is_solid()) || modified || *neighbor_modified
-            {
-                margins::fix_margins(
-                    dimension,
-                    chunk.vertex,
-                    &mut voxels,
-                    chunk_direction,
-                    neighbor_voxels,
-                );
-                *neighbor_old_surface = neighbor_surface.take().or(*neighbor_old_surface);
-            }
+            margins::fix_margins(
+                dimension,
+                chunk.vertex,
+                &mut voxels,
+                chunk_direction,
+                neighbor_voxels,
+            );
+            *neighbor_old_surface = neighbor_surface.take().or(*neighbor_old_surface);
         }
 
         // After clearing any margins we needed to clear, we can now insert the data into the graph

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -93,7 +93,7 @@ impl Graph {
     }
 
     /// Populates a chunk with the given voxel data and ensures that margins are correctly fixed up.
-    pub fn populate_chunk(&mut self, chunk: ChunkId, mut voxels: VoxelData, modified: bool) {
+    pub fn populate_chunk(&mut self, chunk: ChunkId, mut voxels: VoxelData) {
         let dimension = self.layout().dimension;
         // Fix up margins for the chunk we're inserting along with any neighboring chunks
         for chunk_direction in ChunkDirection::iter() {
@@ -101,7 +101,6 @@ impl Graph {
                 voxels: neighbor_voxels,
                 surface: neighbor_surface,
                 old_surface: neighbor_old_surface,
-                ..
             }) = self
                 .get_chunk_neighbor(chunk, chunk_direction.axis, chunk_direction.sign)
                 .map(|chunk_id| &mut self[chunk_id])
@@ -121,7 +120,6 @@ impl Graph {
         // After clearing any margins we needed to clear, we can now insert the data into the graph
         *self.get_chunk_mut(chunk).unwrap() = Chunk::Populated {
             voxels,
-            modified,
             surface: None,
             old_surface: None,
         };
@@ -136,7 +134,6 @@ impl Graph {
         // Update the block
         let Some(Chunk::Populated {
             voxels,
-            modified,
             surface,
             old_surface,
         }) = self.get_chunk_mut(block_update.chunk_id)
@@ -149,7 +146,6 @@ impl Graph {
             .expect("coords are in-bounds");
 
         *voxel = block_update.new_material;
-        *modified = true;
         *old_surface = surface.take().or(*old_surface);
 
         for chunk_direction in ChunkDirection::iter() {
@@ -192,7 +188,6 @@ pub enum Chunk {
     Generating,
     Populated {
         voxels: VoxelData,
-        modified: bool,
         surface: Option<SlotId>,
         old_surface: Option<SlotId>,
     },

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -72,7 +72,7 @@ impl Graph {
         coord_axis: CoordAxis,
         coord_sign: CoordSign,
     ) -> Option<(ChunkId, Coords)> {
-        if coords[coord_axis] == Coords::edge_coord(self.layout().dimension, coord_sign) {
+        if coords[coord_axis] == Coords::boundary_coord(self.layout().dimension, coord_sign) {
             match coord_sign {
                 CoordSign::Plus => {
                     coords = chunk.vertex.chunk_axis_permutations()[coord_axis as usize] * coords;

--- a/common/src/voxel_math.rs
+++ b/common/src/voxel_math.rs
@@ -93,7 +93,7 @@ impl Coords {
     }
 
     /// Returns the x, y, or z coordinate that would correspond to the voxel meeting the chunk boundary in the direction of `sign`
-    pub fn edge_coord(chunk_size: u8, sign: CoordSign) -> u8 {
+    pub fn boundary_coord(chunk_size: u8, sign: CoordSign) -> u8 {
         match sign {
             CoordSign::Plus => chunk_size - 1,
             CoordSign::Minus => 0,

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -289,7 +289,7 @@ impl Sim {
                 if let Some(voxel_data) = self.preloaded_voxel_data.remove(&chunk) {
                     fresh_voxel_data.push((chunk, voxel_data.serialize(self.cfg.chunk_size)));
                     self.modified_chunks.insert(chunk);
-                    self.graph.populate_chunk(chunk, voxel_data, true)
+                    self.graph.populate_chunk(chunk, voxel_data)
                 }
             }
         }
@@ -318,8 +318,7 @@ impl Sim {
                         if let Some(params) =
                             ChunkParams::new(self.cfg.chunk_size, &self.graph, chunk)
                         {
-                            self.graph
-                                .populate_chunk(chunk, params.generate_voxels(), false);
+                            self.graph.populate_chunk(chunk, params.generate_voxels());
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes two bugs related to https://github.com/Ralith/hypermine/pull/379.

## Bug 1
Some of the logic assumed that world generation would never create "solid" chunks unless it was sure that the chunk was deep enough underground or high enough up in the air to not touch any surfaces. This assumption allowed us to avoid reconciling margins between a solid chunk and a dense chunk unless the dense chunk was "modified".

However, since this assumption was incorrect (for instance, due to world generation not turning solid "void" chunks into dense chunks unless a voxel is actually generated), this produced gaps in the terrain whenever a dense chunk met a solid void chunk.

## Bug 2
When a voxel is modified, we assumed that only neighboring chunks' margins needs to update, since all other margins should already be correct. However, if we want to be certain, we also need to update the margins of the chunk the modified voxel is in. This is because we only guarantee that margin voxels are the correct material when they would be rendered.

Because of this, it would have been possible to dig down into a solid dirt chunk, dig across a bit, and dig up again, seeing what looks like dirt in a neighboring chunk's voxel no matter what material that voxel actually is.

## Solution
The fix to bug 1 is to remove the assumption, adding logic to `fix_margins` to handle either chunk being solid.

The fix to bug 2 is to change `update_margin_voxel` into a bidirectional update, updating the margins of both relevant chunks. Since this changes the public interface of the function, I also renamed it to `reconcile_margin_voxels`.

## Bonus cleanup
The only purpose of the `modified` boolean in `Chunk::Populated` was to determine whether assumptions based on world generation would hold when determining whether chunks should be solid or not. Since we no longer make assumptions based on world generation, this field is now obsolete, allowing us to remove it completely.