### PR TITLE
Bugfix: Remove unintended view distance limit

### DIFF
--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -128,11 +128,12 @@ impl Voxels {
         );
         histogram!("frame.cpu.voxels.graph_traversal").record(graph_traversal_started.elapsed());
         // Sort nodes by distance to the view to prioritize loading closer data and improve early Z
-        // performance
+        // performance. Sorting by `mip` in descending order is equivalent to sorting by distance
+        // in ascending order.
         let view_pos = view.local * math::origin();
         nodes.sort_unstable_by(|&(_, ref xf_a), &(_, ref xf_b)| {
-            math::distance(&view_pos, &(xf_a * math::origin()))
-                .partial_cmp(&math::distance(&view_pos, &(xf_b * math::origin())))
+            math::mip(&view_pos, &(xf_b * math::origin()))
+                .partial_cmp(&math::mip(&view_pos, &(xf_a * math::origin())))
                 .unwrap_or(std::cmp::Ordering::Less)
         });
         let node_scan_started = Instant::now();


### PR DESCRIPTION
The `math::distance` normalizes the input vectors as part of its computation, which results in a loss of precision when an input vector is large.

For situations where that matters, such as in `traversal.rs`, we use `math::mip` instead of `math::distance`. Note that, when the input vectors are already pre-normalized, the distance formula simplifies to `(-mip(a, b)).acosh()`, which is likely small enough to not need its own function.

Note that the actual bug this fixes is that distance computations in `traversal::ensure_nearby` were resulting in `NaN`, which caused the loop to continue on forever, continuing to expand out the graph until running out of memory.