### PR TITLE
Handle null pointer in fmt_labels

### DIFF
--- a/client/src/graphics/core.rs
+++ b/client/src/graphics/core.rs
@@ -130,6 +130,12 @@ unsafe extern "system" fn messenger_callback(
     _p_user_data: *mut c_void,
 ) -> vk::Bool32 {
     unsafe fn fmt_labels(ptr: *const vk::DebugUtilsLabelEXT, count: u32) -> String {
+        if count == 0 {
+            // We need to handle a count of 0 separately because ptr may be
+            // null, resulting in undefined behavior if used with
+            // slice::from_raw_parts.
+            return String::new();
+        }
         slice::from_raw_parts(ptr, count as usize)
             .iter()
             .map(|label| {


### PR DESCRIPTION
Rust 1.78.0 introduced some debug assertions for unsafe preconditions. One such precondition, which we have inadvertently violated for a while was that `slice::from_raw_parts` does not accept null pointers, even when the size is 0.

An except from the Rust docs:
> `data` must be non-null and aligned even for zero-length slices. One reason for this is that enum layout optimizations may rely on references (including slices of any length) being aligned and non-null to distinguish them from other data. You can obtain a pointer that is usable as `data` for zero-length slices using `NonNull::dangling`.

While another option could have been to replace `ptr` with `NonNull::dangling` if it was null, simply handling this case separately seems like a simpler approach.

This is the error that appeared when I tried running Hypermine in debug mode:
```
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library\std\src\panicking.rs:645 
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library\core\src\panicking.rs:110
   2: core::panicking::panic_nounwind_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library\core\src\panicking.rs:123
   3: core::panicking::panic_nounwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library\core\src\panicking.rs:156
   4: client::graphics::core::messenger_callback::fmt_labels
             at .\core.rs:133
   5: client::graphics::core::messenger_callback
             at .\core.rs:151
   6: vkDestroyDescriptorPool
   7: vkDestroyDescriptorPool
   8: vkDestroyDescriptorPool
   9: vkDestroyDescriptorPool
  10: vkDestroyDescriptorPool
  11: vkDestroyDescriptorPool
  12: client::graphics::core::Core::new
             at .\core.rs:94
  13: client::main
             at E:\Gamma\git\rust\hypermine\client\src\main.rs:64
  14: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6\library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread caused non-unwinding panic. aborting.
```