### PR TITLE
Add an initial UI to Hypermine

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,8 +14,8 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.38.0", default-features = false, features = ["loaded", "debug", "std"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "7963ae5750ea61fa0a894dbb73d3be0ac77255d2" }
-yakui = { git = "https://github.com/SecondHalfGames/yakui", rev = "2eda113392712e87eb1c372b7d495edc29b8ccdc" }
-yakui-vulkan = { git = "https://github.com/SecondHalfGames/yakui", rev = "2eda113392712e87eb1c372b7d495edc29b8ccdc" }
+yakui = { git = "https://github.com/SecondHalfGames/yakui", rev = "cbac6c06dbf948268df6d9e93346788e977cbef3" }
+yakui-vulkan = { git = "https://github.com/SecondHalfGames/yakui", rev = "cbac6c06dbf948268df6d9e93346788e977cbef3" }
 winit = "0.29.10"
 ash-window = "0.13"
 raw-window-handle = "0.6"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,6 +14,8 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.38.0", default-features = false, features = ["loaded", "debug", "std"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "7963ae5750ea61fa0a894dbb73d3be0ac77255d2" }
+yakui = { git = "https://github.com/SecondHalfGames/yakui", rev = "2eda113392712e87eb1c372b7d495edc29b8ccdc" }
+yakui-vulkan = { git = "https://github.com/SecondHalfGames/yakui", rev = "2eda113392712e87eb1c372b7d495edc29b8ccdc" }
 winit = "0.29.10"
 ash-window = "0.13"
 raw-window-handle = "0.6"

--- a/client/shaders/fog.frag
+++ b/client/shaders/fog.frag
@@ -16,12 +16,6 @@ void main() {
     float view_length = length(view_pos);
     // Convert to true hyperbolic distance, taking care to respect atanh's domain
     float dist = view_length >= 1.0 ? INFINITY : atanh(view_length);
-    if (dot(scaled_view_pos.xy, scaled_view_pos.xy) < 0.0001) {
-        // Temporary code to add a cursor in the center of the window for placing/breaking blocks
-        // TODO: Replace with a UI element when UI exists
-        fog = vec4(0.0, 0.0, 0.0, 0.0);
-    } else {
-        // Exponential^k fog
-        fog = vec4(0.5, 0.65, 0.9, exp(-pow(dist * fog_density, 5)));
-    }
+    // Exponential^k fog
+    fog = vec4(0.5, 0.65, 0.9, exp(-pow(dist * fog_density, 5)));
 }

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -139,7 +139,11 @@ impl Base {
                             .queue_create_infos(&[vk::DeviceQueueCreateInfo::default()
                                 .queue_family_index(queue_family_index)
                                 .queue_priorities(&[1.0])])
-                            .enabled_extension_names(&device_exts),
+                            .enabled_extension_names(&device_exts)
+                            .push_next(
+                                &mut vk::PhysicalDeviceDescriptorIndexingFeatures::default()
+                                    .descriptor_binding_partially_bound(true),
+                            ),
                         None,
                     )
                     .unwrap(),

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{fs, io};
 use tracing::{error, info, trace, warn};
-use yakui_vulkan::{VulkanContext, YakuiVulkan};
 
 use ash::{vk, Device};
 
@@ -37,8 +36,6 @@ pub struct Base {
     pub timestamp_bits: u32,
     pipeline_cache_path: Option<PathBuf>,
     debug_utils: Option<debug_utils::Device>,
-    // Yakui Vulkan context
-    pub yakui_vulkan: yakui_vulkan::YakuiVulkan,
 }
 
 unsafe impl Send for Base {}
@@ -47,7 +44,6 @@ unsafe impl Sync for Base {}
 impl Drop for Base {
     fn drop(&mut self) {
         unsafe {
-            self.yakui_vulkan.cleanup(&self.device);
             self.device
                 .destroy_pipeline_cache(self.pipeline_cache, None);
             self.device.destroy_render_pass(self.render_pass, None);
@@ -278,14 +274,6 @@ impl Base {
                 .as_ref()
                 .map(|_| debug_utils::Device::new(&core.instance, &device));
 
-            let mut yakui_vulkan_options = yakui_vulkan::Options::default();
-            yakui_vulkan_options.render_pass = render_pass;
-            let mut yakui_vulkan = YakuiVulkan::new(
-                &VulkanContext::new(&device, queue, memory_properties),
-                yakui_vulkan_options,
-            );
-            yakui_vulkan.transfers_submitted();
-
             Some(Self {
                 core,
                 physical,
@@ -301,7 +289,6 @@ impl Base {
                 limits: physical_properties.properties.limits,
                 timestamp_bits: queue_family_properties.timestamp_valid_bits,
                 debug_utils,
-                yakui_vulkan,
             })
         }
     }

--- a/client/src/graphics/core.rs
+++ b/client/src/graphics/core.rs
@@ -68,7 +68,7 @@ impl Core {
                 .application_version(0)
                 .engine_name(name)
                 .engine_version(0)
-                .api_version(vk::make_api_version(0, 1, 1, 0));
+                .api_version(vk::make_api_version(0, 1, 2, 0));
             let mut instance_info = vk::InstanceCreateInfo::default()
                 .application_info(&app_info)
                 .enabled_extension_names(&exts);

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -303,6 +303,9 @@ impl Draw {
 
         self.yak.start();
         yakui::text(96.0, "Hello world!");
+        yakui::align(yakui::Alignment::CENTER, || {
+            yakui::colored_box(yakui::Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
+        });
         self.yak.finish();
 
         let paint = self.yak.paint();

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -194,6 +194,7 @@ impl Draw {
 
             let mut yakui_vulkan_options = yakui_vulkan::Options::default();
             yakui_vulkan_options.render_pass = gfx.render_pass;
+            yakui_vulkan_options.subpass = 1;
             let mut yakui_vulkan = yakui_vulkan::YakuiVulkan::new(
                 &yakui_vulkan::VulkanContext::new(device, gfx.queue, gfx.memory_properties),
                 yakui_vulkan_options,
@@ -287,17 +288,16 @@ impl Draw {
         let state = &mut self.states[self.next_state];
         let cmd = state.cmd;
 
-        let yakui_vulkan_context = yakui_vulkan::VulkanContext::new(
-            device,
-            self.gfx.queue,
-            self.gfx.memory_properties,
-        );
+        let yakui_vulkan_context =
+            yakui_vulkan::VulkanContext::new(device, self.gfx.queue, self.gfx.memory_properties);
 
-        self.yak.set_surface_size([extent.width as f32, extent.height as f32].into());
-        self.yak.set_unscaled_viewport(yakui::geometry::Rect::from_pos_size(
-            Default::default(),
-            [extent.width as f32, extent.height as f32].into(),
-        ));
+        self.yak
+            .set_surface_size([extent.width as f32, extent.height as f32].into());
+        self.yak
+            .set_unscaled_viewport(yakui::geometry::Rect::from_pos_size(
+                Default::default(),
+                [extent.width as f32, extent.height as f32].into(),
+            ));
 
         self.yak.start();
         yakui::text(96.0, "Hello world!");
@@ -373,7 +373,8 @@ impl Draw {
         timestamp_index += 1;
 
         self.yakui_vulkan.transfers_finished(&yakui_vulkan_context);
-        self.yakui_vulkan.transfer(paint, &yakui_vulkan_context, cmd);
+        self.yakui_vulkan
+            .transfer(paint, &yakui_vulkan_context, cmd);
 
         // Schedule transfer of uniform data. Note that we defer actually preparing the data to just
         // before submitting the command buffer so time-sensitive values can be set with minimum
@@ -501,12 +502,12 @@ impl Draw {
             }
         }
 
-        // TODO
-        self.yakui_vulkan.paint(paint, &yakui_vulkan_context, cmd, extent);
-
         device.cmd_next_subpass(cmd, vk::SubpassContents::INLINE);
 
-        //self.fog.draw(device, state.common_ds, cmd);
+        self.fog.draw(device, state.common_ds, cmd);
+
+        self.yakui_vulkan
+            .paint(paint, &yakui_vulkan_context, cmd, extent);
 
         // Finish up
         device.cmd_end_render_pass(cmd);

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -200,6 +200,7 @@ impl Draw {
                 yakui_vulkan_options,
             );
             yakui_vulkan.transfers_submitted();
+            yakui_vulkan.transfers_submitted();
 
             Self {
                 gfx,

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -5,8 +5,8 @@ use ash::vk;
 use common::traversal;
 use lahar::Staged;
 use metrics::histogram;
-use yakui::Color;
 
+use super::gui::{self, GuiState};
 use super::{fog, voxels, Base, Fog, Frustum, GltfScene, Meshes, Voxels};
 use crate::{Asset, Config, Loader, Sim};
 use common::proto::{Character, Position};
@@ -271,9 +271,11 @@ impl Draw {
     ///
     /// Submits commands that wait on `image_acquired` before writing to `framebuffer`'s color
     /// attachment.
+    #[allow(clippy::too_many_arguments)] // Every argument is of a different type, making this less of a problem.
     pub unsafe fn draw(
         &mut self,
         mut sim: Option<&mut Sim>,
+        gui_state: &GuiState,
         framebuffer: vk::Framebuffer,
         depth_view: vk::ImageView,
         extent: vk::Extent2D,
@@ -304,18 +306,7 @@ impl Draw {
 
         self.yak.start();
         if let Some(sim) = sim.as_ref() {
-            // Cursor
-            yakui::align(yakui::Alignment::CENTER, || {
-                yakui::colored_box(yakui::Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
-            });
-
-            yakui::align(yakui::Alignment::TOP_LEFT, || {
-                yakui::pad(yakui::widgets::Pad::all(8.0), || {
-                    yakui::colored_box_container(Color::BLACK.with_alpha(0.7), || {
-                        yakui::label(format!("Selected material: {:?}", sim.selected_material()));
-                    });
-                });
-            });
+            gui::gui(gui_state, sim);
         }
         self.yak.finish();
 

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -5,6 +5,7 @@ use ash::vk;
 use common::traversal;
 use lahar::Staged;
 use metrics::histogram;
+use yakui::Color;
 
 use super::{fog, voxels, Base, Fog, Frustum, GltfScene, Meshes, Voxels};
 use crate::{Asset, Config, Loader, Sim};
@@ -302,10 +303,20 @@ impl Draw {
             ));
 
         self.yak.start();
-        yakui::text(96.0, "Hello world!");
-        yakui::align(yakui::Alignment::CENTER, || {
-            yakui::colored_box(yakui::Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
-        });
+        if let Some(sim) = sim.as_ref() {
+            // Cursor
+            yakui::align(yakui::Alignment::CENTER, || {
+                yakui::colored_box(yakui::Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
+            });
+
+            yakui::align(yakui::Alignment::TOP_LEFT, || {
+                yakui::pad(yakui::widgets::Pad::all(8.0), || {
+                    yakui::colored_box_container(Color::BLACK.with_alpha(0.7), || {
+                        yakui::label(format!("Selected material: {:?}", sim.selected_material()));
+                    });
+                });
+            });
+        }
         self.yak.finish();
 
         let paint = self.yak.paint();

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -199,8 +199,9 @@ impl Draw {
                 &yakui_vulkan::VulkanContext::new(device, gfx.queue, gfx.memory_properties),
                 yakui_vulkan_options,
             );
-            yakui_vulkan.transfers_submitted();
-            yakui_vulkan.transfers_submitted();
+            for _ in 0..PIPELINE_DEPTH {
+                yakui_vulkan.transfers_submitted();
+            }
 
             Self {
                 gfx,

--- a/client/src/graphics/gui.rs
+++ b/client/src/graphics/gui.rs
@@ -1,0 +1,37 @@
+use yakui::{
+    align, colored_box, colored_box_container, label, pad, widgets::Pad, Alignment, Color,
+};
+
+use crate::Sim;
+
+pub struct GuiState {
+    show_gui: bool,
+}
+
+impl GuiState {
+    pub fn new() -> Self {
+        GuiState { show_gui: true }
+    }
+
+    pub fn toggle_gui(&mut self) {
+        self.show_gui = !self.show_gui;
+    }
+}
+
+pub fn gui(gui_state: &GuiState, sim: &Sim) {
+    if !gui_state.show_gui {
+        return;
+    }
+
+    align(Alignment::CENTER, || {
+        colored_box(Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
+    });
+
+    align(Alignment::TOP_LEFT, || {
+        pad(Pad::all(8.0), || {
+            colored_box_container(Color::BLACK.with_alpha(0.7), || {
+                label(format!("Selected material: {:?}", sim.selected_material()));
+            });
+        });
+    });
+}

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -6,6 +6,7 @@ mod draw;
 mod fog;
 mod frustum;
 mod gltf_mesh;
+mod gui;
 mod meshes;
 mod png_array;
 pub mod voxels;

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -366,6 +366,7 @@ impl Window {
                 }
                 Err(e) => panic!("queue_present: {e}"),
             };
+            draw.yakui_vulkan.transfers_submitted();
         }
     }
 }

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -15,6 +15,7 @@ use winit::{
     window::{CursorGrabMode, Window as WinitWindow, WindowBuilder},
 };
 
+use super::gui::GuiState;
 use super::{Base, Core, Draw, Frustum};
 use crate::Net;
 use crate::{net, Config, Sim};
@@ -57,6 +58,7 @@ pub struct Window {
     swapchain_needs_update: bool,
     draw: Option<Draw>,
     sim: Option<Sim>,
+    gui_state: GuiState,
     net: Net,
 }
 
@@ -93,6 +95,7 @@ impl Window {
             swapchain_needs_update: false,
             draw: None,
             sim: None,
+            gui_state: GuiState::new(),
             net,
         }
     }
@@ -261,6 +264,9 @@ impl Window {
                                 sim.toggle_no_clip();
                             }
                         }
+                        KeyCode::F1 if state == ElementState::Pressed => {
+                            self.gui_state.toggle_gui();
+                        }
                         KeyCode::Escape => {
                             let _ = self.window.set_cursor_grab(CursorGrabMode::None);
                             self.window.set_cursor_visible(true);
@@ -352,6 +358,7 @@ impl Window {
             // Render the frame
             draw.draw(
                 self.sim.as_mut(),
+                &self.gui_state,
                 frame.buffer,
                 frame.depth_view,
                 swapchain.state.extent,

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -161,6 +161,10 @@ impl Sim {
         self.selected_material = *MATERIAL_PALETTE.get(idx).unwrap_or(&MATERIAL_PALETTE[0]);
     }
 
+    pub fn selected_material(&self) -> Material {
+        self.selected_material
+    }
+
     pub fn set_break_block_pressed_true(&mut self) {
         self.break_block_pressed = true;
     }


### PR DESCRIPTION
This is currently a draft, as there are two issues:
- Fixed: ~Since Hypermine has two subpasses (the second one for fog), to ensure the UI gets drawn on top of everything and is unaffected by fog, the UI needs to be in the second subpass or possibly a third one. Currently, Yakui doesn't seem to support rendering anywhere except the first subpass. (It creates a `vk::GraphicsPipelineCreateInfo` struct and keeps the `subpass` field in that struct as its default.)~
- Fixed: ~I get the following validation error on the second call to `draw::draw` (but strangely, no frames before or after):
`Validation Error: [ VUID-vkFreeMemory-memory-00677 ] | MessageID = 0x485c8ea2 | vkFreeMemory():  can't be called on VkDeviceMemory 0xeeeba00000000288[] that is currently in use by VkBuffer 0x8f6f470000000287[]. The Vulkan spec states: All submitted commands that refer to memory (via images or buffers) must have completed execution (https://vulkan.lunarg.com/doc/view/1.3.280.0/windows/1.3-extensions/vkspec.html#VUID-vkFreeMemory-memory-00677) id=VUID-vkFreeMemory-memory-00677 number=1214025378 queue_labels= cmd_labels= objects=`. The error seems to trigger when I call `transfers_finished`. I haven't fully looked into the root cause yet, so it could just be a simple mistake on my part, as I've mainly been blindly following the `yakui-vulkan` example.~

Note that long-term, I'm not sure whether we can keep putting fog in a separate subpass, since that likely wouldn't work properly if there are any transparent objects in the scene.

(Fixed) ~If I ignore the fog and just render the UI after everything else in the first subpass, the letters are replaced with their bounding boxes filled in with the sky color. If I turn the fog off, everything works.~

I would like to keep this PR as a draft until we have the following (which I may file as a separate PR, closing this one):
- No Vulkan validation errors
- A central cursor
- Some indicator (likely textual) of the block you have selected
- A UI toggle for screenshot purposes
- Good code quality