### PR TITLE
Add a basic GUI to Hypermine powered by yakui

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,6 +14,8 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.38.0", default-features = false, features = ["loaded", "debug", "std"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "7963ae5750ea61fa0a894dbb73d3be0ac77255d2" }
+yakui = { git = "https://github.com/SecondHalfGames/yakui", rev = "273a4a1020803066b84ac69a7646893419c31385" }
+yakui-vulkan = { git = "https://github.com/SecondHalfGames/yakui", rev = "273a4a1020803066b84ac69a7646893419c31385" }
 winit = "0.29.10"
 ash-window = "0.13"
 raw-window-handle = "0.6"

--- a/client/shaders/fog.frag
+++ b/client/shaders/fog.frag
@@ -16,12 +16,6 @@ void main() {
     float view_length = length(view_pos);
     // Convert to true hyperbolic distance, taking care to respect atanh's domain
     float dist = view_length >= 1.0 ? INFINITY : atanh(view_length);
-    if (dot(scaled_view_pos.xy, scaled_view_pos.xy) < 0.0001) {
-        // Temporary code to add a cursor in the center of the window for placing/breaking blocks
-        // TODO: Replace with a UI element when UI exists
-        fog = vec4(0.0, 0.0, 0.0, 0.0);
-    } else {
-        // Exponential^k fog
-        fog = vec4(0.5, 0.65, 0.9, exp(-pow(dist * fog_density, 5)));
-    }
+    // Exponential^k fog
+    fog = vec4(0.5, 0.65, 0.9, exp(-pow(dist * fog_density, 5)));
 }

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -139,7 +139,11 @@ impl Base {
                             .queue_create_infos(&[vk::DeviceQueueCreateInfo::default()
                                 .queue_family_index(queue_family_index)
                                 .queue_priorities(&[1.0])])
-                            .enabled_extension_names(&device_exts),
+                            .enabled_extension_names(&device_exts)
+                            .push_next(
+                                &mut vk::PhysicalDeviceVulkan12Features::default()
+                                    .descriptor_binding_partially_bound(true),
+                            ),
                         None,
                     )
                     .unwrap(),

--- a/client/src/graphics/core.rs
+++ b/client/src/graphics/core.rs
@@ -68,7 +68,7 @@ impl Core {
                 .application_version(0)
                 .engine_name(name)
                 .engine_version(0)
-                .api_version(vk::make_api_version(0, 1, 1, 0));
+                .api_version(vk::make_api_version(0, 1, 2, 0));
             let mut instance_info = vk::InstanceCreateInfo::default()
                 .application_info(&app_info)
                 .enabled_extension_names(&exts);

--- a/client/src/graphics/gui.rs
+++ b/client/src/graphics/gui.rs
@@ -1,4 +1,8 @@
-use yakui::{align, colored_box, Alignment, Color};
+use yakui::{
+    align, colored_box, colored_box_container, label, pad, widgets::Pad, Alignment, Color,
+};
+
+use crate::Sim;
 
 pub struct GuiState {
     show_gui: bool,
@@ -16,13 +20,21 @@ impl GuiState {
 
     /// Prepare the GUI for rendering. This should be called between
     /// Yakui::start and Yakui::finish.
-    pub fn run(&self) {
+    pub fn run(&self, sim: &Sim) {
         if !self.show_gui {
             return;
         }
 
         align(Alignment::CENTER, || {
             colored_box(Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
+        });
+
+        align(Alignment::TOP_LEFT, || {
+            pad(Pad::all(8.0), || {
+                colored_box_container(Color::BLACK.with_alpha(0.7), || {
+                    label(format!("Selected material: {:?}", sim.selected_material()));
+                });
+            });
         });
     }
 }

--- a/client/src/graphics/gui.rs
+++ b/client/src/graphics/gui.rs
@@ -1,0 +1,28 @@
+use yakui::{align, colored_box, Alignment, Color};
+
+pub struct GuiState {
+    show_gui: bool,
+}
+
+impl GuiState {
+    pub fn new() -> Self {
+        GuiState { show_gui: true }
+    }
+
+    /// Toggles whether the GUI is shown
+    pub fn toggle_gui(&mut self) {
+        self.show_gui = !self.show_gui;
+    }
+
+    /// Prepare the GUI for rendering. This should be called between
+    /// Yakui::start and Yakui::finish.
+    pub fn run(&self) {
+        if !self.show_gui {
+            return;
+        }
+
+        align(Alignment::CENTER, || {
+            colored_box(Color::BLACK.with_alpha(0.9), [5.0, 5.0]);
+        });
+    }
+}

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -6,6 +6,7 @@ mod draw;
 mod fog;
 mod frustum;
 mod gltf_mesh;
+mod gui;
 mod meshes;
 mod png_array;
 pub mod voxels;

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -366,7 +366,9 @@ impl Window {
                     [extent.width as f32, extent.height as f32].into(),
                 ));
             self.yak.start();
-            self.gui_state.run();
+            if let Some(sim) = self.sim.as_ref() {
+                self.gui_state.run(sim);
+            }
             self.yak.finish();
             // Render the frame
             draw.draw(

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -161,6 +161,10 @@ impl Sim {
         self.selected_material = *MATERIAL_PALETTE.get(idx).unwrap_or(&MATERIAL_PALETTE[0]);
     }
 
+    pub fn selected_material(&self) -> Material {
+        self.selected_material
+    }
+
     pub fn set_break_block_pressed_true(&mut self) {
         self.break_block_pressed = true;
     }


### PR DESCRIPTION
This PR adds a GUI with the following features:
- A central cursor
- Some indicator (likely textual) of the block you have selected
- The ability to turn it on and off (for screenshot purposes) with F1

![image](https://github.com/Ralith/hypermine/assets/5403380/f9cc60c9-4dac-4233-b704-d18cbc9ae5ed)