### PR TITLE
Fix clippy lints for Rust 1.79

### DIFF
--- a/client/src/graphics/meshes.rs
+++ b/client/src/graphics/meshes.rs
@@ -185,7 +185,7 @@ impl Meshes {
             self.pipeline_layout,
             vk::ShaderStageFlags::VERTEX,
             0,
-            &mem::transmute::<_, [u8; 64]>(*transform),
+            &mem::transmute::<na::Matrix4<f32>, [u8; 64]>(*transform),
         );
         device.cmd_bind_vertex_buffers(cmd, 0, &[mesh.vertices.buffer], &[mesh.vertices.offset]);
         device.cmd_bind_index_buffer(

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -492,7 +492,7 @@ impl SwapchainMgr {
     unsafe fn acquire_next_image(&self, signal: vk::Semaphore) -> Result<(u32, bool), vk::Result> {
         self.state.swapchain_fn.acquire_next_image(
             self.state.handle,
-            std::u64::MAX,
+            u64::MAX,
             signal,
             vk::Fence::null(),
         )

--- a/client/src/lahar_deprecated/transfer.rs
+++ b/client/src/lahar_deprecated/transfer.rs
@@ -130,7 +130,7 @@ impl Reactor {
             self.ctx.device.wait_for_fences(
                 &self.in_flight_fences,
                 false,
-                u64::try_from(timeout.as_nanos()).unwrap_or(u64::max_value()),
+                u64::try_from(timeout.as_nanos()).unwrap_or(u64::MAX),
             )
         };
         match result {
@@ -261,7 +261,7 @@ impl Drop for Reactor {
         unsafe {
             if !self.in_flight.is_empty() {
                 device
-                    .wait_for_fences(&self.in_flight_fences, true, u64::max_value())
+                    .wait_for_fences(&self.in_flight_fences, true, u64::MAX)
                     .unwrap();
             }
             device.destroy_command_pool(self.cmd_pool, None);

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -138,15 +138,15 @@ mod tests {
             )
         };
 
-        pred.generation = u16::max_value() - 1;
+        pred.generation = u16::MAX - 1;
 
-        assert_eq!(push(&mut pred), u16::max_value());
+        assert_eq!(push(&mut pred), u16::MAX);
         assert_eq!(push(&mut pred), 0);
         assert_eq!(pred.log.len(), 2);
 
-        reconcile(&mut pred, u16::max_value() - 1);
+        reconcile(&mut pred, u16::MAX - 1);
         assert_eq!(pred.log.len(), 2);
-        reconcile(&mut pred, u16::max_value());
+        reconcile(&mut pred, u16::MAX);
         assert_eq!(pred.log.len(), 1);
         reconcile(&mut pred, 0);
         assert_eq!(pred.log.len(), 0);

--- a/common/src/lru_slab.rs
+++ b/common/src/lru_slab.rs
@@ -17,7 +17,7 @@ impl<T> LruSlab<T> {
     }
 
     pub fn with_capacity(capacity: u32) -> Self {
-        assert!(capacity != u32::max_value(), "capacity too large");
+        assert!(capacity != u32::MAX, "capacity too large");
         Self {
             slots: (0..capacity)
                 .map(|n| Slot {
@@ -216,7 +216,7 @@ struct Slot<T> {
 pub struct SlotId(pub u32);
 
 impl SlotId {
-    const NONE: Self = SlotId(u32::max_value());
+    const NONE: Self = SlotId(u32::MAX);
 }
 
 pub struct Iter<'a, T> {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -192,8 +192,7 @@ impl Server {
                 self.cleanup_client(client_id);
             }
             ClientEvent::Command(cmd) => {
-                if cmd.generation.wrapping_sub(client.latest_input_received) < u16::max_value() / 2
-                {
+                if cmd.generation.wrapping_sub(client.latest_input_received) < u16::MAX / 2 {
                     client.latest_input_received = cmd.generation;
                     client.inputs.push(cmd, Instant::now());
                 } else {


### PR DESCRIPTION
This PR fixes the following two lints:
* `clippy::legacy_numeric_constants`
* `clippy::missing_transmute_annotations`