### PR TITLE
Player inventory (initial version)

### DIFF
--- a/client/src/graphics/gui.rs
+++ b/client/src/graphics/gui.rs
@@ -32,10 +32,16 @@ impl GuiState {
         align(Alignment::TOP_LEFT, || {
             pad(Pad::all(8.0), || {
                 colored_box_container(Color::BLACK.with_alpha(0.7), || {
+                    let material_count_string = if sim.cfg.gameplay_enabled {
+                        sim.count_inventory_entities_matching_material(sim.selected_material())
+                            .to_string()
+                    } else {
+                        "∞".to_string()
+                    };
                     label(format!(
                         "Selected material: {:?} (×{})",
                         sim.selected_material(),
-                        sim.count_inventory_entities_matching_material(sim.selected_material())
+                        material_count_string
                     ));
                 });
             });

--- a/client/src/graphics/gui.rs
+++ b/client/src/graphics/gui.rs
@@ -32,7 +32,11 @@ impl GuiState {
         align(Alignment::TOP_LEFT, || {
             pad(Pad::all(8.0), || {
                 colored_box_container(Color::BLACK.with_alpha(0.7), || {
-                    label(format!("Selected material: {:?}", sim.selected_material()));
+                    label(format!(
+                        "Selected material: {:?} (×{})",
+                        sim.selected_material(),
+                        sim.count_inventory_entities_matching_material(sim.selected_material())
+                    ));
                 });
             });
         });

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -578,7 +578,7 @@ impl Sim {
             Material::Void
         };
 
-        let consumed_entity = if placing {
+        let consumed_entity = if placing && self.cfg.gameplay_enabled {
             Some(self.get_any_inventory_entity_matching_material(material)?)
         } else {
             None

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -125,6 +125,16 @@ impl Graph {
         };
     }
 
+    /// Returns the material at the specified coordinates of the specified chunk, if the chunk is generated
+    pub fn get_material(&self, chunk_id: ChunkId, coords: Coords) -> Option<Material> {
+        let dimension = self.layout().dimension;
+
+        let Some(Chunk::Populated { voxels, .. }) = self.get_chunk(chunk_id) else {
+            return None;
+        };
+        Some(voxels.get(coords.to_index(dimension)))
+    }
+
     /// Tries to update the block at the given position to the given material.
     /// Fails and returns false if the chunk is not populated yet.
     #[must_use]

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -55,6 +55,8 @@ pub struct Spawns {
     pub nodes: Vec<FreshNode>,
     pub block_updates: Vec<BlockUpdate>,
     pub voxel_data: Vec<(ChunkId, SerializedVoxelData)>,
+    pub inventory_additions: Vec<(EntityId, EntityId)>,
+    pub inventory_removals: Vec<(EntityId, EntityId)>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -78,6 +80,7 @@ pub struct BlockUpdate {
     pub chunk_id: ChunkId,
     pub coords: Coords,
     pub new_material: Material,
+    pub consumed_entity: Option<EntityId>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -90,6 +93,8 @@ pub struct SerializedVoxelData {
 pub enum Component {
     Character(Character),
     Position(Position),
+    Material(Material),
+    Inventory(Inventory),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -103,4 +108,9 @@ pub struct FreshNode {
 pub struct Character {
     pub name: String,
     pub state: CharacterState,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Inventory {
+    pub contents: Vec<EntityId>,
 }

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -36,10 +36,14 @@ pub struct SimConfigRaw {
 pub struct SimConfig {
     /// Amount of time between each step. Inverse of the rate
     pub step_interval: Duration,
+    /// Maximum distance at which anything can be seen in absolute units
     pub view_distance: f32,
     pub input_queue_size: Duration,
+    /// Whether gameplay-like restrictions exist, such as limited inventory
     pub gameplay_enabled: bool,
+    /// Number of voxels along the edge of a chunk
     pub chunk_size: u8,
+    /// Static configuration information relevant to character physics
     pub character: CharacterConfig,
     /// Scaling factor converting meters to absolute units
     pub meters_to_absolute: f32,
@@ -93,28 +97,41 @@ pub struct CharacterConfigRaw {
     pub air_resistance: Option<f32>,
     /// How fast the player jumps off the ground in m/s
     pub jump_speed: Option<f32>,
-    /// How far away the player needs to be from the ground in meters to be considered in the air
+    /// How far away the player needs to be from the ground in meters to be considered in the air in meters
     pub ground_distance_tolerance: Option<f32>,
     /// Radius of the character in meters
     pub character_radius: Option<f32>,
-    /// How far a character can reach when placing blocks
+    /// How far a character can reach when placing blocks in meters
     pub block_reach: Option<f32>,
 }
 
-/// Static configuration information relevant to character physics
+/// Static configuration information relevant to character physics. Most fields are based on
+/// absolute units and seconds.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CharacterConfig {
+    /// Character movement speed in units/s during no-clip
     pub no_clip_movement_speed: f32,
+    /// Character maximumum movement speed while on the ground in units/s
     pub max_ground_speed: f32,
+    /// Character artificial speed cap to avoid overloading the server in units/s
     pub speed_cap: f32,
+    /// Maximum ground slope (0=horizontal, 1=45 degrees)
     pub max_ground_slope: f32,
+    /// Character acceleration while on the ground in units/s^2
     pub ground_acceleration: f32,
+    /// Character acceleration while in the air in units/s^2
     pub air_acceleration: f32,
+    /// Acceleration of gravity in units/s^2
     pub gravity_acceleration: f32,
+    /// Air resistance in (units/s^2) per (units/s); scales linearly with respect to speed
     pub air_resistance: f32,
+    /// How fast the player jumps off the ground in units/s
     pub jump_speed: f32,
+    /// How far away the player needs to be from the ground in meters to be considered in the air in absolute units
     pub ground_distance_tolerance: f32,
+    /// Radius of the character in absolute units
     pub character_radius: f32,
+    /// How far a character can reach when placing blocks in absolute units
     pub block_reach: f32,
 }
 

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -13,6 +13,8 @@ pub struct SimConfigRaw {
     /// Maximum distance at which anything can be seen in meters
     pub view_distance: Option<f32>,
     pub input_queue_size_ms: Option<u16>,
+    /// Whether gameplay-like restrictions exist, such as limited inventory
+    pub gameplay_enabled: Option<bool>,
     /// Number of voxels along the edge of a chunk
     pub chunk_size: Option<u8>,
     /// Approximate length of the edge of a voxel in meters
@@ -36,6 +38,7 @@ pub struct SimConfig {
     pub step_interval: Duration,
     pub view_distance: f32,
     pub input_queue_size: Duration,
+    pub gameplay_enabled: bool,
     pub chunk_size: u8,
     pub character: CharacterConfig,
     /// Scaling factor converting meters to absolute units
@@ -51,6 +54,7 @@ impl SimConfig {
             step_interval: Duration::from_secs(1) / x.rate.unwrap_or(30) as u32,
             view_distance: x.view_distance.unwrap_or(90.0) * meters_to_absolute,
             input_queue_size: Duration::from_millis(x.input_queue_size_ms.unwrap_or(50).into()),
+            gameplay_enabled: x.gameplay_enabled.unwrap_or(false),
             chunk_size,
             character: CharacterConfig::from_raw(&x.character, meters_to_absolute),
             meters_to_absolute,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -115,20 +115,15 @@ impl Server {
 
         // Step the simulation
         let (spawns, delta) = self.sim.step();
-        let spawns = Arc::new(spawns);
+        let spawns = spawns.map(Arc::new);
         let mut overran = Vec::new();
         for (client_id, client) in &mut self.clients {
             if let Some(ref mut handles) = client.handles {
                 let mut delta = delta.clone();
                 delta.latest_input = client.latest_input_processed;
                 let r1 = handles.unordered.try_send(delta);
-                let r2 = if !spawns.spawns.is_empty()
-                    || !spawns.despawns.is_empty()
-                    || !spawns.nodes.is_empty()
-                    || !spawns.block_updates.is_empty()
-                    || !spawns.voxel_data.is_empty()
-                {
-                    handles.ordered.try_send(spawns.clone())
+                let r2 = if let Some(spawns) = spawns.as_ref() {
+                    handles.ordered.try_send(Arc::clone(spawns))
                 } else {
                     Ok(())
                 };


### PR DESCRIPTION
Partial fix for #397

This PR adds the initial version of an inventory component for players to store blocks they break. The following features exist:
- An ability to turn itself on and off, controlled by the `gameplay_enabled` sim_config property
- The GUI that tells you the quantity of the selected material you have. Since not all materials are selectable yet, if you break an unselectable material, it effectively disappears into the void.
- A server-authoritative inventory that gets synchronized with the client

The following features are left to future work:
- The ability to select any material you have on you
- A GUI that shows you everything you're holding at once
- Serialization of the inventory for saving
- Prediction of inventory contents (Required for the player to be able to place more than one block of the same material before receiving server confirmation. This feature likely should be added together with prediction of the world's block updates.)