### PR TITLE
Fix issues with Windows package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,7 +17,7 @@ jobs:
           lfs: true
       - name: Cache Vulkan SDK
         id: cache-vulkan
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.VULKAN_SDK }}
           key: vulkan-${{ env.VULKAN_VERSION }}
@@ -25,7 +25,7 @@ jobs:
         if: steps.cache-vulkan.outputs.cache-hit != 'true'
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_VERSION }}/windows/VulkanSDK-${{ env.VULKAN_VERSION }}-Installer.exe" -OutFile vulkan.exe
-          7z x -aoa vulkan.exe "-o$env:VULKAN_SDK" Lib
+          7z x -aoa vulkan.exe "-o$env:VULKAN_SDK" Lib share/vulkan/registry/vk.xml
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
An update to the shaderc-sys crate from 0.7 to 0.8 added a requirement to be able to view the vk.xml file to gather information about the installed version of Vulkan. To fix the workflow, we need to include that file in the list of files being extracted.

In addition, the cache action was upgraded from v2 to v4 because the old one was broken with errors like the following:
```
C:/VulkanSDK/1.3.231.1/: Can't create '\\\\?\\C:\\VulkanSDK\\1.3.231.1'
```