### PR TITLE
Simplify and document expansion functions of Graph

### DIFF
--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -372,7 +372,7 @@ impl Sim {
             metrics::declare_ready_for_profiling();
         }
         for node in &msg.nodes {
-            self.graph.insert_child(node.parent, node.side);
+            self.graph.insert_neighbor(node.parent, node.side);
         }
         populate_fresh_nodes(&mut self.graph);
         for block_update in msg.block_updates.into_iter() {


### PR DESCRIPTION
This PR accomplishes a few things, all in the spirit of hopefully reducing the mental load of understanding all the algorithms that allow `Graph` to grow:
- The term "parent" no longer depends on the graph's generation order. It now refers to the node along the first descender in enum order.
- Uses of the term "parent" and "child" were removed whenever they didn't refer to the above meaning of "parent". This includes renaming `insert_child` to `insert_neighbor` and renaming `populate_shorter_neighbors_of_child` to `populate_shorter_neighbors_of_subject` (where "subject" is a term that was introduced internally for "the neighbor node we want to insert" to try to improve clarity).
- An unused code path was removed in `ensure_neighbor` to cover the impossible scenario of a not-yet-generated shorter neighbor. Removing this code-path turned `ensure_neighbor` into a one-liner.
- The most conceptually difficult function in the algorithm, `populate_shorter_neighbors_of_subject` is now documented in detail. For simplification purposes, it was also altered to return all shorter neighbors, including the passed in argument (as it previously excluded this argument, resulting in extra logic for `insert_neighbor`).