### PR TITLE
Load character entities from the save file

### DIFF
--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -117,6 +117,12 @@ impl<N: RealField + Copy> MIsometry<N> {
     pub fn from_columns_unchecked(columns: &[MVector<N>; 4]) -> Self {
         Self(na::Matrix4::from_columns(&(*columns).map(|x| x.0)))
     }
+    /// Creates an `MIsometry` with its elements filled with the components provided by a slice in column-major order.
+    /// It is the caller's responsibility to ensure that the resulting matrix is a valid isometry.
+    #[inline]
+    pub fn from_column_slice_unchecked(data: &[N]) -> Self {
+        Self(na::Matrix4::from_column_slice(data))
+    }
     /// Minkowski transpose. Inverse for hyperbolic isometries
     #[rustfmt::skip]
     pub fn mtranspose(self) -> Self {

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -66,7 +66,7 @@ pub struct Command {
     pub orientation: na::UnitQuaternion<f32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CharacterInput {
     /// Relative to the character's current position, excluding orientation
     pub movement: na::Vector3<f32>,
@@ -113,4 +113,13 @@ pub struct Character {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Inventory {
     pub contents: Vec<EntityId>,
+}
+
+pub mod connection_error_codes {
+    use quinn::VarInt;
+
+    pub const CONNECTION_LOST: VarInt = VarInt::from_u32(0);
+    pub const STREAM_ERROR: VarInt = VarInt::from_u32(1);
+    pub const BAD_CLIENT_COMMAND: VarInt = VarInt::from_u32(2);
+    pub const NAME_CONFLICT: VarInt = VarInt::from_u32(3);
 }

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -138,6 +138,16 @@ impl Reader {
             .map(|n| Ok(n.map_err(GetError::from)?.0.value()))
             .collect()
     }
+
+    /// Temporary function to load all entity-related save data at once.
+    /// TODO: Replace this implementation with a streaming implementation
+    /// that does not require loading everything at once
+    pub fn get_all_entity_node_ids(&self) -> Result<Vec<u128>, GetError> {
+        self.entity_nodes
+            .iter()?
+            .map(|n| Ok(n.map_err(GetError::from)?.0.value()))
+            .collect()
+    }
 }
 
 fn decompress(

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -16,7 +16,11 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::{IntervalStream, ReceiverStream};
 use tracing::{debug, error, error_span, info, trace};
 
-use common::{codec, proto, SimConfig};
+use common::{
+    codec,
+    proto::{self, connection_error_codes},
+    SimConfig,
+};
 use input_queue::InputQueue;
 use save::Save;
 use sim::Sim;
@@ -138,9 +142,10 @@ impl Server {
         }
         for client_id in overran {
             error!("dropping slow client {:?}", client_id.0);
-            self.clients[client_id]
-                .conn
-                .close(1u32.into(), b"client reading too slowly");
+            self.clients[client_id].conn.close(
+                connection_error_codes::STREAM_ERROR,
+                b"client reading too slowly",
+            );
             self.cleanup_client(client_id);
         }
 
@@ -161,7 +166,14 @@ impl Server {
             ClientEvent::Hello(hello) => {
                 assert!(client.handles.is_none());
                 let snapshot = Arc::new(self.sim.snapshot());
-                let (id, entity) = self.sim.spawn_character(hello);
+                let Some((id, entity)) = self.sim.activate_or_spawn_character(&hello) else {
+                    error!("could not spawn {} due to name conflict", hello.name);
+                    client
+                        .conn
+                        .close(connection_error_codes::NAME_CONFLICT, b"name conflict");
+                    self.cleanup_client(client_id);
+                    return;
+                };
                 let (ordered_send, ordered_recv) = mpsc::channel(32);
                 ordered_send.try_send(snapshot).unwrap();
                 let (unordered_send, unordered_recv) = mpsc::channel(32);
@@ -183,7 +195,9 @@ impl Server {
             }
             ClientEvent::Lost(e) => {
                 error!("lost: {:#}", e);
-                client.conn.close(0u32.into(), b"");
+                client
+                    .conn
+                    .close(connection_error_codes::CONNECTION_LOST, b"");
                 self.cleanup_client(client_id);
             }
             ClientEvent::Command(cmd) => {
@@ -199,7 +213,7 @@ impl Server {
 
     fn cleanup_client(&mut self, client: ClientId) {
         if let Some(ref x) = self.clients[client].handles {
-            self.sim.destroy(x.character);
+            self.sim.deactivate_character(x.character);
         }
         self.clients.remove(client);
     }
@@ -249,7 +263,10 @@ async fn drive_recv(
                     // we want to drop the client. We close the connection, which will cause `drive_recv` to
                     // return eventually.
                     tracing::error!("Error when parsing unordered stream from client: {e}");
-                    connection.close(2u32.into(), b"could not process stream");
+                    connection.close(
+                        connection_error_codes::BAD_CLIENT_COMMAND,
+                        b"could not process stream",
+                    );
                 }
                 Ok(msg) => {
                     let _ = send.send((id, ClientEvent::Command(msg))).await;


### PR DESCRIPTION
This PR sets up the initial implementation of loading entity data from a save file by loading player characters. In single-player, this has the effect of having the game remember where you were when you close it. If you change your name, you will spawn in as a new character.

The following are not currently implemented:
* Saving client-authoritative orientation data (the orientation quaternion)
* Only loading entities in nearby chunks (Currently, everything is loaded.)
* Saving the inventory