### PR TITLE
Don't crash when placing blocks with gameplay enabled

### DIFF
--- a/save/gen-protos/Cargo.toml
+++ b/save/gen-protos/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prost-build = "0.13.1"
+prost-build = "0.13.3"

--- a/save/src/protos.rs
+++ b/save/src/protos.rs
@@ -48,8 +48,8 @@ impl ComponentType {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            ComponentType::Position => "POSITION",
-            ComponentType::Name => "NAME",
+            Self::Position => "POSITION",
+            Self::Name => "NAME",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -402,11 +402,10 @@ impl Sim {
         if let Ok(position) = self.world.get::<&Position>(entity) {
             self.graph_entities.remove(position.node, entity);
         }
-        self.world.despawn(entity).unwrap();
-
         if !self.world.satisfies::<&InactiveCharacter>(entity).unwrap() {
             self.accumulated_changes.despawns.push(id);
         }
+        self.world.despawn(entity).unwrap();
     }
 
     /// Collect information about all entities, for transmission to new clients


### PR DESCRIPTION
This fixes a bug I introduced in PR #414 that likely only wasn't noticed because, in the current state of the game, entities are rarely destroyed.

Error:
```
thread '<unnamed>' panicked at server\src\sim.rs:407:64: 
called `Result::unwrap()` on an `Err` value: NoSuchEntity
```