### PR TITLE
Serialize the player's inventory in save files

### DIFF
--- a/common/src/world.rs
+++ b/common/src/world.rs
@@ -95,11 +95,25 @@ impl Material {
     ];
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct MaterialOutOfBounds;
+
+impl std::fmt::Display for MaterialOutOfBounds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Integer input does not represent a valid material")
+    }
+}
+
+impl std::error::Error for MaterialOutOfBounds {}
+
 impl TryFrom<u16> for Material {
-    type Error = ();
+    type Error = MaterialOutOfBounds;
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        Material::VALUES.get(value as usize).ok_or(()).copied()
+        Material::VALUES
+            .get(value as usize)
+            .ok_or(MaterialOutOfBounds)
+            .copied()
     }
 }
 

--- a/save/src/protos.proto
+++ b/save/src/protos.proto
@@ -36,4 +36,8 @@ enum ComponentType {
     POSITION = 0;
     // UTF-8 text
     NAME = 1;
+    // u16
+    MATERIAL = 2;
+    // List of u64
+    INVENTORY = 3;
 }

--- a/save/src/protos.rs
+++ b/save/src/protos.rs
@@ -40,6 +40,10 @@ pub enum ComponentType {
     Position = 0,
     /// UTF-8 text
     Name = 1,
+    /// u16
+    Material = 2,
+    /// List of u64
+    Inventory = 3,
 }
 impl ComponentType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -50,6 +54,8 @@ impl ComponentType {
         match self {
             Self::Position => "POSITION",
             Self::Name => "NAME",
+            Self::Material => "MATERIAL",
+            Self::Inventory => "INVENTORY",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -57,6 +63,8 @@ impl ComponentType {
         match value {
             "POSITION" => Some(Self::Position),
             "NAME" => Some(Self::Name),
+            "MATERIAL" => Some(Self::Material),
+            "INVENTORY" => Some(Self::Inventory),
             _ => None,
         }
     }


### PR DESCRIPTION
This completes part of #428.

Allows users to exit and re-open Hypermine while keeping the contents of their inventory, as previously, the inventory was cleared every time the game was loaded.