### PR TITLE
Fix clippy lint warnings for Rust 1.83

### DIFF
--- a/client/src/graphics/voxels/surface_extraction.rs
+++ b/client/src/graphics/voxels/surface_extraction.rs
@@ -110,7 +110,7 @@ impl SurfaceExtraction {
                 .map_entries(&specialization_map_entries)
                 .data(as_bytes(&WORKGROUP_SIZE));
 
-            let p_name = b"main\0".as_ptr() as *const c_char;
+            let p_name = c"main".as_ptr() as *const c_char;
             let mut pipelines = device
                 .create_compute_pipelines(
                     gfx.pipeline_cache,
@@ -651,5 +651,5 @@ const FACE_SIZE: vk::DeviceSize = 8;
 const WORKGROUP_SIZE: [u32; 3] = [4, 4, 4];
 
 fn round_up(value: vk::DeviceSize, alignment: vk::DeviceSize) -> vk::DeviceSize {
-    ((value + alignment - 1) / alignment) * alignment
+    value.div_ceil(alignment) * alignment
 }

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -46,7 +46,7 @@ impl Mul<Plane<f64>> for Side {
     }
 }
 
-impl<'a, N: na::RealField + Copy> Mul<Plane<N>> for &'a MIsometry<N> {
+impl<N: na::RealField + Copy> Mul<Plane<N>> for &MIsometry<N> {
     type Output = Plane<N>;
     fn mul(self, rhs: Plane<N>) -> Plane<N> {
         Plane {


### PR DESCRIPTION
The lints in question are
- [clippy::manual_c_str_literals](https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals)
- [clippy::manual_div_ceil](https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil)
- [clippy::needless_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes)