### PR TITLE
Resolve clippy lints for Rust 1.84.0

### DIFF
--- a/client/src/graphics/gltf_mesh.rs
+++ b/client/src/graphics/gltf_mesh.rs
@@ -242,10 +242,7 @@ async fn load_geom(
         .read_normals()
         .ok_or_else(|| anyhow!("normals missing"))?;
     let vertex_count = positions.len();
-    if vertex_count != normals.len()
-        || texcoords
-            .as_ref()
-            .map_or(false, |x| vertex_count != x.len())
+    if vertex_count != normals.len() || texcoords.as_ref().is_some_and(|x| vertex_count != x.len())
     {
         bail!("inconsistent vertex attribute counts");
     }

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -277,7 +277,7 @@ impl Sim {
             Spawns(msg) => self.handle_spawns(msg),
             StateDelta(msg) => {
                 // Discard out-of-order messages, taking care to account for step counter wrapping.
-                if self.step.map_or(false, |x| x.wrapping_sub(msg.step) >= 0) {
+                if self.step.is_some_and(|x| x.wrapping_sub(msg.step) >= 0) {
                     return;
                 }
                 self.step = Some(msg.step);

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -166,7 +166,7 @@ impl Graph {
     /// Whether `node`'s neighbor along `side` is closer than it to the origin
     fn is_descender(&self, node: NodeId, side: Side) -> bool {
         let v = &self.nodes[&node];
-        v.neighbors[side as usize].map_or(false, |x| self.nodes[&x].length < v.length)
+        v.neighbors[side as usize].is_some_and(|x| self.nodes[&x].length < v.length)
     }
 
     /// Inserts the neighbor of the given node at the given side into the graph, ensuring that all


### PR DESCRIPTION
Resolve all instances of the clippy lint [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or)