### PR TITLE
Document and simplify math module

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -289,7 +289,7 @@ impl Draw {
         let draw_started = Instant::now();
         let view = sim.as_ref().map_or_else(Position::origin, |sim| sim.view());
         let projection = frustum.projection(1.0e-4);
-        let view_projection = projection.matrix() * na::Matrix4::from(view.local.mtranspose());
+        let view_projection = projection.matrix() * na::Matrix4::from(view.local.inverse());
         self.loader.drive();
 
         let device = &*self.gfx.device;

--- a/client/src/graphics/frustum.rs
+++ b/client/src/graphics/frustum.rs
@@ -93,7 +93,8 @@ impl FrustumPlanes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::math::translate_along;
+
+    use common::math::MIsometry;
     use std::f32;
 
     #[test]
@@ -102,28 +103,27 @@ mod tests {
         let planes = Frustum::from_vfov(f32::consts::FRAC_PI_4, 1.0).planes();
         assert!(planes.contain(&MVector::origin(), 0.1));
         assert!(planes.contain(
-            &(translate_along(&-na::Vector3::z()) * MVector::origin()),
+            &(MIsometry::translation_along(&-na::Vector3::z()) * MVector::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(translate_along(&na::Vector3::z()) * MVector::origin()),
-            0.0
-        ));
-
-        assert!(!planes.contain(
-            &(translate_along(&na::Vector3::x()) * MVector::origin()),
+            &(MIsometry::translation_along(&na::Vector3::z()) * MVector::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(translate_along(&na::Vector3::y()) * MVector::origin()),
+            &(MIsometry::translation_along(&na::Vector3::x()) * MVector::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(translate_along(&-na::Vector3::x()) * MVector::origin()),
+            &(MIsometry::translation_along(&na::Vector3::y()) * MVector::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(translate_along(&-na::Vector3::y()) * MVector::origin()),
+            &(MIsometry::translation_along(&-na::Vector3::x()) * MVector::origin()),
+            0.0
+        ));
+        assert!(!planes.contain(
+            &(MIsometry::translation_along(&-na::Vector3::y()) * MVector::origin()),
             0.0
         ));
     }

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -122,7 +122,7 @@ impl Voxels {
         }
         let node_scan_started = Instant::now();
         let frustum_planes = frustum.planes();
-        let local_to_view = view.local.mtranspose();
+        let local_to_view = view.local.inverse();
         let mut extractions = Vec::new();
         let mut workqueue_is_full = false;
         for &(node, ref node_transform) in nearby_nodes {

--- a/client/src/local_character_controller.rs
+++ b/client/src/local_character_controller.rs
@@ -25,8 +25,7 @@ impl LocalCharacterController {
     pub fn oriented_position(&self) -> Position {
         Position {
             node: self.position.node,
-            local: self.position.local
-                * MIsometry::unit_quaternion_to_homogeneous(self.orientation),
+            local: self.position.local * MIsometry::from(self.orientation),
         }
     }
 

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -11,7 +11,7 @@ use common::{
     character_controller,
     collision_math::Ray,
     graph::{Graph, NodeId},
-    graph_ray_casting, math,
+    graph_ray_casting,
     math::{MIsometry, MVector},
     node::{populate_fresh_nodes, ChunkId, VoxelData},
     proto::{
@@ -510,8 +510,9 @@ impl Sim {
     pub fn view(&self) -> Position {
         let mut pos = self.local_character_controller.oriented_position();
         let up = self.graph.get_relative_up(&pos).unwrap();
-        pos.local *=
-            math::translate_along(&(up.as_ref() * (self.cfg.character.character_radius - 1e-3)));
+        pos.local *= MIsometry::translation_along(
+            &(up.as_ref() * (self.cfg.character.character_radius - 1e-3)),
+        );
         pos
     }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { version = "0.3.15", default-features = false, features = 
 rand = "0.9.0"
 rand_pcg = "0.9.0"
 rand_distr = "0.5.0"
+simba = "0.9.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/common/src/character_controller/collision.rs
+++ b/common/src/character_controller/collision.rs
@@ -5,7 +5,7 @@ use tracing::error;
 use crate::{
     collision_math::Ray,
     graph::Graph,
-    graph_collision, math,
+    graph_collision,
     math::{MIsometry, MVector},
     proto::Position,
 };
@@ -56,7 +56,7 @@ pub fn check_collision(
         .atanh();
 
     let displacement_vector = displacement_normalized.xyz() * distance;
-    let displacement_transform = math::translate_along(&displacement_vector);
+    let displacement_transform = MIsometry::translation_along(&displacement_vector);
 
     CollisionCheckingResult {
         displacement_vector,
@@ -67,7 +67,7 @@ pub fn check_collision(
             // This normal now represents a contact point at the origin, so we omit the w-coordinate
             // to ensure that it's orthogonal to the origin.
             normal: na::UnitVector3::new_normalize(
-                (displacement_transform.mtranspose() * hit.normal).xyz(),
+                (displacement_transform.inverse() * hit.normal).xyz(),
             ),
         }),
     }

--- a/common/src/character_controller/mod.rs
+++ b/common/src/character_controller/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         vector_bounds::{BoundedVectors, VectorBound},
     },
     graph::Graph,
-    math,
+    math::{self, MIsometry},
     proto::{CharacterInput, Position},
     sanitize_motion_input,
     sim_config::CharacterConfig,
@@ -47,7 +47,7 @@ pub fn run_character_step(
     }
 
     // Renormalize
-    position.local = position.local.renormalize_isometry();
+    position.local = position.local.renormalized();
     let (next_node, transition_xf) = graph.normalize_transform(position.node, &position.local);
     if next_node != position.node {
         position.node = next_node;
@@ -120,7 +120,7 @@ fn run_no_clip_character_step(
 ) {
     *velocity = ctx.movement_input * ctx.cfg.no_clip_movement_speed;
     *on_ground = false;
-    position.local *= math::translate_along(&(*velocity * ctx.dt_seconds));
+    position.local *= MIsometry::translation_along(&(*velocity * ctx.dt_seconds));
 }
 
 /// Returns the normal corresponding to the ground below the character, up to the `allowed_distance`. If

--- a/common/src/chunk_ray_casting.rs
+++ b/common/src/chunk_ray_casting.rs
@@ -70,7 +70,7 @@ fn find_face_collision(
         // Find a normal to the grid plane. Note that (t, 0, 0, x) is a normal of the plane whose closest point
         // to the origin is (x, 0, 0, t), and we use that fact here.
         let normal = math::tuv_to_xyz(t_axis, MVector::new(1.0, 0.0, 0.0, layout.grid_to_dual(t)))
-            .lorentz_normalize();
+            .normalized();
 
         let Some(new_tanh_distance) = ray.solve_point_plane_intersection(&normal) else {
             continue;
@@ -186,7 +186,7 @@ mod tests {
             ray_start_grid_coords[2] / ctx.layout.dual_to_grid_factor(),
             1.0,
         )
-        .lorentz_normalize();
+        .normalized();
 
         let ray_end = MVector::new(
             ray_end_grid_coords[0] / ctx.layout.dual_to_grid_factor(),
@@ -194,12 +194,12 @@ mod tests {
             ray_end_grid_coords[2] / ctx.layout.dual_to_grid_factor(),
             1.0,
         )
-        .lorentz_normalize();
+        .normalized();
 
         let ray = Ray::new(
             ray_start,
             ((ray_end - ray_start) + ray_start * ray_start.mip(&(ray_end - ray_start)))
-                .lorentz_normalize(),
+                .normalized(),
         );
 
         let tanh_distance = (-(ray_start.mip(&ray_end))).acosh();

--- a/common/src/collision_math.rs
+++ b/common/src/collision_math.rs
@@ -152,12 +152,11 @@ mod tests {
     use approx::assert_abs_diff_eq;
 
     use super::*;
-    use crate::math;
 
     #[test]
     fn solve_sphere_plane_intersection_example() {
         // Hit the z=0 plane with a radius of 0.2
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::new(0.8, 0.0, 0.6, 0.0));
         let normal = -MVector::z();
         let hit_point = ray
@@ -165,7 +164,7 @@ mod tests {
                 ray.solve_sphere_plane_intersection(&normal, 0.2_f32.sinh())
                     .unwrap(),
             )
-            .lorentz_normalize();
+            .normalized();
 
         assert_abs_diff_eq!(hit_point.mip(&normal), 0.2_f32.sinh(), epsilon = 1e-4);
     }
@@ -173,7 +172,7 @@ mod tests {
     #[test]
     fn solve_sphere_plane_intersection_direct_hit() {
         // Directly hit the z=0 plane with a ray 0.5 units away and a radius of 0.2.
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::z());
         let normal = -MVector::z();
         assert_abs_diff_eq!(
@@ -187,7 +186,7 @@ mod tests {
     #[test]
     fn solve_sphere_plane_intersection_miss() {
         // No collision with the plane anywhere along the ray's line
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::x());
         let normal = -MVector::z();
         assert!(ray
@@ -198,7 +197,7 @@ mod tests {
     #[test]
     fn solve_sphere_plane_intersection_margin() {
         // Sphere is already contacting the plane, with some error
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.2))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.2))
             * &Ray::new(MVector::origin(), MVector::z());
         let normal = -MVector::z();
         assert_eq!(
@@ -211,10 +210,10 @@ mod tests {
     #[test]
     fn solve_sphere_line_intersection_example() {
         // Hit the x=z=0 line with a radius of 0.2
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(
                 MVector::origin(),
-                MVector::new(1.0, 2.0, 3.0, 0.0).normalize(),
+                MVector::new(1.0, 2.0, 3.0, 0.0).normalized(),
             );
         let line_normal0 = MVector::x();
         let line_normal1 = MVector::z();
@@ -223,7 +222,7 @@ mod tests {
                 ray.solve_sphere_line_intersection(&line_normal0, &line_normal1, 0.2_f32.sinh())
                     .unwrap(),
             )
-            .lorentz_normalize();
+            .normalized();
         // Measue the distance from hit_point to the line and ensure it's equal to the radius
         assert_abs_diff_eq!(
             (hit_point.mip(&line_normal0).powi(2) + hit_point.mip(&line_normal1).powi(2)).sqrt(),
@@ -237,8 +236,8 @@ mod tests {
         // Directly hit the x=z=0 line with a ray 0.5 units away and a radius of 0.2.
 
         // Ensure the ray is slightly off-center so that the distance math is shown to be correct
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.7, 0.0))
-            * math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.7, 0.0))
+            * MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::z());
         let line_normal0 = MVector::x();
         let line_normal1 = MVector::z();
@@ -253,7 +252,7 @@ mod tests {
     #[test]
     fn solve_sphere_line_intersection_miss() {
         // No collision with the line anywhere along the ray's line
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::x());
         let line_normal0 = MVector::x();
         let line_normal1 = MVector::z();
@@ -265,7 +264,7 @@ mod tests {
     #[test]
     fn solve_sphere_line_intersection_margin() {
         // Sphere is already contacting the line, with some error
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.2))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.2))
             * &Ray::new(MVector::origin(), MVector::z());
         let line_normal0 = MVector::x();
         let line_normal1 = MVector::z();
@@ -300,10 +299,10 @@ mod tests {
     #[test]
     fn solve_sphere_point_intersection_example() {
         // Hit the origin with a radius of 0.2
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(
                 MVector::origin(),
-                MVector::new(1.0, 2.0, 6.0, 0.0).normalize(),
+                MVector::new(1.0, 2.0, 6.0, 0.0).normalized(),
             );
         let point_position = MVector::origin();
         let point_normal0 = MVector::x();
@@ -319,7 +318,7 @@ mod tests {
                 )
                 .unwrap(),
             )
-            .lorentz_normalize();
+            .normalized();
         assert_abs_diff_eq!(
             -hit_point.mip(&point_position),
             0.2_f32.cosh(),
@@ -330,7 +329,7 @@ mod tests {
     #[test]
     fn solve_sphere_point_intersection_direct_hit() {
         // Directly hit the origin with a ray 0.5 units away and a radius of 0.2.
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::z());
         let point_normal0 = MVector::x();
         let point_normal1 = MVector::y();
@@ -351,7 +350,7 @@ mod tests {
     #[test]
     fn solve_sphere_point_intersection_miss() {
         // No collision with the point anywhere along the ray's line
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::x());
         let point_normal0 = MVector::x();
         let point_normal1 = MVector::y();
@@ -369,7 +368,7 @@ mod tests {
     #[test]
     fn solve_sphere_point_intersection_margin() {
         // Sphere is already contacting the point, with some error
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.2))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.2))
             * &Ray::new(MVector::origin(), MVector::z());
         let point_normal0 = MVector::x();
         let point_normal1 = MVector::y();
@@ -389,12 +388,12 @@ mod tests {
     #[test]
     fn foo() {
         // Hit the z=0 plane
-        let ray = math::translate_along(&na::Vector3::new(0.0, 0.0, -0.5))
+        let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::new(0.8, 0.0, 0.6, 0.0));
         let normal = -MVector::z();
         let hit_point = ray
             .ray_point(ray.solve_point_plane_intersection(&normal).unwrap())
-            .lorentz_normalize();
+            .normalized();
         assert_abs_diff_eq!(hit_point.mip(&normal), 0.0, epsilon = 1e-4);
     }
 

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -524,16 +524,16 @@ mod data {
         LazyLock::new(|| Vertex::VALUES.map(|vertex| vertex.dual_to_node().parity()));
 
     pub static SIDE_NORMALS_F32: LazyLock<[MVector<f32>; Side::VALUES.len()]> =
-        LazyLock::new(|| SIDE_NORMALS_F64.map(|n| n.to_f32()));
+        LazyLock::new(|| SIDE_NORMALS_F64.map(|n| n.cast()));
 
     pub static REFLECTIONS_F32: LazyLock<[MIsometry<f32>; Side::VALUES.len()]> =
-        LazyLock::new(|| REFLECTIONS_F64.map(|n| n.to_f32()));
+        LazyLock::new(|| REFLECTIONS_F64.map(|n| n.cast()));
 
     pub static DUAL_TO_NODE_F32: LazyLock<[MIsometry<f32>; Vertex::VALUES.len()]> =
-        LazyLock::new(|| DUAL_TO_NODE_F64.map(|n| n.to_f32()));
+        LazyLock::new(|| DUAL_TO_NODE_F64.map(|n| n.cast()));
 
     pub static NODE_TO_DUAL_F32: LazyLock<[MIsometry<f32>; Vertex::VALUES.len()]> =
-        LazyLock::new(|| NODE_TO_DUAL_F64.map(|n| n.to_f32()));
+        LazyLock::new(|| NODE_TO_DUAL_F64.map(|n| n.cast()));
 
     pub static DUAL_TO_CHUNK_FACTOR_F32: LazyLock<f32> =
         LazyLock::new(|| *DUAL_TO_CHUNK_FACTOR_F64 as f32);

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -56,7 +56,7 @@ pub fn sphere_cast(
             Some(GraphCastHit {
                 tanh_distance: hit.tanh_distance,
                 chunk,
-                normal: transform.mtranspose() * hit.normal,
+                normal: transform.inverse() * hit.normal,
             })
         });
     }
@@ -187,7 +187,7 @@ mod tests {
                     self.chosen_chunk_relative_grid_ray_end[2] / dual_to_grid_factor,
                     1.0,
                 )
-                .lorentz_normalize();
+                .normalized();
 
             let ray_position = *Vertex::A.dual_to_node()
                 * MVector::new(
@@ -196,13 +196,12 @@ mod tests {
                     self.start_chunk_relative_grid_ray_start[2] / dual_to_grid_factor,
                     1.0,
                 )
-                .lorentz_normalize();
+                .normalized();
             let ray_direction = ray_target - ray_position;
 
             let ray = Ray::new(
                 ray_position,
-                (ray_direction + ray_position * ray_position.mip(&ray_direction))
-                    .lorentz_normalize(),
+                (ray_direction + ray_position * ray_position.mip(&ray_direction)).normalized(),
             );
 
             let tanh_distance =
@@ -444,7 +443,7 @@ mod tests {
         // set to 0 and normalized
         let ray = Ray::new(
             MVector::origin(),
-            (vertex_pos - MVector::w() * vertex_pos.w).normalize(),
+            (vertex_pos - MVector::w() * vertex_pos.w).normalized(),
         );
         let sphere_radius = 0.1;
 

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -8,6 +8,7 @@
 
 use na::{RealField, Scalar};
 use serde::{Deserialize, Serialize};
+use simba::scalar::SupersetOf;
 use std::ops::*;
 
 /// A stack-allocated 4-dimensional column-vector in Minkowski space. Such
@@ -106,6 +107,12 @@ impl<N: RealField + Copy> MVector<N> {
         self.0 * na::RowVector4::new(other.x, other.y, other.z, -other.w)
     }
 
+    /// Cast the components of `self` to another type.
+    #[inline]
+    pub fn cast<N2: RealField + Copy + SupersetOf<N>>(self) -> MVector<N2> {
+        MVector(self.0.cast())
+    }
+
     /// The column vector with components `[0, 0, 0, 0]`.
     #[inline]
     pub fn zero() -> Self {
@@ -155,20 +162,6 @@ impl<N: RealField + Copy> MVector<N> {
     #[inline]
     pub fn xyz(self) -> na::Vector3<N> {
         self.0.xyz()
-    }
-}
-
-impl MVector<f32> {
-    /// Casts the components to an `f64`
-    pub fn to_f64(self) -> MVector<f64> {
-        MVector(self.0.cast::<f64>())
-    }
-}
-
-impl MVector<f64> {
-    /// Casts the components to an `f32`
-    pub fn to_f32(self) -> MVector<f32> {
-        MVector(self.0.cast::<f32>())
     }
 }
 
@@ -465,19 +458,11 @@ impl<N: RealField + Copy> MIsometry<N> {
         // orientation components.
         normalized_translation_component * normalized_orientation_component
     }
-}
 
-impl MIsometry<f32> {
-    /// Casts the components to an `f64`
-    pub fn to_f64(self) -> MIsometry<f64> {
-        MIsometry(self.0.cast::<f64>())
-    }
-}
-
-impl MIsometry<f64> {
-    /// Casts the components to an `f32`
-    pub fn to_f32(self) -> MIsometry<f32> {
-        MIsometry(self.0.cast::<f32>())
+    /// Cast the components of `self` to another type.
+    #[inline]
+    pub fn cast<N2: RealField + Copy + SupersetOf<N>>(self) -> MIsometry<N2> {
+        MIsometry(self.0.cast())
     }
 }
 

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -40,7 +40,7 @@ impl Graph {
     pub fn get_relative_up(&self, position: &Position) -> Option<na::UnitVector3<f32>> {
         let node = self.get(position.node).as_ref()?;
         Some(na::UnitVector3::new_normalize(
-            (position.local.mtranspose() * node.state.up_direction()).xyz(),
+            (position.local.inverse() * node.state.up_direction()).xyz(),
         ))
     }
 
@@ -432,7 +432,6 @@ impl VoxelAABB {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::math;
     use crate::math::{MIsometry, MVector};
 
     use super::*;
@@ -446,10 +445,8 @@ mod tests {
         let layout = ChunkLayout::new(dimension);
 
         // Pick an arbitrary ray by transforming the positive-x-axis ray.
-        let ray = MIsometry::rotation_to_homogeneous(na::Rotation3::from_axis_angle(
-            &na::Vector3::z_axis(),
-            0.4,
-        )) * math::translate_along(&na::Vector3::new(0.2, 0.3, 0.1))
+        let ray = MIsometry::from(na::Rotation3::from_axis_angle(&na::Vector3::z_axis(), 0.4))
+            * MIsometry::translation_along(&na::Vector3::new(0.2, 0.3, 0.1))
             * &Ray::new(MVector::w(), MVector::x());
 
         let tanh_distance = 0.2;
@@ -462,7 +459,7 @@ mod tests {
         let ray_test_points: Vec<_> = (0..num_ray_test_points)
             .map(|i| {
                 ray.ray_point(tanh_distance * (i as f32 / (num_ray_test_points - 1) as f32))
-                    .lorentz_normalize()
+                    .normalized()
             })
             .collect();
 
@@ -485,7 +482,7 @@ mod tests {
                 let mut plane_normal = MVector::zero();
                 plane_normal[t_axis] = 1.0;
                 plane_normal[3] = layout.grid_to_dual(t);
-                let plane_normal = plane_normal.lorentz_normalize();
+                let plane_normal = plane_normal.normalized();
 
                 for test_point in &ray_test_points {
                     assert!(
@@ -519,7 +516,7 @@ mod tests {
                     line_position[u_axis] = layout.grid_to_dual(u);
                     line_position[v_axis] = layout.grid_to_dual(v);
                     line_position[3] = 1.0;
-                    let line_position = line_position.lorentz_normalize();
+                    let line_position = line_position.normalized();
 
                     for test_point in &ray_test_points {
                         assert!(
@@ -551,7 +548,7 @@ mod tests {
                         layout.grid_to_dual(z),
                         1.0,
                     )
-                    .lorentz_normalize();
+                    .normalized();
 
                     for test_point in &ray_test_points {
                         assert!(

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{dodeca, math, math::MVector};
+use crate::{dodeca, math::MVector};
 
 /// Manually specified simulation config parameters
 #[derive(Serialize, Deserialize, Default)]
@@ -69,9 +69,11 @@ impl SimConfig {
 /// Compute the scaling factor from meters to absolute units, given the number of voxels in a chunk
 /// and the approximate size of a voxel in meters.
 fn meters_to_absolute(chunk_size: u8, voxel_size: f32) -> f32 {
-    let a = MVector::from(dodeca::Vertex::A.chunk_to_node() * na::Vector4::new(1.0, 0.5, 0.5, 1.0));
-    let b = MVector::from(dodeca::Vertex::A.chunk_to_node() * na::Vector4::new(0.0, 0.5, 0.5, 1.0));
-    let minimum_chunk_face_separation = math::distance(&a, &b);
+    let a = MVector::from(dodeca::Vertex::A.chunk_to_node() * na::Vector4::new(1.0, 0.5, 0.5, 1.0))
+        .normalized();
+    let b = MVector::from(dodeca::Vertex::A.chunk_to_node() * na::Vector4::new(0.0, 0.5, 0.5, 1.0))
+        .normalized();
+    let minimum_chunk_face_separation = a.distance(&b);
     let absolute_voxel_size = minimum_chunk_face_separation / f32::from(chunk_size);
     absolute_voxel_size / voxel_size
 }

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -121,7 +121,7 @@ impl NodeState {
     }
 
     pub fn up_direction(&self) -> MVector<f32> {
-        self.surface.normal().to_f32()
+        self.surface.normal().cast()
     }
 }
 

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -18,7 +18,6 @@ use tracing::{error, error_span, info, trace};
 use common::{
     character_controller, dodeca,
     graph::{Graph, NodeId},
-    math,
     node::{populate_fresh_nodes, Chunk},
     proto::{
         Character, CharacterInput, CharacterState, ClientHello, Command, Component, FreshNode,
@@ -365,7 +364,7 @@ impl Sim {
         // Spawn entirely new character
         let position = Position {
             node: NodeId::ROOT,
-            local: math::translate_along(&(na::Vector3::y() * 1.4)),
+            local: MIsometry::translation_along(&(na::Vector3::y() * 1.4)),
         };
         let character = Character {
             name: hello.name.clone(),


### PR DESCRIPTION
This PR makes the following changes to the `math` module:
- Functions have been re-ordered for simplicity (separated to a different commit for diff readability)
- `simba` has been added as a direct dependency so that `to_f32` and `to_f64` can be combined into a single `cast` function (separated to a different commit because of the extra dependency)
- Rustdoc comments are added to `MVector` and `MIsometry` structs and functions that could benefit from them.
- Code comments are added inside functions with complicated implementations to better explain them.
- A few functions like `as_ref` and `row` are modified to better match their `nalgebra` counterparts (with fewer copies)
- Functions that create an `MIsometry` are moved into `MIsometry` (instead of being free functions, or, in the case of `reflect()`, functions in `MVector`. These functions are also renamed to nouns to better represent the fact that they produce a matrix that performs the operation rather than performing the operation themselves.
- Most functions with "Minkowski" or "Lorentz" in their name have that part removed for brevity, as it is redundant with the `MVector` or `MIsometry` type they are associated with. This includes `mtranspose`, which is renamed to `inverse`, as that is the purpose of that operation.
    - `mip` is excluded from this rename due to familiarity and how often it's used (and the lack of a good name that still has brevity)
    - `minkowsky_outer_product` is also excluded from this rename to parallel `mip`.
- The algorthm to renormalize an isometry has been simplified to use nalgebra's QR factorization for the orientation component.
- The `midpoint`, `distance`, `reflection`, and `translation` functions are modified to only accept normalized `MVector`s as input. This is documented in the method header (and I hope that we can enforce this with types in the future).
    - In doing so, the `reflection` function also now only accepts direction-like `MVectors`, as the formula has a sign error if used with point-like `MVectors`.
    - This change also allows the `distance` function to be more numerically stable.
-  A `debug_assert!` is added to `MVector::normalized` to detect possible logic errors in the future.
- The `minkowski_outer_product` function is made private, as it is only used for intermediate calculations.
- A numerical stability warning was added to `MIsometry::renormalized` and `MVector::normalized`
- The `From<na::Vector3<N>>` implementation was removed for `MVector` because it is only used once (in `plane.rs`)
- Fix: `MIsometry` can no longer be multiplied by a number, since this violates the isometry constraint.

All changes outside the `math` module are just for compatibility with the `math` module's changes.