### PR TITLE
Document and refactor dodeca.rs

### DIFF
--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -7,7 +7,7 @@ use fxhash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dodeca::{Side, SIDE_COUNT},
+    dodeca::Side,
     math::{MIsometry, MVector},
     node::{ChunkId, ChunkLayout, Node},
 };
@@ -277,7 +277,7 @@ struct NodeContainer {
     parent_side: Option<Side>,
     /// Distance to origin via parents
     length: u32,
-    neighbors: [Option<NodeId>; SIDE_COUNT],
+    neighbors: [Option<NodeId>; Side::VALUES.len()],
 }
 
 impl NodeContainer {
@@ -286,7 +286,7 @@ impl NodeContainer {
             value: None,
             parent_side,
             length,
-            neighbors: [None; SIDE_COUNT],
+            neighbors: [None; Side::VALUES.len()],
         }
     }
 }

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -116,7 +116,7 @@ mod tests {
     fn check_surface_on_plane() {
         assert_abs_diff_eq!(
             Plane::from(Side::A).distance_to_chunk(
-                Vertex::from_sides(Side::A, Side::B, Side::C).unwrap(),
+                Vertex::from_sides([Side::A, Side::B, Side::C]).unwrap(),
                 &na::Vector3::new(0.0, 0.7, 0.1), // The first 0.0 is important, the plane is the midplane of the cube in Side::A direction
             ),
             0.0,
@@ -126,13 +126,13 @@ mod tests {
 
     #[test]
     fn check_elevation_consistency() {
-        let abc = Vertex::from_sides(Side::A, Side::B, Side::C).unwrap();
+        let abc = Vertex::from_sides([Side::A, Side::B, Side::C]).unwrap();
 
         // A cube corner should have the same elevation seen from different cubes
         assert_abs_diff_eq!(
             Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 1.0, 1.0)),
             Plane::from(Side::A).distance_to_chunk(
-                Vertex::from_sides(Side::F, Side::H, Side::J).unwrap(),
+                Vertex::from_sides([Side::F, Side::H, Side::J]).unwrap(),
                 &na::Vector3::new(1.0, 1.0, 1.0),
             ),
             epsilon = 1e-8,

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -191,7 +191,7 @@ impl Sim {
                 for side in character
                     .path
                     .into_iter()
-                    .map(|side| Side::from_index(side as usize))
+                    .map(|side| Side::VALUES[side as usize])
                 {
                     current_node = self.graph.ensure_neighbor(current_node, side);
                 }


### PR DESCRIPTION
Fixes #381

This PR makes the following changes to the `dodeca` module:
- `LazyLock` is used instead of `OnceLock` (This change is also made in cursor.rs)
- `Side` and `Vertex` have a `VALUES` array allowing for easier conversion between integers and enum values
- `VERTEX_COUNT` and `SIDE_COUNT` have been replaced with `Vertex::COUNT` and `Side::COUNT`
- `Vertex::from_sides` now takes in an array instead of 3 separate parameters for consistency with `Vertex::canonical_sides`
- Arrays are now initialized to their final values when it makes sense to do so (instead of being initialized to a dummy value and then filled in). This utilizes `array::from_fn` and `array::map` in various places.
- Complicated math is better explained in code comments
- Some implementations are replaced with simpler implementations, such as `is_facing`, `ADJACENT`, and `SIDES_TO_VERTEX`

Changes in other modules are for compatibility with the changes to `dodeca`.