### PR TITLE
Update packages to their latest versions

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,8 +14,8 @@ server = { path = "../server" }
 tracing = "0.1.10"
 ash = { version = "0.38.0", default-features = false, features = ["loaded", "debug", "std"] }
 lahar = { git = "https://github.com/Ralith/lahar", rev = "7963ae5750ea61fa0a894dbb73d3be0ac77255d2" }
-yakui = { git = "https://github.com/SecondHalfGames/yakui", rev = "136f88d54f08fcb21a5215f422c8581f89d46dd2" }
-yakui-vulkan = { git = "https://github.com/SecondHalfGames/yakui", rev = "136f88d54f08fcb21a5215f422c8581f89d46dd2" }
+yakui = "0.3.0"
+yakui-vulkan = "0.3.0"
 winit = "0.30.4"
 ash-window = "0.13"
 raw-window-handle = "0.6"
@@ -23,17 +23,17 @@ directories = "6.0.0"
 vk-shader-macros = "0.2.5"
 nalgebra = { workspace = true }
 libm = "0.2.6"
-tokio = { version = "1.18.2", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "macros"] }
 png = "0.17.5"
 anyhow = "1.0.26"
-whoami = "1.2.1"
+whoami = "1.5.2"
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 toml = { workspace = true }
 fxhash = "0.2.1"
 downcast-rs = "2.0.0"
 quinn = { workspace = true }
 futures-util = "0.3.1"
-webpki = "0.22.0"
+webpki = "0.22.4"
 hecs = { workspace = true }
 memoffset = "0.9"
 gltf = { version = "1.0.0", default-features = false, features = ["utils"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR Zlib"
 [dependencies]
 blake3 = "1.3.3"
 serde = { version = "1.0.104", features = ["derive"] }
-nalgebra = { workspace = true, features = ["rand", "serde-serialize"] }
+nalgebra = { workspace = true, features = ["serde-serialize"] }
 bincode = "1.2.1"
 anyhow = "1.0.26"
 quinn = { workspace = true }
@@ -20,9 +20,9 @@ fxhash = "0.2.1"
 tracing = "0.1.10"
 hecs = { workspace = true }
 tracing-subscriber = { version = "0.3.15", default-features = false, features = ["env-filter", "smallvec", "fmt", "ansi", "time", "parking_lot"] }
-rand = "0.8.5"
-rand_pcg = "0.3.1"
-rand_distr = "0.4.3"
+rand = "0.9.0"
+rand_pcg = "0.9.0"
+rand_distr = "0.5.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::needless_borrowed_reference)]
 
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -49,9 +49,9 @@ impl std::fmt::Display for EntityId {
     }
 }
 
-impl Distribution<EntityId> for Standard {
+impl Distribution<EntityId> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> EntityId {
-        EntityId(rng.gen())
+        EntityId(rng.random())
     }
 }
 

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -1,4 +1,4 @@
-use rand::{distributions::Uniform, Rng, SeedableRng};
+use rand::{distr::Uniform, Rng, SeedableRng};
 use rand_distr::Normal;
 
 use crate::{
@@ -387,13 +387,13 @@ impl ChunkParams {
     /// wood block as the ground block.
     fn generate_trees(&self, voxels: &mut VoxelData, rng: &mut Pcg64Mcg) {
         // margins are added to keep voxels outside the chunk from being read/written
-        let random_position = Uniform::new(1, self.dimension - 1);
+        let random_position = Uniform::new(1, self.dimension - 1).unwrap();
 
         let rain = self.env.rainfalls[0];
         let tree_candidate_count =
             (u32::from(self.dimension - 2).pow(3) as f64 * (rain / 100.0).clamp(0.0, 0.5)) as usize;
         for _ in 0..tree_candidate_count {
-            let loc = na::Vector3::from_distribution(&random_position, rng);
+            let loc = na::Vector3::from_fn(|_, _| rng.sample(random_position));
             let voxel_of_interest_index = index(self.dimension, loc);
             let neighbor_data = self.voxel_neighbors(loc, voxels);
 
@@ -477,7 +477,7 @@ struct EnviroFactors {
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: u64) -> Self {
         let mut rng = rand_pcg::Pcg64Mcg::seed_from_u64(spice);
-        let unif = Uniform::new_inclusive(-1.0, 1.0);
+        let unif = Uniform::new_inclusive(-1.0, 1.0).unwrap();
         let max_elevation = parent.max_elevation + rng.sample(Normal::new(0.0, 4.0).unwrap());
 
         Self {

--- a/save/Cargo.toml
+++ b/save/Cargo.toml
@@ -14,7 +14,7 @@ zstd = { package = "zstd-safe", version = "7.1.0", default-features = false, fea
 [dev-dependencies]
 tempfile = "3.4"
 criterion = "0.5"
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 
 [[bench]]
 name = "bench"

--- a/save/benches/bench.rs
+++ b/save/benches/bench.rs
@@ -13,7 +13,7 @@ fn save(c: &mut Criterion) {
             voxels: vec![0; 12 * 12 * 12 * 2],
         }],
     };
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
     for count in [1, 100, 10000] {
         write.throughput(Throughput::Elements(count));
         write.bench_function(BenchmarkId::from_parameter(count), |b| {
@@ -22,7 +22,7 @@ fn save(c: &mut Criterion) {
                     let file = tempfile::NamedTempFile::new().unwrap();
                     let save = Save::open(file.path(), 12).unwrap();
                     let node_ids = (&mut rng)
-                        .sample_iter(rand::distributions::Standard)
+                        .sample_iter(rand::distr::StandardUniform)
                         .take(count as usize)
                         .collect::<Vec<u128>>();
                     (file, save, node_ids)
@@ -51,7 +51,7 @@ fn save(c: &mut Criterion) {
                     let file = tempfile::NamedTempFile::new().unwrap();
                     let save = Save::open(file.path(), 12).unwrap();
                     let node_ids = (&mut rng)
-                        .sample_iter(rand::distributions::Standard)
+                        .sample_iter(rand::distr::StandardUniform)
                         .take(count as usize)
                         .collect::<Vec<u128>>();
 

--- a/save/tests/heavy.rs
+++ b/save/tests/heavy.rs
@@ -6,7 +6,7 @@ use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 #[test]
 fn write() {
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
     let file = tempfile::NamedTempFile::new().unwrap();
     let save = Save::open(file.path(), 12).unwrap();
     let node = save::VoxelNode {
@@ -23,7 +23,7 @@ fn write() {
         let mut writer_guard = save.write().unwrap();
         let mut writer = writer_guard.get().unwrap();
         for _ in 0..NODES {
-            writer.put_voxel_node(rng.gen(), &node).unwrap();
+            writer.put_voxel_node(rng.random(), &node).unwrap();
         }
         drop(writer);
         writer_guard.commit().unwrap();

--- a/save/tests/tests.rs
+++ b/save/tests/tests.rs
@@ -41,10 +41,10 @@ fn persist_character() {
     let save = Save::open(file.path(), 12).unwrap();
     let mut writer_guard = save.write().unwrap();
     let mut writer = writer_guard.get().unwrap();
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
     let mut path = Vec::with_capacity(17000);
     for _ in 0..17000 {
-        path.push(rng.gen_range(0..12));
+        path.push(rng.random_range(0..12));
     }
     let ch = save::Character { path };
     writer.put_character("asdf", &ch).unwrap();

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.26"
 rcgen = { version = "0.13.1", default-features = false, features = ["ring"] }
 hostname = "0.4.0"
 hecs = { workspace = true }
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 fxhash = "0.2.1"
 nalgebra = { workspace = true }
 libm = "0.2.6"

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -53,7 +53,7 @@ pub struct Sim {
 impl Sim {
     pub fn new(cfg: Arc<SimConfig>, save: &save::Save) -> Self {
         let mut result = Self {
-            rng: SmallRng::from_entropy(),
+            rng: SmallRng::from_os_rng(),
             step: 0,
             entity_ids: FxHashMap::default(),
             world: hecs::World::new(),
@@ -647,7 +647,7 @@ impl Sim {
 
     fn new_id(&mut self) -> EntityId {
         loop {
-            let id = self.rng.gen();
+            let id = self.rng.random();
             if !self.entity_ids.contains_key(&id) {
                 return id;
             }


### PR DESCRIPTION
This PR updates the following packages:
- rand
- rand_pcg
- rand_distr
- yakui
- yakui-vulkan
- tokio
- whoami
- webpki

Note that yakui released 0.3.0 recently, allowing us to use it as a cargo dependency instead of a github dependency.

The `nalgebra` package has not yet updated rand, so to avoid conflicts, I have removed the `rand` feature from `nalgebra` for now, replacing a call of `na::Vector3::from_distribution` with a call to `na::Vector3::from_fn` instead.