### PR TITLE
Introduce two new unit vector types for MVector

### DIFF
--- a/client/src/graphics/frustum.rs
+++ b/client/src/graphics/frustum.rs
@@ -1,5 +1,5 @@
 use common::Plane;
-use common::math::MVector;
+use common::math::MPoint;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Frustum {
@@ -80,7 +80,7 @@ pub struct FrustumPlanes {
 }
 
 impl FrustumPlanes {
-    pub fn contain(&self, point: &MVector<f32>, radius: f32) -> bool {
+    pub fn contain(&self, point: &MPoint<f32>, radius: f32) -> bool {
         for &plane in &[&self.left, &self.right, &self.down, &self.up] {
             if plane.distance_to(point) < -radius {
                 return false;
@@ -101,29 +101,29 @@ mod tests {
     fn planes_sanity() {
         // 90 degree square
         let planes = Frustum::from_vfov(f32::consts::FRAC_PI_4, 1.0).planes();
-        assert!(planes.contain(&MVector::origin(), 0.1));
+        assert!(planes.contain(&MPoint::origin(), 0.1));
         assert!(planes.contain(
-            &(MIsometry::translation_along(&-na::Vector3::z()) * MVector::origin()),
+            &(MIsometry::translation_along(&-na::Vector3::z()) * MPoint::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(MIsometry::translation_along(&na::Vector3::z()) * MVector::origin()),
+            &(MIsometry::translation_along(&na::Vector3::z()) * MPoint::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(MIsometry::translation_along(&na::Vector3::x()) * MVector::origin()),
+            &(MIsometry::translation_along(&na::Vector3::x()) * MPoint::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(MIsometry::translation_along(&na::Vector3::y()) * MVector::origin()),
+            &(MIsometry::translation_along(&na::Vector3::y()) * MPoint::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(MIsometry::translation_along(&-na::Vector3::x()) * MVector::origin()),
+            &(MIsometry::translation_along(&-na::Vector3::x()) * MPoint::origin()),
             0.0
         ));
         assert!(!planes.contain(
-            &(MIsometry::translation_along(&-na::Vector3::y()) * MVector::origin()),
+            &(MIsometry::translation_along(&-na::Vector3::y()) * MPoint::origin()),
             0.0
         ));
     }

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -126,7 +126,7 @@ impl Voxels {
             let mut extractions = Vec::new();
             let mut workqueue_is_full = false;
             for &(node, ref node_transform) in nearby_nodes {
-                let node_to_view = local_to_view * *node_transform;
+                let node_to_view = local_to_view * node_transform;
                 let origin = node_to_view * MVector::origin();
                 if !frustum_planes.contain(&origin, dodeca::BOUNDING_SPHERE_RADIUS) {
                     // Don't bother generating or drawing chunks from nodes that are wholly outside the

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -16,11 +16,11 @@ use crate::{
     loader::{Cleanup, LoadCtx, LoadFuture, Loadable, WorkQueue},
 };
 use common::{
-    LruSlab, dodeca,
-    dodeca::Vertex,
+    LruSlab,
+    dodeca::{self, Vertex},
     graph::NodeId,
     lru_slab::SlotId,
-    math::{MIsometry, MVector},
+    math::{MIsometry, MPoint},
     node::{Chunk, ChunkId, VoxelData},
 };
 
@@ -127,7 +127,7 @@ impl Voxels {
             let mut workqueue_is_full = false;
             for &(node, ref node_transform) in nearby_nodes {
                 let node_to_view = local_to_view * node_transform;
-                let origin = node_to_view * MVector::origin();
+                let origin = node_to_view * MPoint::origin();
                 if !frustum_planes.contain(&origin, dodeca::BOUNDING_SPHERE_RADIUS) {
                     // Don't bother generating or drawing chunks from nodes that are wholly outside the
                     // frustum.

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -12,7 +12,7 @@ use common::{
     collision_math::Ray,
     graph::{Graph, NodeId},
     graph_ray_casting,
-    math::{MIsometry, MVector},
+    math::{MDirection, MIsometry, MPoint},
     node::{ChunkId, VoxelData, populate_fresh_nodes},
     proto::{
         self, BlockUpdate, Character, CharacterInput, CharacterState, Command, Component,
@@ -549,7 +549,7 @@ impl Sim {
         let ray_casing_result = graph_ray_casting::ray_cast(
             &self.graph,
             &view_position,
-            &Ray::new(MVector::w(), -MVector::z()),
+            &Ray::new(MPoint::w(), -MDirection::z()),
             self.cfg.character.block_reach,
         );
 

--- a/common/src/character_controller/collision.rs
+++ b/common/src/character_controller/collision.rs
@@ -6,7 +6,7 @@ use crate::{
     collision_math::Ray,
     graph::Graph,
     graph_collision,
-    math::{MIsometry, MVector},
+    math::{MDirection, MIsometry, MPoint},
     proto::Position,
 };
 
@@ -17,7 +17,6 @@ pub fn check_collision(
     relative_displacement: &na::Vector3<f32>,
 ) -> CollisionCheckingResult {
     // Split relative_displacement into its norm and a unit vector
-    let relative_displacement = relative_displacement.to_homogeneous();
     let displacement_sqr = relative_displacement.norm_squared();
     if displacement_sqr < 1e-16 {
         // Fallback for if the displacement vector isn't large enough to reliably be normalized.
@@ -26,11 +25,12 @@ pub fn check_collision(
     }
 
     let displacement_norm = displacement_sqr.sqrt();
-    let displacement_normalized = relative_displacement / displacement_norm;
+    let displacement_normalized =
+        na::UnitVector3::new_unchecked(relative_displacement / displacement_norm);
 
     let ray = Ray::new(
-        MVector::origin(),
-        MVector::<f32>::from(displacement_normalized),
+        MPoint::origin(),
+        MDirection::<f32>::from(displacement_normalized),
     );
     let tanh_distance = displacement_norm.tanh();
 

--- a/common/src/chunk_ray_casting.rs
+++ b/common/src/chunk_ray_casting.rs
@@ -1,7 +1,6 @@
 use crate::{
     collision_math::Ray,
-    math,
-    math::MVector,
+    math::{MVector, PermuteXYZ},
     node::{ChunkLayout, VoxelAABB, VoxelData},
     voxel_math::{CoordAxis, CoordSign, Coords},
     world::Material,
@@ -69,8 +68,9 @@ fn find_face_collision(
     for t in bounding_box.grid_planes(t_axis) {
         // Find a normal to the grid plane. Note that (t, 0, 0, x) is a normal of the plane whose closest point
         // to the origin is (x, 0, 0, t), and we use that fact here.
-        let normal = math::tuv_to_xyz(t_axis, MVector::new(1.0, 0.0, 0.0, layout.grid_to_dual(t)))
-            .normalized();
+        let normal = MVector::new(1.0, 0.0, 0.0, layout.grid_to_dual(t))
+            .tuv_to_xyz(t_axis)
+            .normalized_direction();
 
         let Some(new_tanh_distance) = ray.solve_point_plane_intersection(&normal) else {
             continue;
@@ -97,7 +97,7 @@ fn find_face_collision(
         };
 
         let ray_endpoint = ray.ray_point(new_tanh_distance);
-        let contact_point = ray_endpoint - normal * ray_endpoint.mip(&normal);
+        let contact_point = ray_endpoint - normal.as_ref() * ray_endpoint.mip(&normal);
 
         // Compute the u and v-coordinates of the voxels at the contact point
         let Some(voxel_u) = layout.dual_to_voxel(contact_point[u_axis] / contact_point.w) else {
@@ -111,7 +111,7 @@ fn find_face_collision(
         if !voxel_is_solid(
             voxel_data,
             layout,
-            math::tuv_to_xyz(t_axis, [voxel_t, voxel_u, voxel_v]),
+            [voxel_t, voxel_u, voxel_v].tuv_to_xyz(t_axis),
         ) {
             continue;
         }
@@ -119,7 +119,7 @@ fn find_face_collision(
         // A collision was found. Update the hit.
         hit = Some(ChunkCastHit {
             tanh_distance: new_tanh_distance,
-            voxel_coords: Coords(math::tuv_to_xyz(t_axis, [voxel_t, voxel_u, voxel_v])),
+            voxel_coords: Coords([voxel_t, voxel_u, voxel_v].tuv_to_xyz(t_axis)),
             face_axis: CoordAxis::try_from(t_axis).unwrap(),
             face_sign,
         });
@@ -186,7 +186,7 @@ mod tests {
             ray_start_grid_coords[2] / ctx.layout.dual_to_grid_factor(),
             1.0,
         )
-        .normalized();
+        .normalized_point();
 
         let ray_end = MVector::new(
             ray_end_grid_coords[0] / ctx.layout.dual_to_grid_factor(),
@@ -194,12 +194,13 @@ mod tests {
             ray_end_grid_coords[2] / ctx.layout.dual_to_grid_factor(),
             1.0,
         )
-        .normalized();
+        .normalized_point();
 
         let ray = Ray::new(
             ray_start,
-            ((ray_end - ray_start) + ray_start * ray_start.mip(&(ray_end - ray_start)))
-                .normalized(),
+            ((ray_end.as_ref() - ray_start.as_ref())
+                + ray_start.as_ref() * ray_start.mip(&(ray_end.as_ref() - ray_start.as_ref())))
+            .normalized_direction(),
         );
 
         let tanh_distance = (-(ray_start.mip(&ray_end))).acosh();

--- a/common/src/dodeca.rs
+++ b/common/src/dodeca.rs
@@ -481,12 +481,12 @@ mod data {
                 // value that doesn't depend on the normal vector, so the formula
                 // used here takes advantage of that.
                 let vertex_position = (MVector::origin()
-                    - (*a.normal_f64() + *b.normal_f64() + *c.normal_f64()) * mip_origin_normal)
+                    - (a.normal_f64() + b.normal_f64() + c.normal_f64()) * mip_origin_normal)
                     .normalized();
                 MIsometry::from_columns_unchecked(&[
-                    -*a.normal_f64(),
-                    -*b.normal_f64(),
-                    -*c.normal_f64(),
+                    -a.normal_f64(),
+                    -b.normal_f64(),
+                    -c.normal_f64(),
                     vertex_position,
                 ])
             })

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -131,7 +131,7 @@ impl Graph {
         original: &MIsometry<f32>,
     ) -> (NodeId, MIsometry<f32>) {
         let mut transform = MIsometry::identity();
-        let mut location = *original * MVector::origin();
+        let mut location = original * MVector::origin();
         'outer: loop {
             for side in Side::iter() {
                 if !side.is_facing(&location) {
@@ -141,7 +141,7 @@ impl Graph {
                     None => continue,
                     Some(x) => x,
                 };
-                let mat = *side.reflection();
+                let mat = side.reflection();
                 location = mat * location;
                 transform = mat * transform;
                 continue 'outer;

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     dodeca::Side,
-    math::{MIsometry, MVector},
+    math::{MIsometry, MPoint},
     node::{ChunkId, ChunkLayout, Node},
 };
 
@@ -131,7 +131,7 @@ impl Graph {
         original: &MIsometry<f32>,
     ) -> (NodeId, MIsometry<f32>) {
         let mut transform = MIsometry::identity();
-        let mut location = original * MVector::origin();
+        let mut location = original * MPoint::origin();
         'outer: loop {
             for side in Side::iter() {
                 if !side.is_facing(&location) {

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -175,9 +175,9 @@ mod tests {
                 .node_path
                 .iter()
                 .fold(MIsometry::identity(), |transform: MIsometry<f32>, side| {
-                    transform * *side.reflection()
+                    transform * side.reflection()
                 })
-                * *self.chosen_voxel.vertex.dual_to_node();
+                * self.chosen_voxel.vertex.dual_to_node();
 
             let dual_to_grid_factor = graph.layout().dual_to_grid_factor();
             let ray_target = chosen_chunk_transform
@@ -437,7 +437,7 @@ mod tests {
         }
 
         // The node coordinates of the corner of the missing node
-        let vertex_pos = *Vertex::A.dual_to_node() * MVector::origin();
+        let vertex_pos = Vertex::A.dual_to_node() * MVector::origin();
 
         // Use a ray starting from the origin. The direction vector is vertex_pos with the w coordinate
         // set to 0 and normalized

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -88,7 +88,7 @@ mod tests {
         collision_math::Ray,
         dodeca::{self, Side, Vertex},
         graph::{Graph, NodeId},
-        math::MIsometry,
+        math::{MIsometry, MPoint},
         node::{VoxelData, populate_fresh_nodes},
         proto::Position,
         traversal::{ensure_nearby, nearby_nodes},
@@ -187,7 +187,7 @@ mod tests {
                     self.chosen_chunk_relative_grid_ray_end[2] / dual_to_grid_factor,
                     1.0,
                 )
-                .normalized();
+                .normalized_point();
 
             let ray_position = *Vertex::A.dual_to_node()
                 * MVector::new(
@@ -196,12 +196,13 @@ mod tests {
                     self.start_chunk_relative_grid_ray_start[2] / dual_to_grid_factor,
                     1.0,
                 )
-                .normalized();
-            let ray_direction = ray_target - ray_position;
+                .normalized_point();
+            let ray_direction = ray_target.as_ref() - ray_position.as_ref();
 
             let ray = Ray::new(
                 ray_position,
-                (ray_direction + ray_position * ray_position.mip(&ray_direction)).normalized(),
+                (ray_direction.as_ref() + ray_position.as_ref() * ray_position.mip(&ray_direction))
+                    .normalized_direction(),
             );
 
             let tanh_distance =
@@ -437,13 +438,13 @@ mod tests {
         }
 
         // The node coordinates of the corner of the missing node
-        let vertex_pos = Vertex::A.dual_to_node() * MVector::origin();
+        let vertex_pos = Vertex::A.dual_to_node() * MPoint::origin();
 
         // Use a ray starting from the origin. The direction vector is vertex_pos with the w coordinate
         // set to 0 and normalized
         let ray = Ray::new(
-            MVector::origin(),
-            (vertex_pos - MVector::w() * vertex_pos.w).normalized(),
+            MPoint::origin(),
+            (vertex_pos.as_ref() - MVector::w() * vertex_pos.w).normalized_direction(),
         );
         let sphere_radius = 0.1;
 

--- a/common/src/margins.rs
+++ b/common/src/margins.rs
@@ -1,7 +1,7 @@
 use crate::{
     dodeca::Vertex,
     graph::Graph,
-    math,
+    math::PermuteXYZ,
     node::{Chunk, ChunkId, VoxelData},
     voxel_math::{ChunkAxisPermutation, ChunkDirection, CoordAxis, CoordSign, Coords},
     world::Material,
@@ -62,14 +62,11 @@ pub fn fix_margins(
             // Determine coordinates of the boundary voxel (to read from) and the margin voxel (to write to)
             // in voxel_data's perspective. To convert to neighbor_voxel_data's perspective, left-multiply
             // by neighbor_axis_permutation.
-            let coords_of_boundary_voxel = CoordsWithMargins(math::tuv_to_xyz(
-                direction.axis as usize,
-                [boundary_coord, i + 1, j + 1],
-            ));
-            let coords_of_margin_voxel = CoordsWithMargins(math::tuv_to_xyz(
-                direction.axis as usize,
-                [margin_coord, i + 1, j + 1],
-            ));
+            let coords_of_boundary_voxel = CoordsWithMargins(
+                [boundary_coord, i + 1, j + 1].tuv_to_xyz(direction.axis as usize),
+            );
+            let coords_of_margin_voxel =
+                CoordsWithMargins([margin_coord, i + 1, j + 1].tuv_to_xyz(direction.axis as usize));
 
             // Use neighbor_voxel_data to set margins of voxel_data
             voxel_data[coords_of_margin_voxel.to_index(dimension)] = neighbor_voxel_data
@@ -93,10 +90,9 @@ fn all_voxels_at_face(
     let boundary_coord = CoordsWithMargins::boundary_coord(dimension, direction.sign);
     for j in 0..dimension {
         for i in 0..dimension {
-            let coords_of_boundary_voxel = CoordsWithMargins(math::tuv_to_xyz(
-                direction.axis as usize,
-                [boundary_coord, i + 1, j + 1],
-            ));
+            let coords_of_boundary_voxel = CoordsWithMargins(
+                [boundary_coord, i + 1, j + 1].tuv_to_xyz(direction.axis as usize),
+            );
 
             if !f(voxels.get(coords_of_boundary_voxel.to_index(dimension))) {
                 return false;
@@ -123,14 +119,12 @@ pub fn initialize_margins(dimension: u8, voxels: &mut VoxelData) {
         for j in 0..dimension {
             for i in 0..dimension {
                 // Determine coordinates of the boundary voxel (to read from) and the margin voxel (to write to).
-                let coords_of_boundary_voxel = CoordsWithMargins(math::tuv_to_xyz(
-                    direction.axis as usize,
-                    [boundary_coord, i + 1, j + 1],
-                ));
-                let coords_of_margin_voxel = CoordsWithMargins(math::tuv_to_xyz(
-                    direction.axis as usize,
-                    [margin_coord, i + 1, j + 1],
-                ));
+                let coords_of_boundary_voxel = CoordsWithMargins(
+                    [boundary_coord, i + 1, j + 1].tuv_to_xyz(direction.axis as usize),
+                );
+                let coords_of_margin_voxel = CoordsWithMargins(
+                    [margin_coord, i + 1, j + 1].tuv_to_xyz(direction.axis as usize),
+                );
 
                 chunk_data[coords_of_margin_voxel.to_index(dimension)] =
                     chunk_data[coords_of_boundary_voxel.to_index(dimension)];

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -85,7 +85,7 @@ impl<N: RealField + Copy> MVector<N> {
     pub fn midpoint(&self, other: &Self) -> MVector<N> {
         // The midpoint in the hyperboloid model is simply the midpoint in the
         // underlying Euclidean 4-space normalized to land on the hyperboloid.
-        (*self + *other).normalized()
+        (self + other).normalized()
     }
 
     /// Returns the distance between the this vector and the given vector. An
@@ -219,10 +219,41 @@ impl<N: RealField> std::ops::Add<MVector<N>> for MVector<N> {
     }
 }
 
+impl<N: RealField> std::ops::Add<&MVector<N>> for MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn add(self, other: &MVector<N>) -> Self::Output {
+        MVector(self.0 + &other.0)
+    }
+}
+
+impl<N: RealField> std::ops::Add<MVector<N>> for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn add(self, other: MVector<N>) -> Self::Output {
+        MVector(&self.0 + other.0)
+    }
+}
+
+impl<N: RealField> std::ops::Add<&MVector<N>> for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn add(self, other: &MVector<N>) -> Self::Output {
+        MVector(&self.0 + &other.0)
+    }
+}
+
 impl<N: RealField> std::ops::AddAssign<MVector<N>> for MVector<N> {
     #[inline]
     fn add_assign(&mut self, other: MVector<N>) {
         self.0 += other.0;
+    }
+}
+
+impl<N: RealField> std::ops::AddAssign<&MVector<N>> for MVector<N> {
+    #[inline]
+    fn add_assign(&mut self, other: &MVector<N>) {
+        self.0 += &other.0;
     }
 }
 
@@ -234,10 +265,41 @@ impl<N: RealField> std::ops::Sub<MVector<N>> for MVector<N> {
     }
 }
 
+impl<N: RealField> std::ops::Sub<&MVector<N>> for MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn sub(self, other: &MVector<N>) -> Self::Output {
+        MVector(self.0 - &other.0)
+    }
+}
+
+impl<N: RealField> std::ops::Sub<MVector<N>> for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn sub(self, other: MVector<N>) -> Self::Output {
+        MVector(&self.0 - other.0)
+    }
+}
+
+impl<N: RealField> std::ops::Sub<&MVector<N>> for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn sub(self, other: &MVector<N>) -> Self::Output {
+        MVector(&self.0 - &other.0)
+    }
+}
+
 impl<N: RealField> std::ops::SubAssign<MVector<N>> for MVector<N> {
     #[inline]
     fn sub_assign(&mut self, other: MVector<N>) {
         self.0 -= other.0;
+    }
+}
+
+impl<N: RealField> std::ops::SubAssign<&MVector<N>> for MVector<N> {
+    #[inline]
+    fn sub_assign(&mut self, other: &MVector<N>) {
+        self.0 -= &other.0;
     }
 }
 
@@ -249,11 +311,27 @@ impl<N: RealField> std::ops::Neg for MVector<N> {
     }
 }
 
+impl<N: RealField> std::ops::Neg for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn neg(self) -> Self::Output {
+        MVector(-&self.0)
+    }
+}
+
 impl<N: RealField> std::ops::Mul<N> for MVector<N> {
     type Output = MVector<N>;
     #[inline]
     fn mul(self, rhs: N) -> Self::Output {
         MVector(self.0 * rhs)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<N> for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn mul(self, rhs: N) -> Self::Output {
+        MVector(&self.0 * rhs)
     }
 }
 
@@ -269,6 +347,14 @@ impl<N: RealField> std::ops::Div<N> for MVector<N> {
     #[inline]
     fn div(self, rhs: N) -> Self::Output {
         MVector(self.0 / rhs)
+    }
+}
+
+impl<N: RealField> std::ops::Div<N> for &MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn div(self, rhs: N) -> Self::Output {
+        MVector(&self.0 / rhs)
     }
 }
 
@@ -359,7 +445,7 @@ impl<N: RealField + Copy> MIsometry<N> {
         // `I + (a+b)(a+b)*/(1-a*b) + 2aa* - 2(a+b)a*`
         // `I + (a+b)(a+b)*/(1-a*b) + 2aa* - 2aa* - 2ba*`
         // `I - 2ba* + (a+b)(a+b)*/(1-a*b)`
-        let a_plus_b = *a + *b;
+        let a_plus_b = a + b;
         Self(
             na::Matrix4::<N>::identity() - b.minkowski_outer_product(a) * na::convert::<_, N>(2.0)
                 + a_plus_b.minkowski_outer_product(&a_plus_b) / (N::one() - a.mip(b)),
@@ -453,7 +539,7 @@ impl<N: RealField + Copy> MIsometry<N> {
         // Once we have the translation component, we use that component's
         // inverse to remove the translation from the original matrix to extract
         // the orientation component.
-        let orientation_component = normalized_translation_component.inverse() * *self;
+        let orientation_component = normalized_translation_component.inverse() * self;
 
         // Then, we use the QR decomposition to convert the orientation
         // component into an orthogonal matrix, which renormalizes it.
@@ -533,10 +619,41 @@ impl<N: RealField> std::ops::Mul<MIsometry<N>> for MIsometry<N> {
     }
 }
 
+impl<N: RealField> std::ops::Mul<&MIsometry<N>> for MIsometry<N> {
+    type Output = MIsometry<N>;
+    #[inline]
+    fn mul(self, rhs: &MIsometry<N>) -> Self::Output {
+        MIsometry(self.0 * &rhs.0)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<MIsometry<N>> for &MIsometry<N> {
+    type Output = MIsometry<N>;
+    #[inline]
+    fn mul(self, rhs: MIsometry<N>) -> Self::Output {
+        MIsometry(&self.0 * rhs.0)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<&MIsometry<N>> for &MIsometry<N> {
+    type Output = MIsometry<N>;
+    #[inline]
+    fn mul(self, rhs: &MIsometry<N>) -> Self::Output {
+        MIsometry(&self.0 * &rhs.0)
+    }
+}
+
 impl<N: RealField> std::ops::MulAssign<MIsometry<N>> for MIsometry<N> {
     #[inline]
     fn mul_assign(&mut self, rhs: MIsometry<N>) {
         self.0 *= rhs.0;
+    }
+}
+
+impl<N: RealField> std::ops::MulAssign<&MIsometry<N>> for MIsometry<N> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: &MIsometry<N>) {
+        self.0 *= &rhs.0;
     }
 }
 
@@ -545,6 +662,30 @@ impl<N: RealField> std::ops::Mul<MVector<N>> for MIsometry<N> {
     #[inline]
     fn mul(self, rhs: MVector<N>) -> Self::Output {
         MVector(self.0 * rhs.0)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<&MVector<N>> for MIsometry<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn mul(self, rhs: &MVector<N>) -> Self::Output {
+        MVector(self.0 * &rhs.0)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<MVector<N>> for &MIsometry<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn mul(self, rhs: MVector<N>) -> Self::Output {
+        MVector(&self.0 * rhs.0)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<&MVector<N>> for &MIsometry<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn mul(self, rhs: &MVector<N>) -> Self::Output {
+        MVector(&self.0 * &rhs.0)
     }
 }
 

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -9,7 +9,6 @@
 use na::{RealField, Scalar};
 use serde::{Deserialize, Serialize};
 use simba::scalar::SupersetOf;
-use std::ops::*;
 
 /// A stack-allocated 4-dimensional column-vector in Minkowski space. Such
 /// vectors are useful for computations in the hyperboloid model of hyperbolic
@@ -165,7 +164,7 @@ impl<N: RealField + Copy> MVector<N> {
     }
 }
 
-impl<N: Scalar> Index<usize> for MVector<N> {
+impl<N: Scalar> std::ops::Index<usize> for MVector<N> {
     type Output = N;
     #[inline]
     fn index(&self, i: usize) -> &Self::Output {
@@ -173,9 +172,9 @@ impl<N: Scalar> Index<usize> for MVector<N> {
     }
 }
 
-impl<N: Scalar> IndexMut<usize> for MVector<N> {
+impl<N: Scalar> std::ops::IndexMut<usize> for MVector<N> {
     #[inline]
-    fn index_mut(&mut self, i: usize) -> &mut N {
+    fn index_mut(&mut self, i: usize) -> &mut Self::Output {
         &mut self.0[i]
     }
 }
@@ -197,7 +196,7 @@ impl<N: Scalar> From<MVector<N>> for na::Vector4<N> {
     }
 }
 
-impl<N: Scalar> Deref for MVector<N> {
+impl<N: Scalar> std::ops::Deref for MVector<N> {
     type Target = na::coordinates::XYZW<N>;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -205,45 +204,52 @@ impl<N: Scalar> Deref for MVector<N> {
     }
 }
 
-impl<N: Scalar> DerefMut for MVector<N> {
+impl<N: Scalar> std::ops::DerefMut for MVector<N> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
     }
 }
 
-impl<N: RealField> Add for MVector<N> {
-    type Output = Self;
+impl<N: RealField> std::ops::Add<MVector<N>> for MVector<N> {
+    type Output = MVector<N>;
     #[inline]
-    fn add(self, other: Self) -> Self {
-        Self(self.0 + other.0)
+    fn add(self, other: MVector<N>) -> Self::Output {
+        MVector(self.0 + other.0)
     }
 }
 
-impl<N: RealField + Copy> std::ops::AddAssign for MVector<N> {
+impl<N: RealField> std::ops::AddAssign<MVector<N>> for MVector<N> {
     #[inline]
-    fn add_assign(&mut self, other: Self) {
+    fn add_assign(&mut self, other: MVector<N>) {
         self.0 += other.0;
     }
 }
 
-impl<N: RealField> Sub for MVector<N> {
-    type Output = Self;
+impl<N: RealField> std::ops::Sub<MVector<N>> for MVector<N> {
+    type Output = MVector<N>;
     #[inline]
-    fn sub(self, other: Self) -> Self {
-        Self(self.0 - other.0)
+    fn sub(self, other: MVector<N>) -> Self::Output {
+        MVector(self.0 - other.0)
     }
 }
 
-impl<N: RealField> Neg for MVector<N> {
-    type Output = Self;
+impl<N: RealField> std::ops::SubAssign<MVector<N>> for MVector<N> {
     #[inline]
-    fn neg(self) -> Self {
-        Self(-self.0)
+    fn sub_assign(&mut self, other: MVector<N>) {
+        self.0 -= other.0;
     }
 }
 
-impl<N: RealField> Mul<N> for MVector<N> {
+impl<N: RealField> std::ops::Neg for MVector<N> {
+    type Output = MVector<N>;
+    #[inline]
+    fn neg(self) -> Self::Output {
+        MVector(-self.0)
+    }
+}
+
+impl<N: RealField> std::ops::Mul<N> for MVector<N> {
     type Output = MVector<N>;
     #[inline]
     fn mul(self, rhs: N) -> Self::Output {
@@ -251,18 +257,25 @@ impl<N: RealField> Mul<N> for MVector<N> {
     }
 }
 
-impl<N: RealField + Copy> MulAssign<N> for MVector<N> {
+impl<N: RealField> std::ops::MulAssign<N> for MVector<N> {
     #[inline]
     fn mul_assign(&mut self, rhs: N) {
         self.0 *= rhs;
     }
 }
 
-impl<N: RealField> Div<N> for MVector<N> {
+impl<N: RealField> std::ops::Div<N> for MVector<N> {
     type Output = MVector<N>;
     #[inline]
     fn div(self, rhs: N) -> Self::Output {
         MVector(self.0 / rhs)
+    }
+}
+
+impl<N: RealField> std::ops::DivAssign<N> for MVector<N> {
+    #[inline]
+    fn div_assign(&mut self, rhs: N) {
+        self.0 /= rhs;
     }
 }
 
@@ -466,7 +479,7 @@ impl<N: RealField + Copy> MIsometry<N> {
     }
 }
 
-impl<N: Scalar> Index<(usize, usize)> for MIsometry<N> {
+impl<N: Scalar> std::ops::Index<(usize, usize)> for MIsometry<N> {
     type Output = N;
     #[inline]
     fn index(&self, ij: (usize, usize)) -> &Self::Output {
@@ -497,7 +510,7 @@ impl<N: Scalar> From<MIsometry<N>> for na::Matrix4<N> {
     }
 }
 
-impl<N: Scalar> Deref for MIsometry<N> {
+impl<N: Scalar> std::ops::Deref for MIsometry<N> {
     type Target = na::coordinates::M4x4<N>;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -505,29 +518,29 @@ impl<N: Scalar> Deref for MIsometry<N> {
     }
 }
 
-impl<N: RealField + Copy> AsRef<[[N; 4]; 4]> for MIsometry<N> {
+impl<N: RealField> AsRef<[[N; 4]; 4]> for MIsometry<N> {
     #[inline]
     fn as_ref(&self) -> &[[N; 4]; 4] {
         self.0.as_ref()
     }
 }
 
-impl<N: RealField> Mul for MIsometry<N> {
-    type Output = Self;
+impl<N: RealField> std::ops::Mul<MIsometry<N>> for MIsometry<N> {
+    type Output = MIsometry<N>;
     #[inline]
-    fn mul(self, rhs: Self) -> Self::Output {
+    fn mul(self, rhs: MIsometry<N>) -> Self::Output {
         MIsometry(self.0 * rhs.0)
     }
 }
 
-impl<N: RealField + Copy> MulAssign for MIsometry<N> {
+impl<N: RealField> std::ops::MulAssign<MIsometry<N>> for MIsometry<N> {
     #[inline]
-    fn mul_assign(&mut self, rhs: Self) {
+    fn mul_assign(&mut self, rhs: MIsometry<N>) {
         self.0 *= rhs.0;
     }
 }
 
-impl<N: RealField> Mul<MVector<N>> for MIsometry<N> {
+impl<N: RealField> std::ops::Mul<MVector<N>> for MIsometry<N> {
     type Output = MVector<N>;
     #[inline]
     fn mul(self, rhs: MVector<N>) -> Self::Output {

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -41,7 +41,9 @@ impl Graph {
     pub fn get_relative_up(&self, position: &Position) -> Option<na::UnitVector3<f32>> {
         let node = self.get(position.node).as_ref()?;
         Some(na::UnitVector3::new_normalize(
-            (position.local.inverse() * node.state.up_direction()).xyz(),
+            (position.local.inverse() * node.state.up_direction())
+                .as_ref()
+                .xyz(),
         ))
     }
 
@@ -475,7 +477,7 @@ impl VoxelAABB {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::math::{MIsometry, MVector};
+    use crate::math::{MDirection, MIsometry, MPoint, MVector};
 
     use super::*;
 
@@ -490,7 +492,7 @@ mod tests {
         // Pick an arbitrary ray by transforming the positive-x-axis ray.
         let ray = MIsometry::from(na::Rotation3::from_axis_angle(&na::Vector3::z_axis(), 0.4))
             * MIsometry::translation_along(&na::Vector3::new(0.2, 0.3, 0.1))
-            * &Ray::new(MVector::w(), MVector::x());
+            * &Ray::new(MPoint::w(), MDirection::x());
 
         let tanh_distance = 0.2;
         let radius = 0.1;
@@ -502,7 +504,7 @@ mod tests {
         let ray_test_points: Vec<_> = (0..num_ray_test_points)
             .map(|i| {
                 ray.ray_point(tanh_distance * (i as f32 / (num_ray_test_points - 1) as f32))
-                    .normalized()
+                    .normalized_point()
             })
             .collect();
 
@@ -525,7 +527,7 @@ mod tests {
                 let mut plane_normal = MVector::zero();
                 plane_normal[t_axis] = 1.0;
                 plane_normal[3] = layout.grid_to_dual(t);
-                let plane_normal = plane_normal.normalized();
+                let plane_normal = plane_normal.normalized_direction();
 
                 for test_point in &ray_test_points {
                     assert!(
@@ -559,7 +561,7 @@ mod tests {
                     line_position[u_axis] = layout.grid_to_dual(u);
                     line_position[v_axis] = layout.grid_to_dual(v);
                     line_position[3] = 1.0;
-                    let line_position = line_position.normalized();
+                    let line_position = line_position.normalized_point();
 
                     for test_point in &ray_test_points {
                         assert!(
@@ -591,7 +593,7 @@ mod tests {
                         layout.grid_to_dual(z),
                         1.0,
                     )
-                    .normalized();
+                    .normalized_point();
 
                     for test_point in &ray_test_points {
                         assert!(

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -50,7 +50,7 @@ impl<N: na::RealField + Copy> Mul<Plane<N>> for &MIsometry<N> {
     type Output = Plane<N>;
     fn mul(self, rhs: Plane<N>) -> Plane<N> {
         Plane {
-            normal: (*self * rhs.normal).normalized(),
+            normal: (self * rhs.normal).normalized(),
         }
     }
 }

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -70,9 +70,9 @@ impl SimConfig {
 /// and the approximate size of a voxel in meters.
 fn meters_to_absolute(chunk_size: u8, voxel_size: f32) -> f32 {
     let a = MVector::from(dodeca::Vertex::A.chunk_to_node() * na::Vector4::new(1.0, 0.5, 0.5, 1.0))
-        .normalized();
+        .normalized_point();
     let b = MVector::from(dodeca::Vertex::A.chunk_to_node() * na::Vector4::new(0.0, 0.5, 0.5, 1.0))
-        .normalized();
+        .normalized_point();
     let minimum_chunk_face_separation = a.distance(&b);
     let absolute_voxel_size = minimum_chunk_face_separation / f32::from(chunk_size);
     absolute_voxel_size / voxel_size

--- a/common/src/traversal.rs
+++ b/common/src/traversal.rs
@@ -6,7 +6,7 @@ use crate::{
     collision_math::Ray,
     dodeca::{self, Side, Vertex},
     graph::{Graph, NodeId},
-    math::{MIsometry, MVector},
+    math::{MIsometry, MPoint},
     node::ChunkId,
     proto::Position,
 };
@@ -21,7 +21,7 @@ pub fn ensure_nearby(graph: &mut Graph, start: &Position, distance: f32) {
 
     pending.push_back((start.node, MIsometry::identity()));
     visited.insert(start.node);
-    let start_p = start.local * MVector::origin();
+    let start_p = start.local * MPoint::origin();
 
     while let Some((node, current_transform)) = pending.pop_front() {
         for side in Side::iter() {
@@ -31,7 +31,7 @@ pub fn ensure_nearby(graph: &mut Graph, start: &Position, distance: f32) {
             }
             visited.insert(neighbor);
             let neighbor_transform = current_transform * side.reflection();
-            let neighbor_p = neighbor_transform * MVector::origin();
+            let neighbor_p = neighbor_transform * MPoint::origin();
             if -start_p.mip(&neighbor_p) > distance.cosh() {
                 continue;
             }
@@ -59,7 +59,7 @@ pub fn nearby_nodes(
     // hundreds of transformations being composed.
     let mut pending = VecDeque::<PendingNode>::new();
     let mut visited = FxHashSet::<NodeId>::default();
-    let start_p = start.local * MVector::origin();
+    let start_p = start.local * MPoint::origin();
 
     pending.push_back(PendingNode {
         id: start.node,
@@ -68,7 +68,7 @@ pub fn nearby_nodes(
     visited.insert(start.node);
 
     while let Some(current) = pending.pop_front() {
-        let current_p = current.transform * MVector::origin();
+        let current_p = current.transform * MPoint::origin();
         if -start_p.mip(&current_p) > distance.cosh() {
             continue;
         }
@@ -114,7 +114,7 @@ impl<'a> RayTraverser<'a> {
         let mut closest_vertex_cosh_distance = f32::INFINITY;
         for vertex in Vertex::iter() {
             let vertex_cosh_distance =
-                (vertex.node_to_dual() * position.local * MVector::origin()).w;
+                (vertex.node_to_dual() * position.local * MPoint::origin()).w;
             if vertex_cosh_distance < closest_vertex_cosh_distance {
                 closest_vertex = vertex;
                 closest_vertex_cosh_distance = vertex_cosh_distance;

--- a/common/src/traversal.rs
+++ b/common/src/traversal.rs
@@ -30,7 +30,7 @@ pub fn ensure_nearby(graph: &mut Graph, start: &Position, distance: f32) {
                 continue;
             }
             visited.insert(neighbor);
-            let neighbor_transform = current_transform * *side.reflection();
+            let neighbor_transform = current_transform * side.reflection();
             let neighbor_p = neighbor_transform * MVector::origin();
             if -start_p.mip(&neighbor_p) > distance.cosh() {
                 continue;
@@ -84,7 +84,7 @@ pub fn nearby_nodes(
             }
             pending.push_back(PendingNode {
                 id: neighbor,
-                transform: current.transform * *side.reflection(),
+                transform: current.transform * side.reflection(),
             });
             visited.insert(neighbor);
         }
@@ -114,7 +114,7 @@ impl<'a> RayTraverser<'a> {
         let mut closest_vertex_cosh_distance = f32::INFINITY;
         for vertex in Vertex::iter() {
             let vertex_cosh_distance =
-                (*vertex.node_to_dual() * position.local * MVector::origin()).w;
+                (vertex.node_to_dual() * position.local * MVector::origin()).w;
             if vertex_cosh_distance < closest_vertex_cosh_distance {
                 closest_vertex = vertex;
                 closest_vertex_cosh_distance = vertex_cosh_distance;
@@ -163,7 +163,7 @@ impl<'a> RayTraverser<'a> {
                 continue;
             };
 
-            let local_ray = *vertex.node_to_dual() * node_transform * self.ray;
+            let local_ray = vertex.node_to_dual() * node_transform * self.ray;
 
             // Compute the Klein-Beltrami coordinates of the ray segment's endpoints. To check whether neighboring chunks
             // are needed, we need to check whether the endpoints of the line segments lie outside the boundaries of the square
@@ -179,7 +179,7 @@ impl<'a> RayTraverser<'a> {
                     || klein_ray_end[axis] <= self.klein_lower_boundary
                 {
                     let side = vertex.canonical_sides()[axis];
-                    let next_node_transform = *side.reflection() * node_transform;
+                    let next_node_transform = side.reflection() * node_transform;
                     // Crude check to ensure that the neighboring chunk's node can be in the path of the ray. For simplicity, this
                     // check treats each node as a sphere and assumes the ray is pointed directly towards its center. The check is
                     // needed because chunk generation uses this approximation, and this check is not guaranteed to pass near corners

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -5,8 +5,8 @@ use crate::{
     Plane,
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
-    margins, math,
-    math::MVector,
+    margins,
+    math::{self, MDirection},
     node::{ChunkId, VoxelData},
     terraingen::VoronoiInfo,
     world::Material,
@@ -122,7 +122,7 @@ impl NodeState {
         }
     }
 
-    pub fn up_direction(&self) -> MVector<f32> {
+    pub fn up_direction(&self) -> MDirection<f32> {
         self.surface.normal().cast()
     }
 }


### PR DESCRIPTION
Fixes #264

Introduce two new unit vector types for `MVector`:
- `MPoint`
- `MDirection`

`MPoint` has the constraint `v.mip(v) == -1`, while `MDirection` has the constraint `v.mip(v) == 1`. Every method signature requiring an `MVector` with one of these constraints has been updated to take one of these more constrained types to reduce the chance of mistakes.