### PR TITLE
Upgrade to the Rust 2024 edition

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "client"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0 OR Zlib"
 

--- a/client/benches/surface_extraction.rs
+++ b/client/benches/surface_extraction.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use ash::vk;
-use bencher::{benchmark_group, benchmark_main, Bencher};
+use bencher::{Bencher, benchmark_group, benchmark_main};
 
 use client::graphics::{
-    voxels::surface_extraction::{self, ExtractTask, SurfaceExtraction},
     Base,
+    voxels::surface_extraction::{self, ExtractTask, SurfaceExtraction},
 };
 //use common::world::Material;
 

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -1,13 +1,13 @@
 //! Common state shared throughout the graphics system
 
 use ash::ext::debug_utils;
-use std::ffi::{c_char, CStr};
+use std::ffi::{CStr, c_char};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{fs, io};
 use tracing::{error, info, trace, warn};
 
-use ash::{vk, Device};
+use ash::{Device, vk};
 
 use super::Core;
 
@@ -315,17 +315,19 @@ impl Base {
     }
 
     /// Set an object's name for use in diagnostics
-    pub unsafe fn set_name<T: vk::Handle>(&self, object: T, name: &CStr) { unsafe {
-        let Some(ref ex) = self.debug_utils else {
-            return;
-        };
-        ex.set_debug_utils_object_name(
-            &vk::DebugUtilsObjectNameInfoEXT::default()
-                .object_handle(object)
-                .object_name(name),
-        )
-        .unwrap();
-    }}
+    pub unsafe fn set_name<T: vk::Handle>(&self, object: T, name: &CStr) {
+        unsafe {
+            let Some(ref ex) = self.debug_utils else {
+                return;
+            };
+            ex.set_debug_utils_object_name(
+                &vk::DebugUtilsObjectNameInfoEXT::default()
+                    .object_handle(object)
+                    .object_name(name),
+            )
+            .unwrap();
+        }
+    }
 
     /// Convenience constructor for tests and benchmarks
     pub fn headless() -> Self {

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -315,7 +315,7 @@ impl Base {
     }
 
     /// Set an object's name for use in diagnostics
-    pub unsafe fn set_name<T: vk::Handle>(&self, object: T, name: &CStr) {
+    pub unsafe fn set_name<T: vk::Handle>(&self, object: T, name: &CStr) { unsafe {
         let Some(ref ex) = self.debug_utils else {
             return;
         };
@@ -325,7 +325,7 @@ impl Base {
                 .object_name(name),
         )
         .unwrap();
-    }
+    }}
 
     /// Convenience constructor for tests and benchmarks
     pub fn headless() -> Self {

--- a/client/src/graphics/core.rs
+++ b/client/src/graphics/core.rs
@@ -128,8 +128,8 @@ unsafe extern "system" fn messenger_callback(
     _message_types: vk::DebugUtilsMessageTypeFlagsEXT,
     p_data: *const vk::DebugUtilsMessengerCallbackDataEXT,
     _p_user_data: *mut c_void,
-) -> vk::Bool32 {
-    unsafe fn fmt_labels(ptr: *const vk::DebugUtilsLabelEXT, count: u32) -> String {
+) -> vk::Bool32 { unsafe {
+    unsafe fn fmt_labels(ptr: *const vk::DebugUtilsLabelEXT, count: u32) -> String { unsafe {
         if count == 0 {
             // We need to handle a count of 0 separately because ptr may be
             // null, resulting in undefined behavior if used with
@@ -145,7 +145,7 @@ unsafe extern "system" fn messenger_callback(
             })
             .collect::<Vec<_>>()
             .join(", ")
-    }
+    }}
 
     let data = &*p_data;
     let msg_id = if data.p_message_id_name.is_null() {
@@ -177,4 +177,4 @@ unsafe extern "system" fn messenger_callback(
         trace!(target: "vulkan", id = %msg_id, number = data.message_id_number, queue_labels = %queue_labels, cmd_labels = %cmd_labels, objects = %objects, "{}", msg);
     }
     vk::FALSE
-}
+}}

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -247,7 +247,7 @@ impl Draw {
     /// Waits for a frame's worth of resources to become available for use in rendering a new frame
     ///
     /// Call before signaling the image_acquired semaphore or invoking `draw`.
-    pub unsafe fn wait(&mut self) {
+    pub unsafe fn wait(&mut self) { unsafe {
         let device = &*self.gfx.device;
         let state = &mut self.states[self.next_state];
         device.wait_for_fences(&[state.fence], true, !0).unwrap();
@@ -258,7 +258,7 @@ impl Draw {
                 self.gfx.memory_properties,
             ));
         state.in_flight = false;
-    }
+    }}
 
     /// Semaphore that must be signaled when an output framebuffer can be rendered to
     ///
@@ -285,7 +285,7 @@ impl Draw {
         extent: vk::Extent2D,
         present: vk::Semaphore,
         frustum: &Frustum,
-    ) {
+    ) { unsafe {
         let draw_started = Instant::now();
         let view = sim.as_ref().map_or_else(Position::origin, |sim| sim.view());
         let projection = frustum.projection(1.0e-4);
@@ -548,7 +548,7 @@ impl Draw {
         state.used = true;
         state.in_flight = true;
         histogram!("frame.cpu").record(draw_started.elapsed());
-    }
+    }}
 
     /// Wait for all drawing to complete
     ///

--- a/client/src/graphics/fog.rs
+++ b/client/src/graphics/fog.rs
@@ -1,4 +1,4 @@
-use ash::{vk, Device};
+use ash::{Device, vk};
 use vk_shader_macros::include_glsl;
 
 use super::Base;
@@ -128,23 +128,27 @@ impl Fog {
         device: &Device,
         common_ds: vk::DescriptorSet,
         cmd: vk::CommandBuffer,
-    ) { unsafe {
-        device.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::GRAPHICS, self.pipeline);
-        device.cmd_bind_descriptor_sets(
-            cmd,
-            vk::PipelineBindPoint::GRAPHICS,
-            self.pipeline_layout,
-            0,
-            &[common_ds],
-            &[],
-        );
-        device.cmd_draw(cmd, 3, 1, 0, 0);
-    }}
+    ) {
+        unsafe {
+            device.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::GRAPHICS, self.pipeline);
+            device.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::GRAPHICS,
+                self.pipeline_layout,
+                0,
+                &[common_ds],
+                &[],
+            );
+            device.cmd_draw(cmd, 3, 1, 0, 0);
+        }
+    }
 
-    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
-        device.destroy_pipeline(self.pipeline, None);
-        device.destroy_pipeline_layout(self.pipeline_layout, None);
-    }}
+    pub unsafe fn destroy(&mut self, device: &Device) {
+        unsafe {
+            device.destroy_pipeline(self.pipeline, None);
+            device.destroy_pipeline_layout(self.pipeline_layout, None);
+        }
+    }
 }
 
 /// Compute the density value that will lead to a certain transmission from points at a certain

--- a/client/src/graphics/fog.rs
+++ b/client/src/graphics/fog.rs
@@ -128,7 +128,7 @@ impl Fog {
         device: &Device,
         common_ds: vk::DescriptorSet,
         cmd: vk::CommandBuffer,
-    ) {
+    ) { unsafe {
         device.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::GRAPHICS, self.pipeline);
         device.cmd_bind_descriptor_sets(
             cmd,
@@ -139,12 +139,12 @@ impl Fog {
             &[],
         );
         device.cmd_draw(cmd, 3, 1, 0, 0);
-    }
+    }}
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         device.destroy_pipeline(self.pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
-    }
+    }}
 }
 
 /// Compute the density value that will lead to a certain transmission from points at a certain

--- a/client/src/graphics/frustum.rs
+++ b/client/src/graphics/frustum.rs
@@ -1,5 +1,5 @@
-use common::math::MVector;
 use common::Plane;
+use common::math::MVector;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Frustum {

--- a/client/src/graphics/gltf_mesh.rs
+++ b/client/src/graphics/gltf_mesh.rs
@@ -68,11 +68,11 @@ impl GlbFile {
 pub struct GltfScene(pub Vec<Mesh>);
 
 impl Cleanup for GltfScene {
-    unsafe fn cleanup(self, gfx: &Base) {
+    unsafe fn cleanup(self, gfx: &Base) { unsafe {
         for mesh in self.0 {
             mesh.cleanup(gfx);
         }
-    }
+    }}
 }
 
 fn load_node<'a>(

--- a/client/src/graphics/gltf_mesh.rs
+++ b/client/src/graphics/gltf_mesh.rs
@@ -7,13 +7,13 @@ use std::{
     ptr,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use ash::vk;
-use futures_util::future::{try_join_all, BoxFuture, FutureExt};
+use futures_util::future::{BoxFuture, FutureExt, try_join_all};
 use lahar::{BufferRegionAlloc, DedicatedImage};
 use tracing::{error, trace};
 
-use super::{meshes::Vertex, Base, Mesh};
+use super::{Base, Mesh, meshes::Vertex};
 use crate::loader::{Cleanup, LoadCtx, LoadFuture, Loadable};
 
 pub struct GlbFile {
@@ -68,11 +68,13 @@ impl GlbFile {
 pub struct GltfScene(pub Vec<Mesh>);
 
 impl Cleanup for GltfScene {
-    unsafe fn cleanup(self, gfx: &Base) { unsafe {
-        for mesh in self.0 {
-            mesh.cleanup(gfx);
+    unsafe fn cleanup(self, gfx: &Base) {
+        unsafe {
+            for mesh in self.0 {
+                mesh.cleanup(gfx);
+            }
         }
-    }}
+    }
 }
 
 fn load_node<'a>(
@@ -385,7 +387,7 @@ async fn load_material(
                 ctx,
                 prim.material().pbr_metallic_roughness().base_color_factor(),
             )
-            .await
+            .await;
         }
         Some(x) => x,
     };

--- a/client/src/graphics/gui.rs
+++ b/client/src/graphics/gui.rs
@@ -1,5 +1,5 @@
 use yakui::{
-    align, colored_box, colored_box_container, label, pad, widgets::Pad, Alignment, Color,
+    Alignment, Color, align, colored_box, colored_box_container, label, pad, widgets::Pad,
 };
 
 use crate::Sim;

--- a/client/src/graphics/meshes.rs
+++ b/client/src/graphics/meshes.rs
@@ -170,7 +170,7 @@ impl Meshes {
         cmd: vk::CommandBuffer,
         mesh: &Mesh,
         transform: &na::Matrix4<f32>,
-    ) {
+    ) { unsafe {
         device.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::GRAPHICS, self.pipeline);
         device.cmd_bind_descriptor_sets(
             cmd,
@@ -195,12 +195,12 @@ impl Meshes {
             vk::IndexType::UINT32,
         );
         device.cmd_draw_indexed(cmd, mesh.index_count, 1, 0, 0, 0);
-    }
+    }}
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         device.destroy_pipeline(self.pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
-    }
+    }}
 }
 
 #[repr(C)]
@@ -223,10 +223,10 @@ pub struct Mesh {
 }
 
 impl crate::loader::Cleanup for Mesh {
-    unsafe fn cleanup(mut self, gfx: &Base) {
+    unsafe fn cleanup(mut self, gfx: &Base) { unsafe {
         let device = &*gfx.device;
         device.destroy_descriptor_pool(self.pool, None);
         device.destroy_image_view(self.color_view, None);
         self.color.destroy(device);
-    }
+    }}
 }

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -28,9 +28,9 @@ pub use self::{
     window::{EarlyWindow, Window},
 };
 
-unsafe fn as_bytes<T: Copy>(x: &T) -> &[u8] { unsafe {
-    std::slice::from_raw_parts(x as *const T as *const u8, std::mem::size_of::<T>())
-}}
+unsafe fn as_bytes<T: Copy>(x: &T) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(x as *const T as *const u8, std::mem::size_of::<T>()) }
+}
 
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/client/src/graphics/mod.rs
+++ b/client/src/graphics/mod.rs
@@ -28,9 +28,9 @@ pub use self::{
     window::{EarlyWindow, Window},
 };
 
-unsafe fn as_bytes<T: Copy>(x: &T) -> &[u8] {
+unsafe fn as_bytes<T: Copy>(x: &T) -> &[u8] { unsafe {
     std::slice::from_raw_parts(x as *const T as *const u8, std::mem::size_of::<T>())
-}
+}}
 
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/client/src/graphics/png_array.rs
+++ b/client/src/graphics/png_array.rs
@@ -1,6 +1,6 @@
 use std::{fs, fs::File, path::PathBuf};
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{Context, anyhow, bail};
 use ash::vk;
 use lahar::DedicatedImage;
 use tracing::trace;

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -91,7 +91,7 @@ impl Voxels {
         nearby_nodes: &[(NodeId, MIsometry<f32>)],
         cmd: vk::CommandBuffer,
         frustum: &Frustum,
-    ) {
+    ) { unsafe {
         // Clean up after previous frame
         for i in frame.extracted.drain(..) {
             self.extraction_scratch.free(i);
@@ -163,7 +163,7 @@ impl Voxels {
                         }
                         continue;
                     }
-                    Populated {
+                    &mut Populated {
                         ref mut surface,
                         ref mut old_surface,
                         ref voxels,
@@ -241,7 +241,7 @@ impl Voxels {
             &extractions,
         );
         histogram!("frame.cpu.voxels.node_scan").record(node_scan_started.elapsed());
-    }
+    }}
 
     pub unsafe fn draw(
         &mut self,
@@ -250,7 +250,7 @@ impl Voxels {
         common_ds: vk::DescriptorSet,
         frame: &Frame,
         cmd: vk::CommandBuffer,
-    ) {
+    ) { unsafe {
         let started = Instant::now();
         if !self.draw.bind(
             device,
@@ -266,14 +266,14 @@ impl Voxels {
             self.draw.draw(device, cmd, &self.surfaces, chunk.0);
         }
         histogram!("frame.cpu.voxels.draw").record(started.elapsed());
-    }
+    }}
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         self.surface_extraction.destroy(device);
         self.extraction_scratch.destroy(device);
         self.surfaces.destroy(device);
         self.draw.destroy(device);
-    }
+    }}
 }
 
 pub struct Frame {
@@ -284,9 +284,9 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         self.surface.destroy(device);
-    }
+    }}
 }
 
 impl Frame {

--- a/client/src/graphics/voxels/surface.rs
+++ b/client/src/graphics/voxels/surface.rs
@@ -252,7 +252,7 @@ impl Surface {
         common_ds: vk::DescriptorSet,
         frame: &Frame,
         cmd: vk::CommandBuffer,
-    ) -> bool {
+    ) -> bool { unsafe {
         if self.colors_view == vk::ImageView::null() {
             if let Some(colors) = loader.get(self.colors) {
                 self.colors_view = device
@@ -308,7 +308,7 @@ impl Surface {
         );
 
         true
-    }
+    }}
 
     pub unsafe fn draw(
         &self,
@@ -316,7 +316,7 @@ impl Surface {
         cmd: vk::CommandBuffer,
         buffer: &DrawBuffer,
         chunk: u32,
-    ) {
+    ) { unsafe {
         device.cmd_draw_indirect(
             cmd,
             buffer.indirect_buffer(),
@@ -324,9 +324,9 @@ impl Surface {
             1,
             16,
         );
-    }
+    }}
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         device.destroy_pipeline(self.pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
         device.destroy_descriptor_set_layout(self.static_ds_layout, None);
@@ -334,7 +334,7 @@ impl Surface {
         if self.colors_view != vk::ImageView::null() {
             device.destroy_image_view(self.colors_view, None);
         }
-    }
+    }}
 }
 
 pub struct Frame {
@@ -361,9 +361,9 @@ impl Frame {
 }
 
 impl Frame {
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         self.transforms.destroy(device);
-    }
+    }}
 }
 
 // 4x4 f32 matrix

--- a/client/src/graphics/voxels/surface_extraction.rs
+++ b/client/src/graphics/voxels/surface_extraction.rs
@@ -145,12 +145,12 @@ impl SurfaceExtraction {
         }
     }
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         device.destroy_descriptor_set_layout(self.params_layout, None);
         device.destroy_descriptor_set_layout(self.ds_layout, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
         device.destroy_pipeline(self.extract, None);
-    }
+    }}
 }
 
 /// Scratch space for actually performing the extraction
@@ -317,7 +317,7 @@ impl ScratchBuffer {
         face_buffer: vk::Buffer,
         cmd: vk::CommandBuffer,
         tasks: &[ExtractTask],
-    ) {
+    ) { unsafe {
         // Prevent overlap with the last batch of work
         device.cmd_pipeline_barrier(
             cmd,
@@ -509,15 +509,15 @@ impl ScratchBuffer {
             &[],
             &[],
         );
-    }
+    }}
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         device.destroy_descriptor_pool(self.descriptor_pool, None);
         self.params.destroy(device);
         self.voxels_staging.destroy(device);
         self.voxels.destroy(device);
         self.state.destroy(device);
-    }
+    }}
 }
 
 /// Specifies a single chunk's worth of surface extraction work
@@ -637,10 +637,10 @@ impl DrawBuffer {
         self.dimension
     }
 
-    pub unsafe fn destroy(&mut self, device: &Device) {
+    pub unsafe fn destroy(&mut self, device: &Device) { unsafe {
         self.indirect.destroy(device);
         self.faces.destroy(device);
-    }
+    }}
 }
 
 // Size of the VkDrawIndirectCommand struct

--- a/client/src/graphics/voxels/tests.rs
+++ b/client/src/graphics/voxels/tests.rs
@@ -4,7 +4,7 @@ use ash::vk;
 use lahar::DedicatedMapping;
 use renderdoc::{RenderDoc, V110};
 
-use super::{surface_extraction, SurfaceExtraction};
+use super::{SurfaceExtraction, surface_extraction};
 use crate::graphics::{Base, VkDrawIndirectCommand};
 use common::world::Material;
 

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -447,7 +447,7 @@ impl SwapchainMgr {
         surface_fn: &khr::surface::Instance,
         surface: vk::SurfaceKHR,
         fallback_size: PhysicalSize<u32>,
-    ) {
+    ) { unsafe {
         self.state = SwapchainState::new(
             surface_fn,
             self.state.swapchain_fn.clone(),
@@ -457,20 +457,20 @@ impl SwapchainMgr {
             self.state.handle,
             fallback_size,
         );
-    }
+    }}
 
     /// Get the index of the next frame to use
-    unsafe fn acquire_next_image(&self, signal: vk::Semaphore) -> Result<(u32, bool), vk::Result> {
+    unsafe fn acquire_next_image(&self, signal: vk::Semaphore) -> Result<(u32, bool), vk::Result> { unsafe {
         self.state.swapchain_fn.acquire_next_image(
             self.state.handle,
             u64::MAX,
             signal,
             vk::Fence::null(),
         )
-    }
+    }}
 
     /// Present a frame on the window
-    unsafe fn queue_present(&self, index: u32) -> Result<bool, vk::Result> {
+    unsafe fn queue_present(&self, index: u32) -> Result<bool, vk::Result> { unsafe {
         self.state.swapchain_fn.queue_present(
             self.state.gfx.queue,
             &vk::PresentInfoKHR::default()
@@ -478,7 +478,7 @@ impl SwapchainMgr {
                 .swapchains(&[self.state.handle])
                 .image_indices(&[index]),
         )
-    }
+    }}
 }
 
 /// Data that's replaced when the swapchain is updated
@@ -499,7 +499,7 @@ impl SwapchainState {
         format: vk::SurfaceFormatKHR,
         old: vk::SwapchainKHR,
         fallback_size: PhysicalSize<u32>,
-    ) -> Self {
+    ) -> Self { unsafe {
         let device = &*gfx.device;
 
         let surface_capabilities = surface_fn
@@ -647,7 +647,7 @@ impl SwapchainState {
             handle,
             frames,
         }
-    }
+    }}
 }
 
 impl Drop for SwapchainState {

--- a/client/src/lahar_deprecated/staging.rs
+++ b/client/src/lahar_deprecated/staging.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 
-use ash::{vk, Device};
+use ash::{Device, vk};
 use futures_util::future;
 
 use super::condition::{self, Condition};

--- a/client/src/lahar_deprecated/transfer.rs
+++ b/client/src/lahar_deprecated/transfer.rs
@@ -78,7 +78,7 @@ impl Reactor {
         queue_family: u32,
         queue: vk::Queue,
         dst_queue_family: Option<u32>,
-    ) -> (TransferHandle, Self) {
+    ) -> (TransferHandle, Self) { unsafe {
         let (send, recv) = mpsc::unbounded_channel();
         let cmd_pool = device
             .create_command_pool(
@@ -109,7 +109,7 @@ impl Reactor {
                 },
             },
         )
-    }
+    }}
 
     pub fn poll(&mut self) -> Result<(), Disconnected> {
         self.run_for(Duration::from_secs(0))

--- a/client/src/lahar_deprecated/transfer.rs
+++ b/client/src/lahar_deprecated/transfer.rs
@@ -78,38 +78,40 @@ impl Reactor {
         queue_family: u32,
         queue: vk::Queue,
         dst_queue_family: Option<u32>,
-    ) -> (TransferHandle, Self) { unsafe {
-        let (send, recv) = mpsc::unbounded_channel();
-        let cmd_pool = device
-            .create_command_pool(
-                &vk::CommandPoolCreateInfo::default()
-                    .queue_family_index(queue_family)
-                    .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER),
-                None,
-            )
-            .unwrap();
-        (
-            TransferHandle { send },
-            Self {
-                queue,
-                spare_fences: Vec::new(),
-                spare_cmds: Vec::new(),
-                in_flight: Vec::new(),
-                in_flight_fences: Vec::new(),
-                cmd_pool,
-                pending: None,
-                recv,
-                ctx: TransferContext {
-                    device,
-                    queue_family,
-                    dst_queue_family: dst_queue_family.unwrap_or(queue_family),
-                    stages: vk::PipelineStageFlags::empty(),
-                    buffer_barriers: Vec::new(),
-                    image_barriers: Vec::new(),
+    ) -> (TransferHandle, Self) {
+        unsafe {
+            let (send, recv) = mpsc::unbounded_channel();
+            let cmd_pool = device
+                .create_command_pool(
+                    &vk::CommandPoolCreateInfo::default()
+                        .queue_family_index(queue_family)
+                        .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER),
+                    None,
+                )
+                .unwrap();
+            (
+                TransferHandle { send },
+                Self {
+                    queue,
+                    spare_fences: Vec::new(),
+                    spare_cmds: Vec::new(),
+                    in_flight: Vec::new(),
+                    in_flight_fences: Vec::new(),
+                    cmd_pool,
+                    pending: None,
+                    recv,
+                    ctx: TransferContext {
+                        device,
+                        queue_family,
+                        dst_queue_family: dst_queue_family.unwrap_or(queue_family),
+                        stages: vk::PipelineStageFlags::empty(),
+                        buffer_barriers: Vec::new(),
+                        image_barriers: Vec::new(),
+                    },
                 },
-            },
-        )
-    }}
+            )
+        }
+    }
 
     pub fn poll(&mut self) -> Result<(), Disconnected> {
         self.run_for(Duration::from_secs(0))

--- a/client/src/loader.rs
+++ b/client/src/loader.rs
@@ -27,9 +27,9 @@ pub trait Cleanup {
 }
 
 impl Cleanup for DedicatedImage {
-    unsafe fn cleanup(mut self, gfx: &Base) {
+    unsafe fn cleanup(mut self, gfx: &Base) { unsafe {
         self.destroy(&gfx.device);
-    }
+    }}
 }
 
 pub trait Loadable: Send + 'static {

--- a/client/src/loader.rs
+++ b/client/src/loader.rs
@@ -7,19 +7,19 @@ use std::{
 
 use anyhow::Result;
 use ash::vk;
-use downcast_rs::{impl_downcast, Downcast};
+use downcast_rs::{Downcast, impl_downcast};
 use fxhash::FxHashMap;
 use lahar::{BufferRegion, DedicatedImage};
 use tokio::sync::mpsc;
 use tracing::error;
 
 use crate::{
+    Config,
     graphics::Base,
     lahar_deprecated::{
         staging::StagingBuffer,
         transfer::{self, TransferHandle},
     },
-    Config,
 };
 
 pub trait Cleanup {
@@ -27,9 +27,11 @@ pub trait Cleanup {
 }
 
 impl Cleanup for DedicatedImage {
-    unsafe fn cleanup(mut self, gfx: &Base) { unsafe {
-        self.destroy(&gfx.device);
-    }}
+    unsafe fn cleanup(mut self, gfx: &Base) {
+        unsafe {
+            self.destroy(&gfx.device);
+        }
+    }
 }
 
 pub trait Loadable: Send + 'static {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,12 +1,12 @@
 use std::{sync::Arc, thread};
 
-use client::{graphics, metrics, net, Config};
+use client::{Config, graphics, metrics, net};
 use common::proto;
 use save::Save;
 
 use ash::khr;
 use server::Server;
-use tracing::{debug, error, error_span, info, Instrument};
+use tracing::{Instrument, debug, error, error_span, info};
 use winit::{
     application::ApplicationHandler,
     event_loop::{ActiveEventLoop, EventLoop},

--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, thread};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use quinn::rustls;
 use tokio::sync::mpsc;
 

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -1,10 +1,9 @@
 use std::collections::VecDeque;
 
 use common::{
-    character_controller,
+    SimConfig, character_controller,
     graph::Graph,
     proto::{CharacterInput, Position},
-    SimConfig,
 };
 
 /// Predicts the result of motion inputs in-flight to the server

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -8,19 +8,18 @@ use crate::{
     local_character_controller::LocalCharacterController, metrics, prediction::PredictedMotion,
 };
 use common::{
-    character_controller,
+    EntityId, GraphEntities, SimConfig, Step, character_controller,
     collision_math::Ray,
     graph::{Graph, NodeId},
     graph_ray_casting,
     math::{MIsometry, MVector},
-    node::{populate_fresh_nodes, ChunkId, VoxelData},
+    node::{ChunkId, VoxelData, populate_fresh_nodes},
     proto::{
         self, BlockUpdate, Character, CharacterInput, CharacterState, Command, Component,
         Inventory, Position,
     },
     sanitize_motion_input,
     world::Material,
-    EntityId, GraphEntities, SimConfig, Step,
 };
 
 const MATERIAL_PALETTE: [Material; 10] = [

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "common"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0 OR Zlib"
 

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -1,10 +1,10 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use common::{
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
     node::Chunk,
-    node::{populate_fresh_nodes, ChunkId},
+    node::{ChunkId, populate_fresh_nodes},
     proto::Position,
     traversal::ensure_nearby,
     worldgen::ChunkParams,

--- a/common/src/character_controller/mod.rs
+++ b/common/src/character_controller/mod.rs
@@ -6,8 +6,9 @@ use std::mem::replace;
 use tracing::warn;
 
 use crate::{
+    SimConfig,
     character_controller::{
-        collision::{check_collision, Collision, CollisionContext},
+        collision::{Collision, CollisionContext, check_collision},
         vector_bounds::{BoundedVectors, VectorBound},
     },
     graph::Graph,
@@ -15,7 +16,6 @@ use crate::{
     proto::{CharacterInput, Position},
     sanitize_motion_input,
     sim_config::CharacterConfig,
-    SimConfig,
 };
 
 /// Runs a single step of character movement
@@ -262,7 +262,9 @@ fn apply_velocity(
     }
 
     if !all_collisions_resolved {
-        warn!("A character entity processed too many collisions and collision resolution was cut short.");
+        warn!(
+            "A character entity processed too many collisions and collision resolution was cut short."
+        );
     }
 
     *velocity = *bounded_vectors.velocity().unwrap();

--- a/common/src/character_controller/vector_bounds.rs
+++ b/common/src/character_controller/vector_bounds.rs
@@ -108,7 +108,9 @@ impl BoundedVectors {
             (bounds_iter.clone()).filter(|b| !b.check_vector(&self.displacement, self.error_margin))
         {
             let Some(ortho_bound) = bound.get_self_constrained_with_bound(new_bound) else {
-                warn!("Unsatisfied existing bound is parallel to new bound. Is the character squeezed between two walls?");
+                warn!(
+                    "Unsatisfied existing bound is parallel to new bound. Is the character squeezed between two walls?"
+                );
                 continue;
             };
 

--- a/common/src/codec.rs
+++ b/common/src/codec.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Result};
-use serde::{de::DeserializeOwned, Serialize};
+use anyhow::{Result, bail};
+use serde::{Serialize, de::DeserializeOwned};
 
 pub async fn send<T: Serialize + ?Sized>(stream: &mut quinn::SendStream, msg: &T) -> Result<()> {
     let mut buf = Vec::new();

--- a/common/src/collision_math.rs
+++ b/common/src/collision_math.rs
@@ -189,9 +189,10 @@ mod tests {
         let ray = MIsometry::translation_along(&na::Vector3::new(0.0, 0.0, -0.5))
             * &Ray::new(MVector::origin(), MVector::x());
         let normal = -MVector::z();
-        assert!(ray
-            .solve_sphere_plane_intersection(&normal, 0.2_f32.sinh())
-            .is_none());
+        assert!(
+            ray.solve_sphere_plane_intersection(&normal, 0.2_f32.sinh())
+                .is_none()
+        );
     }
 
     #[test]
@@ -256,9 +257,10 @@ mod tests {
             * &Ray::new(MVector::origin(), MVector::x());
         let line_normal0 = MVector::x();
         let line_normal1 = MVector::z();
-        assert!(ray
-            .solve_sphere_line_intersection(&line_normal0, &line_normal1, 0.2_f32.sinh())
-            .is_none());
+        assert!(
+            ray.solve_sphere_line_intersection(&line_normal0, &line_normal1, 0.2_f32.sinh())
+                .is_none()
+        );
     }
 
     #[test]
@@ -291,9 +293,10 @@ mod tests {
         let radius = 0.019090926_f32;
         // The following returns wrong results in the other implementation, so we test this case
         // to make sure there are no regressions.
-        assert!(ray
-            .solve_sphere_line_intersection(&line_normal0, &line_normal1, radius.sinh())
-            .is_none());
+        assert!(
+            ray.solve_sphere_line_intersection(&line_normal0, &line_normal1, radius.sinh())
+                .is_none()
+        );
     }
 
     #[test]
@@ -355,14 +358,15 @@ mod tests {
         let point_normal0 = MVector::x();
         let point_normal1 = MVector::y();
         let point_normal2 = MVector::z();
-        assert!(ray
-            .solve_sphere_point_intersection(
+        assert!(
+            ray.solve_sphere_point_intersection(
                 &point_normal0,
                 &point_normal1,
                 &point_normal2,
                 0.2_f32.sinh()
             )
-            .is_none());
+            .is_none()
+        );
     }
 
     #[test]

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -79,7 +79,7 @@ impl Graph {
     /// Returns all of the sides between the provided node and its shorter neighbors.
     ///
     /// A node's length is its distance from the root node.
-    pub fn descenders(&self, node: NodeId) -> impl ExactSizeIterator<Item = (Side, NodeId)> {
+    pub fn descenders(&self, node: NodeId) -> impl ExactSizeIterator<Item = (Side, NodeId)> + use<> {
         let node_length = self.length(node);
 
         let mut results = [None; 3];
@@ -224,7 +224,7 @@ impl Graph {
         &mut self,
         node: NodeId,
         side: Side,
-    ) -> impl Iterator<Item = (Side, NodeId)> + Clone {
+    ) -> impl Iterator<Item = (Side, NodeId)> + Clone + use<> {
         let mut shorter_neighbors_of_subject = [None; 3]; // Maximum number of shorter neighbors is 3
         let mut count = 0;
         for candidate_descender in Side::iter() {

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -79,7 +79,10 @@ impl Graph {
     /// Returns all of the sides between the provided node and its shorter neighbors.
     ///
     /// A node's length is its distance from the root node.
-    pub fn descenders(&self, node: NodeId) -> impl ExactSizeIterator<Item = (Side, NodeId)> + use<> {
+    pub fn descenders(
+        &self,
+        node: NodeId,
+    ) -> impl ExactSizeIterator<Item = (Side, NodeId)> + use<> {
         let node_length = self.length(node);
 
         let mut results = [None; 3];

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -89,7 +89,7 @@ mod tests {
         dodeca::{self, Side, Vertex},
         graph::{Graph, NodeId},
         math::MIsometry,
-        node::{populate_fresh_nodes, VoxelData},
+        node::{VoxelData, populate_fresh_nodes},
         proto::Position,
         traversal::{ensure_nearby, nearby_nodes},
         voxel_math::Coords,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::needless_borrowed_reference)]
 
 use rand::{
-    distr::{Distribution, StandardUniform},
     Rng,
+    distr::{Distribution, StandardUniform},
 };
 
 #[macro_use]

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -371,7 +371,7 @@ impl ChunkLayout {
 
     /// Takes in a single grid coordinate and returns a range containing all voxel coordinates surrounding it.
     #[inline]
-    pub fn neighboring_voxels(&self, grid_coord: u8) -> impl Iterator<Item = u8> {
+    pub fn neighboring_voxels(&self, grid_coord: u8) -> impl Iterator<Item = u8> + use<> {
         grid_coord.saturating_sub(1)..grid_coord.saturating_add(1).min(self.dimension())
     }
 }
@@ -450,7 +450,7 @@ impl VoxelAABB {
         axis0: usize,
         axis1: usize,
         axis2: usize,
-    ) -> impl Iterator<Item = (u8, u8, u8)> {
+    ) -> impl Iterator<Item = (u8, u8, u8)> + use<> {
         let bounds = self.bounds;
         (bounds[axis0][0]..bounds[axis0][1]).flat_map(move |i| {
             (bounds[axis1][0]..bounds[axis1][1])
@@ -459,14 +459,14 @@ impl VoxelAABB {
     }
 
     /// Iterator over grid lines intersecting the region, represented as ordered pairs determining the line's two fixed coordinates
-    pub fn grid_lines(&self, axis0: usize, axis1: usize) -> impl Iterator<Item = (u8, u8)> {
+    pub fn grid_lines(&self, axis0: usize, axis1: usize) -> impl Iterator<Item = (u8, u8)> + use<> {
         let bounds = self.bounds;
         (bounds[axis0][0]..bounds[axis0][1])
             .flat_map(move |i| (bounds[axis1][0]..bounds[axis1][1]).map(move |j| (i, j)))
     }
 
     /// Iterator over grid planes intersecting the region, represented as integers determining the plane's fixed coordinate
-    pub fn grid_planes(&self, axis: usize) -> impl Iterator<Item = u8> {
+    pub fn grid_planes(&self, axis: usize) -> impl Iterator<Item = u8> + use<> {
         self.bounds[axis][0]..self.bounds[axis][1]
     }
 }

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -12,7 +12,7 @@ use crate::proto::{BlockUpdate, Position, SerializedVoxelData};
 use crate::voxel_math::{ChunkDirection, CoordAxis, CoordSign, Coords};
 use crate::world::Material;
 use crate::worldgen::NodeState;
-use crate::{margins, Chunks};
+use crate::{Chunks, margins};
 
 /// Unique identifier for a single chunk (1/20 of a dodecahedron) in the graph
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/common/src/proto.rs
+++ b/common/src/proto.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dodeca, graph::NodeId, math::MIsometry, node::ChunkId, voxel_math::Coords, world::Material,
-    EntityId, SimConfig, Step,
+    EntityId, SimConfig, Step, dodeca, graph::NodeId, math::MIsometry, node::ChunkId,
+    voxel_math::Coords, world::Material,
 };
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -1,7 +1,8 @@
-use rand::{distr::Uniform, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, distr::Uniform};
 use rand_distr::Normal;
 
 use crate::{
+    Plane,
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
     margins, math,
@@ -9,7 +10,6 @@ use crate::{
     node::{ChunkId, VoxelData},
     terraingen::VoronoiInfo,
     world::Material,
-    Plane,
 };
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -617,8 +617,8 @@ fn hash(a: u64, b: u64) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::node::Node;
     use crate::Chunks;
+    use crate::node::Node;
     use approx::*;
 
     const CHUNK_SIZE: u8 = 12;

--- a/save/Cargo.toml
+++ b/save/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "save"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/save/benches/bench.rs
+++ b/save/benches/bench.rs
@@ -1,9 +1,9 @@
 use save::Save;
 
 use criterion::{
-    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 
 fn save(c: &mut Criterion) {
     let mut write = c.benchmark_group("write");

--- a/save/gen-protos/Cargo.toml
+++ b/save/gen-protos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gen-protos"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/save/src/lib.rs
+++ b/save/src/lib.rs
@@ -18,7 +18,6 @@ impl Save {
         let db = Database::create(path).map_err(redb::Error::from)?;
         let meta = {
             let tx = db.begin_read().map_err(redb::Error::from)?;
-            // Intermediate variable to make borrowck happy
             match tx.open_table(META_TABLE) {
                 Ok(meta) => {
                     let Some(value) = meta.get(&[][..]).map_err(redb::Error::from)? else {

--- a/save/tests/heavy.rs
+++ b/save/tests/heavy.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use save::Save;
 
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 
 #[test]
 fn write() {

--- a/save/tests/tests.rs
+++ b/save/tests/tests.rs
@@ -1,4 +1,4 @@
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 
 use save::Save;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "server"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0 OR Zlib"
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -7,7 +7,7 @@ mod sim;
 
 use std::{net::UdpSocket, sync::Arc, time::Instant};
 
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{Context, Error, Result, anyhow};
 use hecs::Entity;
 use quinn::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use slotmap::DenseSlotMap;
@@ -15,9 +15,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, error_span, info, trace, warn};
 
 use common::{
-    codec,
+    SimConfig, codec,
     proto::{self, connection_error_codes},
-    SimConfig,
 };
 use input_queue::InputQueue;
 use save::Save;

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -6,7 +6,7 @@ use common::math::MIsometry;
 use common::node::VoxelData;
 use common::proto::{BlockUpdate, Inventory, SerializedVoxelData};
 use common::world::Material;
-use common::{node::ChunkId, GraphEntities};
+use common::{GraphEntities, node::ChunkId};
 use fxhash::{FxHashMap, FxHashSet};
 use hecs::{DynamicBundle, Entity, EntityBuilder};
 use rand::rngs::SmallRng;
@@ -16,16 +16,15 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, error_span, info, trace};
 
 use common::{
-    character_controller, dodeca,
+    EntityId, SimConfig, Step, character_controller, dodeca,
     graph::{Graph, NodeId},
-    node::{populate_fresh_nodes, Chunk},
+    node::{Chunk, populate_fresh_nodes},
     proto::{
         Character, CharacterInput, CharacterState, ClientHello, Command, Component, FreshNode,
         Position, Spawns, StateDelta,
     },
     traversal::{ensure_nearby, nearby_nodes},
     worldgen::ChunkParams,
-    EntityId, SimConfig, Step,
 };
 
 use crate::postcard_helpers::{self, SaveEntity};
@@ -183,7 +182,10 @@ impl Sim {
                 // Ensure that every node occupied by a character is generated.
                 let Some(character) = read.get_character(&name)? else {
                     // Skip loading named entities that lack path information.
-                    error!("Entity {} will not be loaded because their node path information is missing.", name);
+                    error!(
+                        "Entity {} will not be loaded because their node path information is missing.",
+                        name
+                    );
                     return Ok(());
                 };
                 let mut current_node = NodeId::ROOT;
@@ -198,7 +200,10 @@ impl Sim {
                     // Skip loading named entities that are in the wrong place. This can happen
                     // when there are multiple entities with the same name, which has been possible
                     // in previous versions of Hypermine.
-                    error!("Entity {} will not be loaded because their node path information is incorrect.", name);
+                    error!(
+                        "Entity {} will not be loaded because their node path information is incorrect.",
+                        name
+                    );
                     return Ok(());
                 }
                 // Prepare all relevant components that are needed to support ComponentType::Name


### PR DESCRIPTION
This is done in two separate commits for easier readability:
- Run `cargo edition --fix` and look at (but do nothing about) the warnings, and then make manual changes based on what was learned from `cargo edition --fix`
- Run `cargo fmt`

The main warnings when running `cargo edition --fix` came from [Tail expression temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html#tail-expression-temporary-scope). There have been some changes to semantics here, which `cargo fix --edition` is unable to correct for, so it warns about it. However, my understanding is that for our use case, the new semantics perfectly make sense and do not need to be corrected for.

The main manual change I made was undoing the automatic changes from [if let temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html#if-let-temporary-scope), since the new semantics are fine for our use case. I also deleted an outdated comment (`Intermediate variable to make borrowck happy`) that I discovered while looking into the warnings from `cargo edition --fix`.

I ran `cargo fmt` in a separate commit because it makes a large diff for two reasons:
- There were edition changes to `cargo fmt`, most notably the order of imports.
- The edition fixes for [unsafe_op_in_unsafe_fn warning](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html#unsafe_op_in_unsafe_fn-warning) and new `unsafe` blocks, which increase the level of indentation of many `unsafe` functions we have.