### PR TITLE
Improve numerical stability of ground plane distance estimation

### DIFF
--- a/client/src/graphics/frustum.rs
+++ b/client/src/graphics/frustum.rs
@@ -1,5 +1,4 @@
-use common::Plane;
-use common::math::MPoint;
+use common::math::{MDirection, MPoint};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Frustum {
@@ -51,19 +50,19 @@ impl Frustum {
 
     pub fn planes(&self) -> FrustumPlanes {
         FrustumPlanes {
-            left: Plane::from(
+            left: MDirection::from(
                 na::UnitQuaternion::from_axis_angle(&na::Vector3::y_axis(), self.left)
                     * -na::Vector3::x_axis(),
             ),
-            right: Plane::from(
+            right: MDirection::from(
                 na::UnitQuaternion::from_axis_angle(&na::Vector3::y_axis(), self.right)
                     * na::Vector3::x_axis(),
             ),
-            down: Plane::from(
+            down: MDirection::from(
                 na::UnitQuaternion::from_axis_angle(&na::Vector3::x_axis(), self.down)
                     * na::Vector3::y_axis(),
             ),
-            up: Plane::from(
+            up: MDirection::from(
                 na::UnitQuaternion::from_axis_angle(&na::Vector3::x_axis(), self.up)
                     * -na::Vector3::y_axis(),
             ),
@@ -73,16 +72,16 @@ impl Frustum {
 
 #[derive(Debug, Copy, Clone)]
 pub struct FrustumPlanes {
-    left: Plane<f32>,
-    right: Plane<f32>,
-    down: Plane<f32>,
-    up: Plane<f32>,
+    left: MDirection<f32>,
+    right: MDirection<f32>,
+    down: MDirection<f32>,
+    up: MDirection<f32>,
 }
 
 impl FrustumPlanes {
     pub fn contain(&self, point: &MPoint<f32>, radius: f32) -> bool {
         for &plane in &[&self.left, &self.right, &self.down, &self.up] {
-            if plane.distance_to(point) < -radius {
+            if plane.mip(point).asinh() < -radius {
                 return false;
             }
         }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -37,7 +37,6 @@ pub mod worldgen;
 pub use chunks::Chunks;
 pub use graph_entities::GraphEntities;
 pub use lru_slab::LruSlab;
-pub use plane::Plane;
 pub use sim_config::{SimConfig, SimConfigRaw};
 
 // Stable IDs made of 8 random bytes for easy persistent references

--- a/common/src/math.rs
+++ b/common/src/math.rs
@@ -1150,15 +1150,15 @@ mod tests {
 
     #[test]
     fn distance_commutative() {
-        let p = MPoint::new_unchecked(-1.0, -1.0, 0.0, 3.0f64.sqrt());
-        let q = MPoint::new_unchecked(1.0, -1.0, 0.0, 3.0f64.sqrt());
+        let p = MPoint::new_unchecked(-1.0, -1.0, 0.0, 3.0f32.sqrt());
+        let q = MPoint::new_unchecked(1.0, -1.0, 0.0, 3.0f32.sqrt());
         assert_abs_diff_eq!(p.distance(&q), q.distance(&p));
     }
 
     #[test]
     fn midpoint_distance() {
-        let p = MPoint::new_unchecked(-1.0, -1.0, 0.0, 3.0f64.sqrt());
-        let q = MPoint::new_unchecked(1.0, -1.0, 0.0, 3.0f64.sqrt());
+        let p = MPoint::new_unchecked(-1.0, -1.0, 0.0, 3.0f32.sqrt());
+        let q = MPoint::new_unchecked(1.0, -1.0, 0.0, 3.0f32.sqrt());
         let m = p.midpoint(&q);
         assert_abs_diff_eq!(p.distance(&m), m.distance(&q), epsilon = 1e-5);
         assert_abs_diff_eq!(p.distance(&m) * 2.0, p.distance(&q), epsilon = 1e-5);

--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -5,27 +5,35 @@ use crate::{
     math::{MDirection, MIsometry, MPoint, MVector},
 };
 
-/// A hyperbolic plane
+/// A hyperbolic plane. This data structure uses a separate "exponent" field to
+/// allow for planes very far from the origin. This struct is meant to be used
+/// with world generation.
 #[derive(Debug, Copy, Clone)]
 pub struct Plane {
-    normal: MDirection<f64>,
+    scaled_normal: MVector<f64>,
+    exponent: f64, // Multiply "normal" by e^exponent to get the actual normal vector
 }
 
 impl From<Side> for Plane {
     /// A surface overlapping with a particular dodecahedron side
     fn from(side: Side) -> Self {
-        Self {
-            normal: *side.normal_f64(),
+        Plane::from(*side.normal_f64())
+    }
+}
+
+impl From<MDirection<f64>> for Plane {
+    fn from(normal: MDirection<f64>) -> Self {
+        Plane {
+            scaled_normal: normal.into(),
+            exponent: 0.0,
         }
     }
 }
 
 impl From<na::Unit<na::Vector3<f64>>> for Plane {
     /// A plane passing through the origin
-    fn from(x: na::Unit<na::Vector3<f64>>) -> Self {
-        Self {
-            normal: MDirection::from(x),
-        }
+    fn from(x: na::UnitVector3<f64>) -> Self {
+        Self::from(MDirection::from(x))
     }
 }
 
@@ -33,7 +41,8 @@ impl Neg for Plane {
     type Output = Self;
     fn neg(self) -> Self {
         Self {
-            normal: -self.normal,
+            scaled_normal: -self.scaled_normal,
+            exponent: self.exponent,
         }
     }
 }
@@ -50,28 +59,52 @@ impl Mul<Plane> for &MIsometry<f64> {
     type Output = Plane;
     fn mul(self, rhs: Plane) -> Plane {
         Plane {
-            normal: (self * rhs.normal).as_ref().normalized_direction(),
+            scaled_normal: self * rhs.scaled_normal,
+            exponent: rhs.exponent,
         }
+        .update_exponent()
     }
 }
 
 impl Plane {
-    /// Hyperbolic normal vector identifying the plane
-    pub fn normal(&self) -> &MDirection<f64> {
-        &self.normal
+    /// Hyperbolic normal vector identifying the plane, possibly scaled to avoid
+    /// being too large to represent in an f64.
+    pub fn scaled_normal(&self) -> &MVector<f64> {
+        &self.scaled_normal
     }
 
     /// Shortest distance between the plane and a point
     pub fn distance_to(&self, point: &MPoint<f64>) -> f64 {
-        let mip_value = self.normal.mip(point);
-        // Workaround for bug fixed in rust PR #72486
-        libm::asinh(mip_value.abs()) * mip_value.signum()
+        if self.exponent == 0.0 {
+            libm::asinh(self.scaled_normal.mip(point))
+        } else {
+            let mip_2 = self.scaled_normal.mip(point) * 2.0;
+            (libm::log(mip_2.abs()) + self.exponent) * mip_2.signum()
+        }
     }
 
     /// Like `distance_to`, but using chunk coordinates for a chunk in the same node space
     pub fn distance_to_chunk(&self, chunk: Vertex, coord: &na::Vector3<f64>) -> f64 {
         let pos = (MVector::from(chunk.chunk_to_node_f64() * coord.push(1.0))).normalized_point();
         self.distance_to(&pos)
+    }
+
+    fn update_exponent(mut self) -> Self {
+        // For simplicity, we use the basic approximation of sinh whenever the
+        // exponent is nonzero, so we want to only update the exponent when
+        // we're sure such an approximation will be good enough. Once the
+        // vector's w-coordinate is above 1.0e8, the error becomes unnoticeable
+        // in double-precision floating point.
+
+        // Note that this is a one-way operation. Since trying to use matrices
+        // to transform a plane closer to the origin would result in a kind of
+        // catastrophic cancellation, Plane is not designed to handle that kind
+        // of use case.
+        while self.scaled_normal.w.abs() > 1.0e8 {
+            self.scaled_normal *= libm::exp(-16.0);
+            self.exponent += 16.0;
+        }
+        self
     }
 }
 
@@ -157,5 +190,24 @@ mod tests {
             Plane::from(Side::A).distance_to_chunk(abc, &na::Vector3::new(1.0, 1.0, -1.0)),
             epsilon = 1e-8,
         );
+    }
+
+    #[test]
+    fn large_distances() {
+        for offset in [10.0, -10.0] {
+            let mut plane = Plane::from(MDirection::x());
+            let point = MPoint::<f64>::origin();
+            let mut expected_distance = 0.0;
+
+            for _ in 0..200 {
+                plane = &MIsometry::translation_along(&(na::Vector3::x() * offset)) * plane;
+                expected_distance -= offset;
+                assert_abs_diff_eq!(
+                    plane.distance_to(&point),
+                    expected_distance,
+                    epsilon = 1.0e-8
+                );
+            }
+        }
     }
 }

--- a/common/src/terraingen.rs
+++ b/common/src/terraingen.rs
@@ -928,16 +928,16 @@ const SURFACE_DEEP: [VoronoiInfo; 113] = [
     VoronoiInfo::new(Material::Lava, -10.50, 10.50),
 ];
 
-const TERRAIN_SURFACE_THICKNESS: f64 = 0.2;
+const TERRAIN_SURFACE_THICKNESS: f32 = 0.2;
 
 pub struct VoronoiInfo {
     pub location: [f32; 2],
     pub material: Material,
 }
 impl VoronoiInfo {
-    pub const fn new(mat: Material, rain: f64, temp: f64) -> VoronoiInfo {
+    pub const fn new(mat: Material, rain: f32, temp: f32) -> VoronoiInfo {
         VoronoiInfo {
-            location: [rain as f32, temp as f32],
+            location: [rain, temp],
             material: mat,
         }
     }
@@ -952,7 +952,7 @@ impl VoronoiInfo {
     // elev represents distance from the guiding plane. There are four strata of
     // terrain that are defined by elev thresholds. Variations between strata
     // are intended to represent the effects of more or less skylight being exposed.
-    pub fn terraingen_voronoi(elev: f64, rain: f64, temp: f64, dist: f64) -> Material {
+    pub fn terraingen_voronoi(elev: f32, rain: f32, temp: f32, dist: f32) -> Material {
         let voronoi_choices = if dist <= TERRAIN_SURFACE_THICKNESS {
             if elev < -30.0 {
                 SURFACE_DEEP
@@ -973,7 +973,7 @@ impl VoronoiInfo {
             GENERAL_HIGH
         };
 
-        let y: [f32; 2] = [rain as f32, temp as f32];
+        let y: [f32; 2] = [rain, temp];
         let mut dist_squared = math::sqr(voronoi_choices[0].location[0] - y[0])
             + math::sqr(voronoi_choices[0].location[1] - y[1]);
         let mut voxel_mat = voronoi_choices[0].material;

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -5,7 +5,7 @@ use crate::{
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
     margins,
-    math::{self, MDirection},
+    math::{self, MVector},
     node::{ChunkId, VoxelData},
     plane::Plane,
     terraingen::VoronoiInfo,
@@ -122,8 +122,8 @@ impl NodeState {
         }
     }
 
-    pub fn up_direction(&self) -> MDirection<f32> {
-        self.surface.normal().cast()
+    pub fn up_direction(&self) -> MVector<f32> {
+        self.surface.scaled_normal().cast()
     }
 }
 

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -123,7 +123,7 @@ impl NodeState {
     }
 
     pub fn up_direction(&self) -> MVector<f32> {
-        self.surface.scaled_normal().cast()
+        *self.surface.scaled_normal()
     }
 }
 
@@ -215,7 +215,7 @@ impl ChunkParams {
         // Maximum difference between elevations at the center of a chunk and any other point in the chunk
         // TODO: Compute what this actually is, current value is a guess! Real one must be > 0.6
         // empirically.
-        const ELEVATION_MARGIN: f64 = 0.7;
+        const ELEVATION_MARGIN: f32 = 0.7;
         let center_elevation = self
             .surface
             .distance_to_chunk(self.chunk, &na::Vector3::repeat(0.5));
@@ -393,7 +393,7 @@ impl ChunkParams {
 
         let rain = self.env.rainfalls[0];
         let tree_candidate_count =
-            (u32::from(self.dimension - 2).pow(3) as f64 * (rain / 100.0).clamp(0.0, 0.5)) as usize;
+            (u32::from(self.dimension - 2).pow(3) as f32 * (rain / 100.0).clamp(0.0, 0.5)) as usize;
         for _ in 0..tree_candidate_count {
             let loc = na::Vector3::from_fn(|_, _| rng.sample(random_position));
             let voxel_of_interest_index = index(self.dimension, loc);
@@ -462,7 +462,7 @@ impl ChunkParams {
     }
 }
 
-const TERRAIN_SMOOTHNESS: f64 = 10.0;
+const TERRAIN_SMOOTHNESS: f32 = 10.0;
 
 struct NeighborData {
     coords_opposing: na::Vector3<u8>,
@@ -471,10 +471,10 @@ struct NeighborData {
 
 #[derive(Copy, Clone)]
 struct EnviroFactors {
-    max_elevation: f64,
-    temperature: f64,
-    rainfall: f64,
-    blockiness: f64,
+    max_elevation: f32,
+    temperature: f32,
+    rainfall: f32,
+    blockiness: f32,
 }
 impl EnviroFactors {
     fn varied_from(parent: Self, spice: u64) -> Self {
@@ -498,7 +498,7 @@ impl EnviroFactors {
         }
     }
 }
-impl From<EnviroFactors> for (f64, f64, f64, f64) {
+impl From<EnviroFactors> for (f32, f32, f32, f32) {
     fn from(envirofactors: EnviroFactors) -> Self {
         (
             envirofactors.max_elevation,
@@ -509,14 +509,14 @@ impl From<EnviroFactors> for (f64, f64, f64, f64) {
     }
 }
 struct ChunkIncidentEnviroFactors {
-    max_elevations: [f64; 8],
-    temperatures: [f64; 8],
-    rainfalls: [f64; 8],
-    blockinesses: [f64; 8],
+    max_elevations: [f32; 8],
+    temperatures: [f32; 8],
+    rainfalls: [f32; 8],
+    blockinesses: [f32; 8],
 }
 
 /// Returns the max_elevation values for the nodes that are incident to this chunk,
-/// sorted and converted to f64 for use in functions like trilerp.
+/// sorted and converted to f32 for use in functions like trilerp.
 ///
 /// Returns `None` if not all incident nodes are populated.
 fn chunk_incident_enviro_factors(
@@ -587,16 +587,16 @@ fn serp<N: na::RealField + Copy>(v0: N, v1: N, t: N, threshold: N) -> N {
 /// scale controls wavelength and amplitude. It is not 1:1 to the number of blocks in a period.
 /// strength represents extremity of terracing effect. Sensible values are in (0, 0.5).
 /// The greater the value of limiter, the stronger the bias of threshold towards 0.
-fn terracing_diff(elev_raw: f64, block: f64, scale: f64, strength: f64, limiter: f64) -> f64 {
-    let threshold: f64 = strength / (1.0 + libm::pow(2.0, limiter - block));
-    let elev_floor = libm::floor(elev_raw / scale);
+fn terracing_diff(elev_raw: f32, block: f32, scale: f32, strength: f32, limiter: f32) -> f32 {
+    let threshold: f32 = strength / (1.0 + libm::powf(2.0, limiter - block));
+    let elev_floor = libm::floorf(elev_raw / scale);
     let elev_rem = elev_raw / scale - elev_floor;
     scale * elev_floor + serp(0.0, scale, elev_rem, threshold) - elev_raw
 }
 
 /// Location of the center of a voxel in a unit chunk
-fn voxel_center(dimension: u8, voxel: na::Vector3<u8>) -> na::Vector3<f64> {
-    voxel.map(|x| f64::from(x) + 0.5) / f64::from(dimension)
+fn voxel_center(dimension: u8, voxel: na::Vector3<u8>) -> na::Vector3<f32> {
+    voxel.map(|x| f32::from(x) + 0.5) / f32::from(dimension)
 }
 
 fn index(dimension: u8, v: na::Vector3<u8>) -> usize {
@@ -688,7 +688,7 @@ mod test {
             *g.get_mut(new_node) = Some(Node {
                 state: {
                     let mut state = NodeState::root();
-                    state.enviro.max_elevation = i as f64 + 1.0;
+                    state.enviro.max_elevation = i as f32 + 1.0;
                     state
                 },
                 chunks: Chunks::default(),
@@ -699,7 +699,7 @@ mod test {
             chunk_incident_enviro_factors(&g, ChunkId::new(NodeId::ROOT, Vertex::A)).unwrap();
         for (i, max_elevation) in enviros.max_elevations.into_iter().enumerate() {
             println!("{i}, {max_elevation}");
-            assert_abs_diff_eq!(max_elevation, (i + 1) as f64, epsilon = 1e-8);
+            assert_abs_diff_eq!(max_elevation, (i + 1) as f32, epsilon = 1e-8);
         }
 
         // see corresponding test for trilerp
@@ -714,7 +714,7 @@ mod test {
                     let a = na::Vector3::new(x, y, z);
                     if a == center {
                         checked_center = true;
-                        let c = center.map(|x| x as f64) / CHUNK_SIZE as f64;
+                        let c = center.map(|x| x as f32) / CHUNK_SIZE as f32;
                         let center_max_elevation = trilerp(&enviros.max_elevations, c);
                         assert_abs_diff_eq!(center_max_elevation, 4.5, epsilon = 1e-8);
                         break 'top;

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -2,12 +2,12 @@ use rand::{Rng, SeedableRng, distr::Uniform};
 use rand_distr::Normal;
 
 use crate::{
-    Plane,
     dodeca::{Side, Vertex},
     graph::{Graph, NodeId},
     margins,
     math::{self, MDirection},
     node::{ChunkId, VoxelData},
+    plane::Plane,
     terraingen::VoronoiInfo,
     world::Material,
 };
@@ -66,7 +66,7 @@ impl NodeStateRoad {
 /// generation logic uses this information as a starting point.
 pub struct NodeState {
     kind: NodeStateKind,
-    surface: Plane<f64>,
+    surface: Plane,
     road_state: NodeStateRoad,
     enviro: EnviroFactors,
 }
@@ -171,7 +171,7 @@ pub struct ChunkParams {
     /// Random quantities stored at the eight adjacent nodes, used for terrain generation
     env: ChunkIncidentEnviroFactors,
     /// Reference plane for the terrain surface
-    surface: Plane<f64>,
+    surface: Plane,
     /// Whether this chunk contains a segment of the road
     is_road: bool,
     /// Whether this chunk contains a section of the road's supports


### PR DESCRIPTION
Fixes #102

This PR repurposes plane.rs to serve primarily as the ground plane in worldgen, with the extra logic suggested in #102 (with some minor changes) to handle situations in which the ground plane is far from the origin. The main differences or possible surprises are as follows:
- The normal vector is represented as `scaled_normal * e^exponent` instead of `scaled_normal * 2^exponent`. (a base of `e` instead of 2)
- The exponent is a floating point number instead of an integer. This reduces the amount of casting needed.
- The magnitude of the normal vector is estimated by taking the absolute value of the w-coordinate, as for large enough vectors, the magnitude is proportional to that value.
- The exponent is only updated when the vector becomes very large in magnitude (instead of updating every time the exponent could increase by 1). There's no real downside to this, and it enables another optimization:
- The approximate formula for `sinh(x)` (`ln(abs(x)*2) * signum(x)`) is used whenever the exponent is nonzero, so the decision does not need to determine the magnitude of `x` first.
- It is assumed that repeated transformations to the plane will be applied in such a way that the plane in general gets farther away from the origin (and all the points it's compared to) over time. Going the other way may result in inaccurate calculations because the exponent is set to never decrease. Note that the calculations would have been inaccurate anyway because of catastrophic cancellation.

A few related changes have been bundled with this main change:
- `Frustum` no longer uses `Plane`, since it does not need its more complicated features.
- `Plane`'s generic type parameter has been removed, as it is designed with one floating point type in mind, and there are no real downsides to this simplification anymore.
- All worldgen code (including `Plane`'s implementation) has been switched over to `f32`, as the precision issues of `Plane` were the main blocker to doing this earlier.