### PR TITLE
Uncouple client worldgen from rendering

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -7,7 +7,6 @@ use lahar::Staged;
 use metrics::histogram;
 
 use super::{Base, Fog, Frustum, GltfScene, Meshes, Voxels, fog, voxels};
-use crate::worldgen_driver::WorldgenDriver;
 use crate::{Asset, Config, Loader, Sim};
 use common::SimConfig;
 use common::proto::{Character, Position};
@@ -35,9 +34,6 @@ pub struct Draw {
 
     /// Drives async asset loading
     loader: Loader,
-
-    /// Drives chunk generation
-    worldgen_driver: WorldgenDriver,
 
     //
     // Rendering pipelines
@@ -133,8 +129,6 @@ impl Draw {
 
             let mut loader = Loader::new(cfg.clone(), gfx.clone());
 
-            let worldgen_driver = WorldgenDriver::new(cfg.clone(), &mut loader);
-
             // Construct the per-frame states
             let states = cmds
                 .chunks(2)
@@ -220,8 +214,6 @@ impl Draw {
                 common_descriptor_pool,
 
                 loader,
-
-                worldgen_driver,
 
                 voxels: None,
                 meshes,
@@ -412,7 +404,6 @@ impl Draw {
             histogram!("frame.cpu.nearby_nodes").record(nearby_nodes_started.elapsed());
 
             if let (Some(voxels), Some(sim)) = (self.voxels.as_mut(), sim.as_mut()) {
-                self.worldgen_driver.drive(sim, &nearby_nodes, frustum);
                 voxels.prepare(
                     device,
                     state.voxels.as_mut().unwrap(),

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -7,6 +7,7 @@ use lahar::Staged;
 use metrics::histogram;
 
 use super::{Base, Fog, Frustum, GltfScene, Meshes, Voxels, fog, voxels};
+use crate::worldgen_driver::WorldgenDriver;
 use crate::{Asset, Config, Loader, Sim};
 use common::SimConfig;
 use common::proto::{Character, Position};
@@ -34,6 +35,9 @@ pub struct Draw {
 
     /// Drives async asset loading
     loader: Loader,
+
+    /// Drives chunk generation
+    worldgen_driver: WorldgenDriver,
 
     //
     // Rendering pipelines
@@ -129,6 +133,8 @@ impl Draw {
 
             let mut loader = Loader::new(cfg.clone(), gfx.clone());
 
+            let worldgen_driver = WorldgenDriver::new(cfg.clone(), &mut loader);
+
             // Construct the per-frame states
             let states = cmds
                 .chunks(2)
@@ -214,6 +220,8 @@ impl Draw {
                 common_descriptor_pool,
 
                 loader,
+
+                worldgen_driver,
 
                 voxels: None,
                 meshes,
@@ -404,6 +412,7 @@ impl Draw {
             histogram!("frame.cpu.nearby_nodes").record(nearby_nodes_started.elapsed());
 
             if let (Some(voxels), Some(sim)) = (self.voxels.as_mut(), sim.as_mut()) {
+                self.worldgen_driver.drive(sim, &nearby_nodes, frustum);
                 voxels.prepare(
                     device,
                     state.voxels.as_mut().unwrap(),

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -213,10 +213,10 @@ impl Voxels {
                                         [lru.chunk]
                                     {
                                         // Remove references to released slot IDs
-                                        if surface.map_or(false, |slot| lru_slot == slot) {
+                                        if *surface == Some(lru_slot) {
                                             *surface = None;
                                         }
-                                        if old_surface.map_or(false, |slot| lru_slot == slot) {
+                                        if *old_surface == Some(lru_slot) {
                                             *old_surface = None;
                                         }
                                     }

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -13,7 +13,6 @@ use tracing::warn;
 use crate::{
     Config, Loader, Sim,
     graphics::{Base, Frustum},
-    loader::{Cleanup, LoadCtx, LoadFuture, Loadable, WorkQueue},
 };
 use common::{
     LruSlab,
@@ -35,7 +34,6 @@ pub struct Voxels {
     states: LruSlab<SurfaceState>,
     draw: Surface,
     max_chunks: u32,
-    worldgen: WorkQueue<ChunkDesc>,
 }
 
 impl Voxels {
@@ -67,7 +65,6 @@ impl Voxels {
             dimension,
         );
         Self {
-            worldgen: loader.make_queue(config.chunk_load_parallelism as usize),
             config,
             surface_extraction,
             extraction_scratch,
@@ -98,19 +95,6 @@ impl Voxels {
         for chunk in frame.drawn.drain(..) {
             self.states.peek_mut(chunk).refcount -= 1;
         }
-        while let Some(chunk) = self.worldgen.poll() {
-            let chunk_id = ChunkId::new(chunk.node, chunk.chunk);
-            sim.graph.populate_chunk(chunk_id, chunk.voxels);
-
-            // Now that the block is populated, we can apply any pending block updates the server
-            // provided that the client couldn't apply.
-            if let Some(block_updates) = sim.preloaded_block_updates.remove(&chunk_id) {
-                for block_update in block_updates {
-                    // The chunk was just populated, so a block update should always succeed.
-                    assert!(sim.graph.update_block(&block_update));
-                }
-            }
-        }
 
         // Determine what to load/render
         let view = sim.view();
@@ -123,7 +107,6 @@ impl Voxels {
         let frustum_planes = frustum.planes();
         let local_to_view = view.local.inverse();
         let mut extractions = Vec::new();
-        let mut workqueue_is_full = false;
         for &(node, ref node_transform) in nearby_nodes {
             let node_to_view = local_to_view * node_transform;
             let origin = node_to_view * MPoint::origin();
@@ -136,98 +119,76 @@ impl Voxels {
             use Chunk::*;
             for vertex in Vertex::iter() {
                 let chunk = ChunkId::new(node, vertex);
+
                 // Fetch existing chunk, or extract surface of new chunk
-                match sim
-                    .graph
-                    .get_chunk_mut(chunk)
-                    .expect("all nodes must be populated before rendering")
-                {
-                    Generating => continue,
-                    Fresh => {
-                        // Don't bother trying to generate fresh nodes if the work queue is full
-                        if workqueue_is_full {
-                            continue;
-                        }
-                        // Generate voxel data
-                        if let Some(params) = common::worldgen::ChunkParams::new(
-                            self.surfaces.dimension() as u8,
-                            &sim.graph,
-                            chunk,
-                        ) {
-                            if self.worldgen.load(ChunkDesc { node, params }).is_ok() {
-                                sim.graph[chunk] = Generating;
-                            } else {
-                                workqueue_is_full = true;
-                            }
-                        }
+                let &mut Populated {
+                    ref mut surface,
+                    ref mut old_surface,
+                    ref voxels,
+                } = &mut sim.graph[chunk]
+                else {
+                    continue;
+                };
+
+                if let Some(slot) = surface.or(*old_surface) {
+                    // Render an already-extracted surface
+                    self.states.get_mut(slot).refcount += 1;
+                    frame.drawn.push(slot);
+                    // Transfer transform
+                    frame.surface.transforms_mut()[slot.0 as usize] =
+                        na::Matrix4::from(*node_transform) * vertex.chunk_to_node();
+                }
+                if let (None, &VoxelData::Dense(ref data)) = (&surface, voxels) {
+                    // Extract a surface so it can be drawn in future frames
+                    if frame.extracted.len() == self.config.chunk_load_parallelism as usize {
                         continue;
                     }
-                    &mut Populated {
-                        ref mut surface,
-                        ref mut old_surface,
-                        ref voxels,
-                    } => {
-                        if let Some(slot) = surface.or(*old_surface) {
-                            // Render an already-extracted surface
-                            self.states.get_mut(slot).refcount += 1;
-                            frame.drawn.push(slot);
-                            // Transfer transform
-                            frame.surface.transforms_mut()[slot.0 as usize] =
-                                na::Matrix4::from(*node_transform) * vertex.chunk_to_node();
+                    let removed = if self.states.len() == self.max_chunks {
+                        let slot = self.states.lru().expect("full LRU table is nonempty");
+                        if self.states.peek(slot).refcount != 0 {
+                            warn!("MAX_CHUNKS is too small");
+                            break;
                         }
-                        if let (None, &VoxelData::Dense(ref data)) = (&surface, voxels) {
-                            // Extract a surface so it can be drawn in future frames
-                            if frame.extracted.len() == self.config.chunk_load_parallelism as usize
-                            {
-                                continue;
+                        Some((slot, self.states.remove(slot)))
+                    } else {
+                        None
+                    };
+                    let scratch_slot = self.extraction_scratch.alloc().expect(
+                        "there are at least chunks_loaded_per_frame scratch slots per frame",
+                    );
+                    frame.extracted.push(scratch_slot);
+                    let slot = self.states.insert(SurfaceState {
+                        node,
+                        chunk: vertex,
+                        refcount: 0,
+                    });
+                    *surface = Some(slot);
+                    let storage = self.extraction_scratch.storage(scratch_slot);
+                    storage.copy_from_slice(&data[..]);
+                    if let Some((lru_slot, lru)) = removed {
+                        if let Populated {
+                            ref mut surface,
+                            ref mut old_surface,
+                            ..
+                        } = sim.graph.get_mut(lru.node).as_mut().unwrap().chunks[lru.chunk]
+                        {
+                            // Remove references to released slot IDs
+                            if *surface == Some(lru_slot) {
+                                *surface = None;
                             }
-                            let removed = if self.states.len() == self.max_chunks {
-                                let slot = self.states.lru().expect("full LRU table is nonempty");
-                                if self.states.peek(slot).refcount != 0 {
-                                    warn!("MAX_CHUNKS is too small");
-                                    break;
-                                }
-                                Some((slot, self.states.remove(slot)))
-                            } else {
-                                None
-                            };
-                            let scratch_slot = self.extraction_scratch.alloc().expect("there are at least chunks_loaded_per_frame scratch slots per frame");
-                            frame.extracted.push(scratch_slot);
-                            let slot = self.states.insert(SurfaceState {
-                                node,
-                                chunk: vertex,
-                                refcount: 0,
-                            });
-                            *surface = Some(slot);
-                            let storage = self.extraction_scratch.storage(scratch_slot);
-                            storage.copy_from_slice(&data[..]);
-                            if let Some((lru_slot, lru)) = removed {
-                                if let Populated {
-                                    ref mut surface,
-                                    ref mut old_surface,
-                                    ..
-                                } =
-                                    sim.graph.get_mut(lru.node).as_mut().unwrap().chunks[lru.chunk]
-                                {
-                                    // Remove references to released slot IDs
-                                    if *surface == Some(lru_slot) {
-                                        *surface = None;
-                                    }
-                                    if *old_surface == Some(lru_slot) {
-                                        *old_surface = None;
-                                    }
-                                }
+                            if *old_surface == Some(lru_slot) {
+                                *old_surface = None;
                             }
-                            let node_is_odd = sim.graph.length(node) & 1 != 0;
-                            extractions.push(ExtractTask {
-                                index: scratch_slot,
-                                indirect_offset: self.surfaces.indirect_offset(slot.0),
-                                face_offset: self.surfaces.face_offset(slot.0),
-                                draw_id: slot.0,
-                                reverse_winding: vertex.parity() ^ node_is_odd,
-                            });
                         }
                     }
+                    let node_is_odd = sim.graph.length(node) & 1 != 0;
+                    extractions.push(ExtractTask {
+                        index: scratch_slot,
+                        indirect_offset: self.surfaces.indirect_offset(slot.0),
+                        face_offset: self.surfaces.face_offset(slot.0),
+                        draw_id: slot.0,
+                        reverse_winding: vertex.parity() ^ node_is_odd,
+                    });
                 }
             }
         }
@@ -313,32 +274,4 @@ struct SurfaceState {
     node: NodeId,
     chunk: common::dodeca::Vertex,
     refcount: u32,
-}
-
-struct ChunkDesc {
-    node: NodeId,
-    params: common::worldgen::ChunkParams,
-}
-
-struct LoadedChunk {
-    node: NodeId,
-    chunk: Vertex,
-    voxels: VoxelData,
-}
-
-impl Cleanup for LoadedChunk {
-    unsafe fn cleanup(self, _gfx: &Base) {}
-}
-
-impl Loadable for ChunkDesc {
-    type Output = LoadedChunk;
-    fn load(self, _ctx: &LoadCtx) -> LoadFuture<'_, Self::Output> {
-        Box::pin(async move {
-            Ok(LoadedChunk {
-                node: self.node,
-                chunk: self.params.chunk(),
-                voxels: self.params.generate_voxels(),
-            })
-        })
-    }
 }

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -91,149 +91,147 @@ impl Voxels {
         cmd: vk::CommandBuffer,
         frustum: &Frustum,
     ) {
-        unsafe {
-            // Clean up after previous frame
-            for i in frame.extracted.drain(..) {
-                self.extraction_scratch.free(i);
-            }
-            for chunk in frame.drawn.drain(..) {
-                self.states.peek_mut(chunk).refcount -= 1;
-            }
-            while let Some(chunk) = self.worldgen.poll() {
-                let chunk_id = ChunkId::new(chunk.node, chunk.chunk);
-                sim.graph.populate_chunk(chunk_id, chunk.voxels);
+        // Clean up after previous frame
+        for i in frame.extracted.drain(..) {
+            self.extraction_scratch.free(i);
+        }
+        for chunk in frame.drawn.drain(..) {
+            self.states.peek_mut(chunk).refcount -= 1;
+        }
+        while let Some(chunk) = self.worldgen.poll() {
+            let chunk_id = ChunkId::new(chunk.node, chunk.chunk);
+            sim.graph.populate_chunk(chunk_id, chunk.voxels);
 
-                // Now that the block is populated, we can apply any pending block updates the server
-                // provided that the client couldn't apply.
-                if let Some(block_updates) = sim.preloaded_block_updates.remove(&chunk_id) {
-                    for block_update in block_updates {
-                        // The chunk was just populated, so a block update should always succeed.
-                        assert!(sim.graph.update_block(&block_update));
-                    }
+            // Now that the block is populated, we can apply any pending block updates the server
+            // provided that the client couldn't apply.
+            if let Some(block_updates) = sim.preloaded_block_updates.remove(&chunk_id) {
+                for block_update in block_updates {
+                    // The chunk was just populated, so a block update should always succeed.
+                    assert!(sim.graph.update_block(&block_update));
                 }
             }
+        }
 
-            // Determine what to load/render
-            let view = sim.view();
-            if !sim.graph.contains(view.node) {
-                // Graph is temporarily out of sync with the server; we don't know where we are, so
-                // there's no point trying to draw.
-                return;
+        // Determine what to load/render
+        let view = sim.view();
+        if !sim.graph.contains(view.node) {
+            // Graph is temporarily out of sync with the server; we don't know where we are, so
+            // there's no point trying to draw.
+            return;
+        }
+        let node_scan_started = Instant::now();
+        let frustum_planes = frustum.planes();
+        let local_to_view = view.local.inverse();
+        let mut extractions = Vec::new();
+        let mut workqueue_is_full = false;
+        for &(node, ref node_transform) in nearby_nodes {
+            let node_to_view = local_to_view * node_transform;
+            let origin = node_to_view * MPoint::origin();
+            if !frustum_planes.contain(&origin, dodeca::BOUNDING_SPHERE_RADIUS) {
+                // Don't bother generating or drawing chunks from nodes that are wholly outside the
+                // frustum.
+                continue;
             }
-            let node_scan_started = Instant::now();
-            let frustum_planes = frustum.planes();
-            let local_to_view = view.local.inverse();
-            let mut extractions = Vec::new();
-            let mut workqueue_is_full = false;
-            for &(node, ref node_transform) in nearby_nodes {
-                let node_to_view = local_to_view * node_transform;
-                let origin = node_to_view * MPoint::origin();
-                if !frustum_planes.contain(&origin, dodeca::BOUNDING_SPHERE_RADIUS) {
-                    // Don't bother generating or drawing chunks from nodes that are wholly outside the
-                    // frustum.
-                    continue;
-                }
 
-                use Chunk::*;
-                for vertex in Vertex::iter() {
-                    let chunk = ChunkId::new(node, vertex);
-                    // Fetch existing chunk, or extract surface of new chunk
-                    match sim
-                        .graph
-                        .get_chunk_mut(chunk)
-                        .expect("all nodes must be populated before rendering")
-                    {
-                        Generating => continue,
-                        Fresh => {
-                            // Don't bother trying to generate fresh nodes if the work queue is full
-                            if workqueue_is_full {
-                                continue;
-                            }
-                            // Generate voxel data
-                            if let Some(params) = common::worldgen::ChunkParams::new(
-                                self.surfaces.dimension() as u8,
-                                &sim.graph,
-                                chunk,
-                            ) {
-                                if self.worldgen.load(ChunkDesc { node, params }).is_ok() {
-                                    sim.graph[chunk] = Generating;
-                                } else {
-                                    workqueue_is_full = true;
-                                }
-                            }
+            use Chunk::*;
+            for vertex in Vertex::iter() {
+                let chunk = ChunkId::new(node, vertex);
+                // Fetch existing chunk, or extract surface of new chunk
+                match sim
+                    .graph
+                    .get_chunk_mut(chunk)
+                    .expect("all nodes must be populated before rendering")
+                {
+                    Generating => continue,
+                    Fresh => {
+                        // Don't bother trying to generate fresh nodes if the work queue is full
+                        if workqueue_is_full {
                             continue;
                         }
-                        &mut Populated {
-                            ref mut surface,
-                            ref mut old_surface,
-                            ref voxels,
-                        } => {
-                            if let Some(slot) = surface.or(*old_surface) {
-                                // Render an already-extracted surface
-                                self.states.get_mut(slot).refcount += 1;
-                                frame.drawn.push(slot);
-                                // Transfer transform
-                                frame.surface.transforms_mut()[slot.0 as usize] =
-                                    na::Matrix4::from(*node_transform) * vertex.chunk_to_node();
+                        // Generate voxel data
+                        if let Some(params) = common::worldgen::ChunkParams::new(
+                            self.surfaces.dimension() as u8,
+                            &sim.graph,
+                            chunk,
+                        ) {
+                            if self.worldgen.load(ChunkDesc { node, params }).is_ok() {
+                                sim.graph[chunk] = Generating;
+                            } else {
+                                workqueue_is_full = true;
                             }
-                            if let (None, &VoxelData::Dense(ref data)) = (&surface, voxels) {
-                                // Extract a surface so it can be drawn in future frames
-                                if frame.extracted.len()
-                                    == self.config.chunk_load_parallelism as usize
+                        }
+                        continue;
+                    }
+                    &mut Populated {
+                        ref mut surface,
+                        ref mut old_surface,
+                        ref voxels,
+                    } => {
+                        if let Some(slot) = surface.or(*old_surface) {
+                            // Render an already-extracted surface
+                            self.states.get_mut(slot).refcount += 1;
+                            frame.drawn.push(slot);
+                            // Transfer transform
+                            frame.surface.transforms_mut()[slot.0 as usize] =
+                                na::Matrix4::from(*node_transform) * vertex.chunk_to_node();
+                        }
+                        if let (None, &VoxelData::Dense(ref data)) = (&surface, voxels) {
+                            // Extract a surface so it can be drawn in future frames
+                            if frame.extracted.len() == self.config.chunk_load_parallelism as usize
+                            {
+                                continue;
+                            }
+                            let removed = if self.states.len() == self.max_chunks {
+                                let slot = self.states.lru().expect("full LRU table is nonempty");
+                                if self.states.peek(slot).refcount != 0 {
+                                    warn!("MAX_CHUNKS is too small");
+                                    break;
+                                }
+                                Some((slot, self.states.remove(slot)))
+                            } else {
+                                None
+                            };
+                            let scratch_slot = self.extraction_scratch.alloc().expect("there are at least chunks_loaded_per_frame scratch slots per frame");
+                            frame.extracted.push(scratch_slot);
+                            let slot = self.states.insert(SurfaceState {
+                                node,
+                                chunk: vertex,
+                                refcount: 0,
+                            });
+                            *surface = Some(slot);
+                            let storage = self.extraction_scratch.storage(scratch_slot);
+                            storage.copy_from_slice(&data[..]);
+                            if let Some((lru_slot, lru)) = removed {
+                                if let Populated {
+                                    ref mut surface,
+                                    ref mut old_surface,
+                                    ..
+                                } =
+                                    sim.graph.get_mut(lru.node).as_mut().unwrap().chunks[lru.chunk]
                                 {
-                                    continue;
-                                }
-                                let removed = if self.states.len() == self.max_chunks {
-                                    let slot =
-                                        self.states.lru().expect("full LRU table is nonempty");
-                                    if self.states.peek(slot).refcount != 0 {
-                                        warn!("MAX_CHUNKS is too small");
-                                        break;
+                                    // Remove references to released slot IDs
+                                    if *surface == Some(lru_slot) {
+                                        *surface = None;
                                     }
-                                    Some((slot, self.states.remove(slot)))
-                                } else {
-                                    None
-                                };
-                                let scratch_slot = self.extraction_scratch.alloc().expect("there are at least chunks_loaded_per_frame scratch slots per frame");
-                                frame.extracted.push(scratch_slot);
-                                let slot = self.states.insert(SurfaceState {
-                                    node,
-                                    chunk: vertex,
-                                    refcount: 0,
-                                });
-                                *surface = Some(slot);
-                                let storage = self.extraction_scratch.storage(scratch_slot);
-                                storage.copy_from_slice(&data[..]);
-                                if let Some((lru_slot, lru)) = removed {
-                                    if let Populated {
-                                        ref mut surface,
-                                        ref mut old_surface,
-                                        ..
-                                    } = sim.graph.get_mut(lru.node).as_mut().unwrap().chunks
-                                        [lru.chunk]
-                                    {
-                                        // Remove references to released slot IDs
-                                        if *surface == Some(lru_slot) {
-                                            *surface = None;
-                                        }
-                                        if *old_surface == Some(lru_slot) {
-                                            *old_surface = None;
-                                        }
+                                    if *old_surface == Some(lru_slot) {
+                                        *old_surface = None;
                                     }
                                 }
-                                let node_is_odd = sim.graph.length(node) & 1 != 0;
-                                extractions.push(ExtractTask {
-                                    index: scratch_slot,
-                                    indirect_offset: self.surfaces.indirect_offset(slot.0),
-                                    face_offset: self.surfaces.face_offset(slot.0),
-                                    draw_id: slot.0,
-                                    reverse_winding: vertex.parity() ^ node_is_odd,
-                                });
                             }
+                            let node_is_odd = sim.graph.length(node) & 1 != 0;
+                            extractions.push(ExtractTask {
+                                index: scratch_slot,
+                                indirect_offset: self.surfaces.indirect_offset(slot.0),
+                                face_offset: self.surfaces.face_offset(slot.0),
+                                draw_id: slot.0,
+                                reverse_winding: vertex.parity() ^ node_is_odd,
+                            });
                         }
                     }
                 }
             }
+        }
+        unsafe {
             self.extraction_scratch.extract(
                 device,
                 &self.surface_extraction,
@@ -242,8 +240,8 @@ impl Voxels {
                 cmd,
                 &extractions,
             );
-            histogram!("frame.cpu.voxels.node_scan").record(node_scan_started.elapsed());
         }
+        histogram!("frame.cpu.voxels.node_scan").record(node_scan_started.elapsed());
     }
 
     pub unsafe fn draw(

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -278,7 +278,11 @@ impl Window {
                 error!("connection lost: {}", e);
             }
             server::Message::Hello(msg) => {
-                let sim = Sim::new(msg.sim_config, msg.character);
+                let sim = Sim::new(
+                    msg.sim_config,
+                    self.config.chunk_load_parallelism as usize,
+                    msg.character,
+                );
                 if let Some(draw) = self.draw.as_mut() {
                     draw.configure(sim.cfg());
                 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -20,6 +20,7 @@ pub mod metrics;
 pub mod net;
 mod prediction;
 pub mod sim;
+mod worldgen_driver;
 
 pub use config::Config;
 pub use sim::Sim;

--- a/client/src/worldgen_driver.rs
+++ b/client/src/worldgen_driver.rs
@@ -1,0 +1,123 @@
+use std::{sync::Arc, time::Instant};
+
+use common::{
+    dodeca::{self, Vertex},
+    graph::NodeId,
+    math::{MIsometry, MPoint},
+    node::{Chunk, ChunkId, VoxelData},
+};
+use metrics::histogram;
+
+use crate::{
+    Config, Sim,
+    graphics::{Base, Frustum},
+    loader::{Cleanup, LoadCtx, LoadFuture, Loadable, Loader, WorkQueue},
+};
+
+pub struct WorldgenDriver {
+    work_queue: WorkQueue<ChunkDesc>,
+}
+
+impl WorldgenDriver {
+    pub fn new(config: Arc<Config>, loader: &mut Loader) -> Self {
+        Self {
+            work_queue: loader.make_queue(config.chunk_load_parallelism as usize),
+        }
+    }
+
+    pub fn drive(
+        &mut self,
+        sim: &mut Sim,
+        nearby_nodes: &[(NodeId, MIsometry<f32>)],
+        frustum: &Frustum,
+    ) {
+        let drive_worldgen_started = Instant::now();
+
+        // Check for chunks that have finished generating
+        while let Some(chunk) = self.work_queue.poll() {
+            let chunk_id = ChunkId::new(chunk.node, chunk.chunk);
+            sim.graph.populate_chunk(chunk_id, chunk.voxels);
+
+            // Now that the block is populated, we can apply any pending block updates the server
+            // provided that the client couldn't apply.
+            if let Some(block_updates) = sim.preloaded_block_updates.remove(&chunk_id) {
+                for block_update in block_updates {
+                    // The chunk was just populated, so a block update should always succeed.
+                    assert!(sim.graph.update_block(&block_update));
+                }
+            }
+        }
+
+        // Determine what to load/render
+        let view = sim.view();
+        if !sim.graph.contains(view.node) {
+            // Graph is temporarily out of sync with the server; we don't know where we are, so
+            // there's no point trying to draw.
+            return;
+        }
+        let frustum_planes = frustum.planes();
+        let local_to_view = view.local.inverse();
+
+        'nearby_nodes: for &(node, ref node_transform) in nearby_nodes {
+            let node_to_view = local_to_view * node_transform;
+            let origin = node_to_view * MPoint::origin();
+            if !frustum_planes.contain(&origin, dodeca::BOUNDING_SPHERE_RADIUS) {
+                // Don't bother generating or drawing chunks from nodes that are wholly outside the frustum.
+                continue;
+            }
+
+            for vertex in Vertex::iter() {
+                let chunk_id = ChunkId::new(node, vertex);
+
+                if !matches!(sim.graph[chunk_id], Chunk::Fresh) {
+                    continue;
+                }
+
+                let Some(params) = common::worldgen::ChunkParams::new(
+                    sim.graph.layout().dimension(),
+                    &sim.graph,
+                    chunk_id,
+                ) else {
+                    continue;
+                };
+
+                if self.work_queue.load(ChunkDesc { node, params }).is_ok() {
+                    sim.graph[chunk_id] = Chunk::Generating;
+                } else {
+                    // No capacity is available in the work queue. Stop trying to prepare chunks to generate.
+                    break 'nearby_nodes;
+                }
+            }
+        }
+        histogram!("frame.cpu.drive_worldgen").record(drive_worldgen_started.elapsed());
+    }
+}
+
+struct ChunkDesc {
+    node: NodeId,
+    params: common::worldgen::ChunkParams,
+}
+
+struct LoadedChunk {
+    node: NodeId,
+    chunk: Vertex,
+    voxels: VoxelData,
+}
+
+impl Cleanup for LoadedChunk {
+    // TODO: `Base` is unused. Try to uncouple Loader from graphics.
+    unsafe fn cleanup(self, _gfx: &Base) {}
+}
+
+impl Loadable for ChunkDesc {
+    type Output = LoadedChunk;
+    fn load(self, _ctx: &LoadCtx) -> LoadFuture<'_, Self::Output> {
+        Box::pin(async move {
+            Ok(LoadedChunk {
+                node: self.node,
+                chunk: self.params.chunk(),
+                voxels: self.params.generate_voxels(),
+            })
+        })
+    }
+}


### PR DESCRIPTION
Uncoupling world generation from world rendering will be useful to allow flexibility in multiple areas in the future:
* The client's handling of world generation can stick entirely to safe Rust, making it easier to work with for newer contributors.
* The view distance and chunk generation distance can be kept separate, making it easier to find a resolution for #50 without killing performance or creating thick fog (as the user can then opt in or opt out of chunk pop-in).
* Once the client no longer fully relies on the server to decide which nodes should be generated, `WorldgenDriver` can be responsible for deciding how to expand the graph in addition to how to fill out its chunk data.
* Regarding graph traversal, `WorldgenDriver`'s FPS footprint can be reduced by spreading out graph traversal across multiple frames.
* It could also be responsible for storing modified chunks not yet added to the graph, rather than having that data live directly in `Sim` (Done in this PR).
* It could also be responsible for reclaiming memory for chunks far away from the player.
* In short, there's a lot of functionality that makes sense to put together in the general bucket of "manage the voxels and nodes in `Graph`", and decoupling it from rendering allows all that functionality to exist without adding unmanageable complexity to the code.

I am open to alternative names to `WorldgenDriver`, as I'm not convinced it's a good name for this struct. I call it that because it has a `drive` function, which is named that way because it sends and receives data from a `WorkQueue<ChunkDesc>`, making it behave a bit like a `Loader`.

This is part of a series of pull requests I plan to create to hopefully lead up to #75, as I discovered that my WIP branch for that issue was getting somewhat difficult to manage because of this coupling (since I do decouple server and client graph expansion in that branch).