### PR TITLE
Make the server and client expand the graph independently

### DIFF
--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -377,7 +377,10 @@ impl Sim {
             metrics::declare_ready_for_profiling();
         }
         for node in &msg.nodes {
-            self.graph.insert_neighbor(node.parent, node.side);
+            // We need to get a list of nodes from the server, especially on first log-in,
+            // since otherwise, we won't be able to know where the local character is with
+            // just the NodeId alone.
+            self.graph.ensure_neighbor(node.parent, node.side);
         }
         populate_fresh_nodes(&mut self.graph);
         for block_update in msg.block_updates.into_iter() {

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -389,7 +389,8 @@ impl Sim {
                 tracing::error!("Voxel data received from server is of incorrect dimension");
                 continue;
             };
-            self.graph.populate_chunk(chunk_id, voxel_data);
+            self.worldgen_driver
+                .apply_voxel_data(&mut self.graph, chunk_id, voxel_data);
         }
         for (subject, new_entity) in msg.inventory_additions {
             self.world

--- a/client/src/worldgen_driver.rs
+++ b/client/src/worldgen_driver.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use common::{
     dodeca::Vertex,
     graph::{Graph, NodeId},
-    node::{Chunk, ChunkId, VoxelData},
+    node::{self, Chunk, ChunkId, VoxelData},
     proto::{BlockUpdate, Position},
     traversal,
 };
@@ -41,7 +41,8 @@ impl WorldgenDriver {
             // there's no point trying to generate chunks.
             return;
         }
-
+        traversal::ensure_nearby(graph, &view, chunk_generation_distance);
+        node::populate_fresh_nodes(graph);
         let nearby_nodes = traversal::nearby_nodes(graph, &view, chunk_generation_distance);
 
         'nearby_nodes: for &(node, _) in &nearby_nodes {

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -491,13 +491,6 @@ impl Sim {
         let span = error_span!("step", step = self.step);
         let _guard = span.enter();
 
-        // Extend graph structure
-        for (_, (position, _)) in self.world.query::<(&mut Position, &mut Character)>().iter() {
-            ensure_nearby(&mut self.graph, position, self.cfg.view_distance);
-        }
-
-        self.populate_fresh_graph_nodes();
-
         // We want to load all chunks that a player can interact with in a single step, so chunk_generation_distance
         // is set up to cover that distance.
         let chunk_generation_distance = dodeca::BOUNDING_SPHERE_RADIUS
@@ -506,6 +499,20 @@ impl Sim {
             + self.cfg.character.ground_distance_tolerance
             + self.cfg.character.block_reach
             + 0.001;
+
+        // Extend graph structure
+        for (_, (position, _)) in self.world.query::<(&mut Position, &mut Character)>().iter() {
+            // An extra dodeca::BOUNDING_SPHERE_RADIUS is needed here because we need to generate
+            // enough chunks to ensure that the all chunks a character might interact with can be generated
+            // with world generation, which requires all nodes surrounding its vertex to be in the graph.
+            ensure_nearby(
+                &mut self.graph,
+                position,
+                chunk_generation_distance + dodeca::BOUNDING_SPHERE_RADIUS,
+            );
+        }
+
+        self.populate_fresh_graph_nodes();
 
         // Load all chunks around entities corresponding to clients, which correspond to entities
         // with a "Character" component.


### PR DESCRIPTION
The main change this PR makes is to ensure that the server and client can expand their respective graphs mostly independently (with the main exception being that the server needs to tell the client where its character is at the beginning).