### PR TITLE
Refactor graph expansion to remove the concept of "fresh" nodes

### DIFF
--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -543,7 +543,7 @@ impl Draw {
             state.uniforms.write(Uniforms {
                 view_projection,
                 inverse_projection: *projection.inverse().matrix(),
-                fog_density: fog::density(self.cfg.local_simulation.view_distance, 1e-3, 5.0),
+                fog_density: fog::density(self.cfg.local_simulation.fog_distance, 1e-3, 5.0),
                 time: self.epoch.elapsed().as_secs_f32().fract(),
             });
 

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -170,7 +170,7 @@ impl Voxels {
                             ref mut surface,
                             ref mut old_surface,
                             ..
-                        } = sim.graph.get_mut(lru.node).as_mut().unwrap().chunks[lru.chunk]
+                        } = sim.graph[lru.node].chunks[lru.chunk]
                         {
                             // Remove references to released slot IDs
                             if *surface == Some(lru_slot) {

--- a/client/src/prediction.rs
+++ b/client/src/prediction.rs
@@ -100,7 +100,7 @@ impl PredictedMotion {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::math::MIsometry;
+    use common::{graph::NodeId, math::MIsometry};
 
     /// An arbitrary position
     fn pos() -> Position {
@@ -114,7 +114,7 @@ mod tests {
     fn wraparound() {
         let mock_cfg = SimConfig::from_raw(&common::SimConfigRaw::default());
         let mut mock_graph = Graph::new(1);
-        common::node::populate_fresh_nodes(&mut mock_graph);
+        mock_graph.ensure_node_state(NodeId::ROOT);
         let mock_character_input = CharacterInput {
             movement: na::Vector3::x(),
             jump: false,

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -14,7 +14,7 @@ use common::{
     graph::{Graph, NodeId},
     graph_ray_casting,
     math::{MDirection, MIsometry, MPoint},
-    node::{VoxelData, populate_fresh_nodes},
+    node::VoxelData,
     proto::{
         self, BlockUpdate, Character, CharacterInput, CharacterState, Command, Component,
         Inventory, Position,
@@ -88,7 +88,7 @@ impl Sim {
         local_character_id: EntityId,
     ) -> Self {
         let mut graph = Graph::new(cfg.chunk_size);
-        populate_fresh_nodes(&mut graph);
+        graph.ensure_node_state(NodeId::ROOT);
         Self {
             graph,
             worldgen_driver: WorldgenDriver::new(chunk_load_parallelism),
@@ -383,9 +383,9 @@ impl Sim {
             // We need to get a list of nodes from the server, especially on first log-in,
             // since otherwise, we won't be able to know where the local character is with
             // just the NodeId alone.
-            self.graph.ensure_neighbor(node.parent, node.side);
+            let node_id = self.graph.ensure_neighbor(node.parent, node.side);
+            self.graph.ensure_node_state(node_id);
         }
-        populate_fresh_nodes(&mut self.graph);
         for block_update in msg.block_updates.into_iter() {
             self.worldgen_driver
                 .apply_block_update(&mut self.graph, block_update);

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -377,7 +377,10 @@ impl Sim {
             metrics::declare_ready_for_profiling();
         }
         for node in &msg.nodes {
-            self.graph.insert_neighbor(node.parent, node.side);
+            // We need to get a list of nodes from the server, especially on first log-in,
+            // since otherwise, we won't be able to know where the local character is with
+            // just the NodeId alone.
+            self.graph.ensure_neighbor(node.parent, node.side);
         }
         populate_fresh_nodes(&mut self.graph);
         for block_update in msg.block_updates.into_iter() {

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -222,8 +222,11 @@ impl Sim {
 
     pub fn step(&mut self, dt: Duration, net: &mut server::Handle) {
         self.local_character_controller.renormalize_orientation();
-        self.worldgen_driver
-            .drive(self.view(), self.cfg.view_distance, &mut self.graph);
+        self.worldgen_driver.drive(
+            self.view(),
+            self.cfg.chunk_generation_distance,
+            &mut self.graph,
+        );
 
         let step_interval = self.cfg.step_interval;
         self.since_input_sent += dt;

--- a/client/src/sim.rs
+++ b/client/src/sim.rs
@@ -389,7 +389,8 @@ impl Sim {
                 tracing::error!("Voxel data received from server is of incorrect dimension");
                 continue;
             };
-            self.graph.populate_chunk(chunk_id, voxel_data);
+            self.worldgen_driver
+                .apply_voxel_data(&mut self.graph, chunk_id, voxel_data);
         }
         for (subject, new_entity) in msg.inventory_additions {
             self.world

--- a/client/src/worldgen_driver.rs
+++ b/client/src/worldgen_driver.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use common::{
     dodeca::{self, Vertex},
     graph::{Graph, NodeId},
-    node::{self, Chunk, ChunkId, VoxelData},
+    node::{Chunk, ChunkId, VoxelData},
     proto::{BlockUpdate, Position},
     traversal,
 };
@@ -49,7 +49,13 @@ impl WorldgenDriver {
             &view,
             chunk_generation_distance + dodeca::BOUNDING_SPHERE_RADIUS,
         );
-        node::populate_fresh_nodes(graph);
+        for (node_id, _) in traversal::nearby_nodes(
+            graph,
+            &view,
+            chunk_generation_distance + dodeca::BOUNDING_SPHERE_RADIUS,
+        ) {
+            graph.ensure_node_state(node_id);
+        }
         let nearby_nodes = traversal::nearby_nodes(graph, &view, chunk_generation_distance);
 
         'nearby_nodes: for &(node, _) in &nearby_nodes {

--- a/client/src/worldgen_driver.rs
+++ b/client/src/worldgen_driver.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use common::{
-    dodeca::Vertex,
+    dodeca::{self, Vertex},
     graph::{Graph, NodeId},
     node::{self, Chunk, ChunkId, VoxelData},
     proto::{BlockUpdate, Position},
@@ -41,7 +41,14 @@ impl WorldgenDriver {
             // there's no point trying to generate chunks.
             return;
         }
-        traversal::ensure_nearby(graph, &view, chunk_generation_distance);
+        // An extra dodeca::BOUNDING_SPHERE_RADIUS is needed here because we need to generate
+        // enough chunks to ensure that the all chunks within chunk_generation_distance can be filled
+        // with world generation, which requires all nodes surrounding its vertex to be in the graph.
+        traversal::ensure_nearby(
+            graph,
+            &view,
+            chunk_generation_distance + dodeca::BOUNDING_SPHERE_RADIUS,
+        );
         node::populate_fresh_nodes(graph);
         let nearby_nodes = traversal::nearby_nodes(graph, &view, chunk_generation_distance);
 

--- a/client/src/worldgen_driver.rs
+++ b/client/src/worldgen_driver.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use common::{
     dodeca::Vertex,
     graph::{Graph, NodeId},
-    node::{Chunk, ChunkId, VoxelData},
+    node::{self, Chunk, ChunkId, VoxelData},
     proto::{BlockUpdate, Position},
     traversal,
 };
@@ -41,7 +41,8 @@ impl WorldgenDriver {
             // there's no point trying to generate chunks.
             return;
         }
-
+        traversal::ensure_nearby(graph, &view, chunk_generation_distance);
+        node::populate_fresh_nodes(graph);
         let nearby_nodes = traversal::nearby_nodes(graph, &view, chunk_generation_distance);
 
         'nearby_nodes: for &(node, _) in &nearby_nodes {

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -39,26 +39,22 @@ fn build_graph(c: &mut Criterion) {
     c.bench_function("worldgen", |b| {
         b.iter(|| {
             let mut graph = Graph::new(12);
-            ensure_nearby(&mut graph, &Position::origin(), 2.25);
-            let all_nodes = nearby_nodes(&graph, &Position::origin(), 2.25);
-            for &(node, _) in &all_nodes {
-                graph.ensure_node_state(node);
-            }
+            ensure_nearby(&mut graph, &Position::origin(), 1.0);
+            let all_nodes = nearby_nodes(&graph, &Position::origin(), 1.0);
             let mut n = 0;
             for (node, _) in all_nodes {
                 for vertex in Vertex::iter() {
                     let chunk = ChunkId::new(node, vertex);
-                    if let Some(params) = ChunkParams::new(12, &graph, chunk) {
-                        graph[chunk] = Chunk::Populated {
-                            voxels: params.generate_voxels(),
-                            surface: None,
-                            old_surface: None,
-                        };
-                        n += 1;
-                    }
+                    let params = ChunkParams::new(&mut graph, chunk);
+                    graph[chunk] = Chunk::Populated {
+                        voxels: params.generate_voxels(),
+                        surface: None,
+                        old_surface: None,
+                    };
+                    n += 1;
                 }
             }
-            assert_eq!(n, 640);
+            assert_eq!(n, 860);
         })
     });
 }

--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -39,7 +39,7 @@ fn build_graph(c: &mut Criterion) {
     c.bench_function("worldgen", |b| {
         b.iter(|| {
             let mut graph = Graph::new(12);
-            ensure_nearby(&mut graph, &Position::origin(), 3.0);
+            ensure_nearby(&mut graph, &Position::origin(), 2.25);
             let fresh = graph.fresh().to_vec();
             populate_fresh_nodes(&mut graph);
             let mut n = 0;

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -15,9 +15,6 @@ use crate::{
 /// Graph of the right dodecahedral tiling of H^3
 pub struct Graph {
     nodes: FxHashMap<NodeId, NodeContainer>,
-    /// This field stores implicitly added nodes to ensure that they're initialized in the correct
-    /// order
-    fresh: Vec<NodeId>,
     layout: ChunkLayout,
 }
 
@@ -27,7 +24,6 @@ impl Graph {
         nodes.insert(NodeId::ROOT, NodeContainer::new(None, 0));
         Self {
             nodes,
-            fresh: vec![NodeId::ROOT],
             layout: ChunkLayout::new(dimension),
         }
     }
@@ -46,17 +42,6 @@ impl Graph {
     #[inline]
     pub fn contains(&self, node: NodeId) -> bool {
         self.nodes.contains_key(&node)
-    }
-
-    /// Nodes created since the last call to `clear_fresh`
-    #[inline]
-    pub fn fresh(&self) -> &[NodeId] {
-        &self.fresh
-    }
-
-    #[inline]
-    pub fn clear_fresh(&mut self) {
-        self.fresh.clear();
     }
 
     /// Node and vertex that the cube around a certain vertex is canonically assigned to.
@@ -196,7 +181,6 @@ impl Graph {
         for (side, neighbor) in shorter_neighbors_of_subject {
             self.link_neighbors(id, neighbor, side);
         }
-        self.fresh.push(id);
         id
     }
 

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -103,16 +103,6 @@ impl Graph {
     }
 
     #[inline]
-    pub fn get(&self, node: NodeId) -> &Option<Node> {
-        &self.nodes[&node].value
-    }
-
-    #[inline]
-    pub fn get_mut(&mut self, node: NodeId) -> &mut Option<Node> {
-        &mut self.nodes.get_mut(&node).unwrap().value
-    }
-
-    #[inline]
     pub fn neighbor(&self, node: NodeId, which: Side) -> Option<NodeId> {
         self.nodes[&node].neighbors[which as usize]
     }
@@ -274,6 +264,22 @@ impl Graph {
     }
 }
 
+impl std::ops::Index<NodeId> for Graph {
+    type Output = Node;
+
+    #[inline]
+    fn index(&self, node_id: NodeId) -> &Node {
+        &self.nodes[&node_id].value
+    }
+}
+
+impl std::ops::IndexMut<NodeId> for Graph {
+    #[inline]
+    fn index_mut(&mut self, node_id: NodeId) -> &mut Node {
+        &mut self.nodes.get_mut(&node_id).unwrap().value
+    }
+}
+
 /// Unique 128-bit identifier for a dodecahedral node in the graph. This ID
 /// depends entirely on the location of the node within the graph and is
 /// guaranteed not to depend on the order in which nodes are added to the graph.
@@ -289,7 +295,7 @@ impl NodeId {
 }
 
 struct NodeContainer {
-    value: Option<Node>,
+    value: Node,
     parent_side: Option<Side>,
     /// Distance to origin via parents
     length: u32,
@@ -299,7 +305,7 @@ struct NodeContainer {
 impl NodeContainer {
     fn new(parent_side: Option<Side>, length: u32) -> Self {
         Self {
-            value: None,
+            value: Node::default(),
             parent_side,
             length,
             neighbors: [None; Side::VALUES.len()],

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -246,7 +246,7 @@ mod tests {
             );
             let Chunk::Populated {
                 voxels: voxel_data, ..
-            } = graph.get_chunk_mut(chunk).unwrap()
+            } = &mut graph[chunk]
             else {
                 panic!("All chunks should be populated.");
             };

--- a/common/src/graph_collision.rs
+++ b/common/src/graph_collision.rs
@@ -89,7 +89,7 @@ mod tests {
         dodeca::{self, Side, Vertex},
         graph::{Graph, NodeId},
         math::{MIsometry, MPoint},
-        node::{VoxelData, populate_fresh_nodes},
+        node::VoxelData,
         proto::Position,
         traversal::{ensure_nearby, nearby_nodes},
         voxel_math::Coords,
@@ -152,7 +152,6 @@ mod tests {
 
             // Set up a graph with void chunks
             ensure_nearby(&mut graph, &Position::origin(), graph_radius);
-            populate_fresh_nodes(&mut graph);
             for (node, _) in nearby_nodes(&graph, &Position::origin(), graph_radius) {
                 for vertex in dodeca::Vertex::iter() {
                     graph[ChunkId::new(node, vertex)] = Chunk::Populated {
@@ -420,7 +419,6 @@ mod tests {
         ];
 
         // Populate all graph nodes
-        populate_fresh_nodes(&mut graph);
         for node in [
             &[NodeId::ROOT],
             first_neighbors.as_slice(),

--- a/common/src/margins.rs
+++ b/common/src/margins.rs
@@ -288,7 +288,7 @@ impl std::ops::Mul<CoordsWithMargins> for ChunkAxisPermutation {
 
 #[cfg(test)]
 mod tests {
-    use crate::{dodeca::Vertex, graph::NodeId, node, voxel_math::Coords, world::Material};
+    use crate::{dodeca::Vertex, graph::NodeId, voxel_math::Coords, world::Material};
 
     use super::*;
 
@@ -364,7 +364,6 @@ mod tests {
         let neighbor_vertex = current_vertex.adjacent_vertices()[1];
         let neighbor_node =
             graph.ensure_neighbor(NodeId::ROOT, current_vertex.canonical_sides()[0]);
-        node::populate_fresh_nodes(&mut graph);
 
         // These are the chunks this test will work with.
         let current_chunk = ChunkId::new(NodeId::ROOT, current_vertex);
@@ -373,7 +372,7 @@ mod tests {
 
         // Populate relevant chunks
         for chunk in [current_chunk, node_neighbor_chunk, vertex_neighbor_chunk] {
-            *graph.get_chunk_mut(chunk).unwrap() = Chunk::Populated {
+            graph[chunk] = Chunk::Populated {
                 voxels: VoxelData::Solid(Material::Void),
                 surface: None,
                 old_surface: None,
@@ -382,8 +381,7 @@ mod tests {
 
         // Fill current chunk with appropriate materials
         {
-            let Chunk::Populated { voxels, .. } = graph.get_chunk_mut(current_chunk).unwrap()
-            else {
+            let Chunk::Populated { voxels, .. } = &mut graph[current_chunk] else {
                 unreachable!()
             };
             voxels.data_mut(12)[Coords([0, 7, 9]).to_index(12)] = Material::WoodPlanks;
@@ -392,9 +390,7 @@ mod tests {
 
         // Fill vertex_neighbor chunk with appropriate material
         {
-            let Chunk::Populated { voxels, .. } =
-                graph.get_chunk_mut(vertex_neighbor_chunk).unwrap()
-            else {
+            let Chunk::Populated { voxels, .. } = &mut graph[vertex_neighbor_chunk] else {
                 unreachable!()
             };
             voxels.data_mut(12)[Coords([5, 9, 11]).to_index(12)] = Material::Slate;
@@ -418,7 +414,7 @@ mod tests {
         let Chunk::Populated {
             voxels: current_voxels,
             ..
-        } = graph.get_chunk(current_chunk).unwrap()
+        } = &graph[current_chunk]
         else {
             unreachable!("node_neighbor_chunk should have been populated by this test");
         };
@@ -431,7 +427,7 @@ mod tests {
         let Chunk::Populated {
             voxels: node_neighbor_voxels,
             ..
-        } = graph.get_chunk(node_neighbor_chunk).unwrap()
+        } = &graph[node_neighbor_chunk]
         else {
             unreachable!("node_neighbor_chunk should have been populated by this test");
         };
@@ -444,7 +440,7 @@ mod tests {
         let Chunk::Populated {
             voxels: vertex_neighbor_voxels,
             ..
-        } = graph.get_chunk(vertex_neighbor_chunk).unwrap()
+        } = &graph[vertex_neighbor_chunk]
         else {
             unreachable!("vertex_neighbor_chunk should have been populated by this test");
         };

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -233,8 +233,8 @@ pub enum Chunk {
     /// - It was just added to the graph and hasn't had time to be processed.
     /// - All world generation threads are occupied, and it is not this chunk's
     ///   turn yet.
-    /// - Not all nodes adjacent to this chunk are in the graph yet, so this
-    ///   chunk lacks information necessary for world generation to proceed.
+    /// - The chunk is not close enough to be worth generating. This might
+    ///   happen for chunks on the far side of a node.
     #[default]
     Fresh,
 

--- a/common/src/sim_config.rs
+++ b/common/src/sim_config.rs
@@ -10,8 +10,12 @@ use crate::{dodeca, math::MVector};
 pub struct SimConfigRaw {
     /// Number of steps per second
     pub rate: Option<u16>,
-    /// Maximum distance at which anything can be seen in meters
+    /// Maximum distance at which nodes will be rendered in meters
     pub view_distance: Option<f32>,
+    /// Maximum distance at which new chunks will be generated in meters
+    pub chunk_generation_distance: Option<f32>,
+    /// Distance at which fog becomes completely opaque in meters
+    pub fog_distance: Option<f32>,
     pub input_queue_size_ms: Option<u16>,
     /// Whether gameplay-like restrictions exist, such as limited inventory
     pub gameplay_enabled: Option<bool>,
@@ -36,8 +40,12 @@ pub struct SimConfigRaw {
 pub struct SimConfig {
     /// Amount of time between each step. Inverse of the rate
     pub step_interval: Duration,
-    /// Maximum distance at which anything can be seen in absolute units
+    /// Maximum distance at which nodes will be rendered in absolute units
     pub view_distance: f32,
+    /// Maximum distance at which new chunks will be generate in absolute units
+    pub chunk_generation_distance: f32,
+    /// Distance at which fog becomes completely opaque in absolute units
+    pub fog_distance: f32,
     pub input_queue_size: Duration,
     /// Whether gameplay-like restrictions exist, such as limited inventory
     pub gameplay_enabled: bool,
@@ -56,7 +64,10 @@ impl SimConfig {
         let meters_to_absolute = meters_to_absolute(chunk_size, voxel_size);
         SimConfig {
             step_interval: Duration::from_secs(1) / x.rate.unwrap_or(30) as u32,
-            view_distance: x.view_distance.unwrap_or(90.0) * meters_to_absolute,
+            view_distance: x.view_distance.unwrap_or(75.0) * meters_to_absolute,
+            chunk_generation_distance: x.chunk_generation_distance.unwrap_or(60.0)
+                * meters_to_absolute,
+            fog_distance: x.fog_distance.unwrap_or(90.0) * meters_to_absolute,
             input_queue_size: Duration::from_millis(x.input_queue_size_ms.unwrap_or(50).into()),
             gameplay_enabled: x.gameplay_enabled.unwrap_or(false),
             chunk_size,

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -88,12 +88,12 @@ impl NodeState {
     pub fn child(&self, graph: &Graph, node: NodeId, side: Side) -> Self {
         let mut d = graph
             .descenders(node)
-            .map(|(s, n)| (s, graph[n].state.as_ref().unwrap()));
+            .map(|(s, n)| (s, graph.node_state(n)));
         let enviro = match (d.next(), d.next()) {
             (Some(_), None) => {
                 let parent_side = graph.parent(node).unwrap();
                 let parent_node = graph.neighbor(node, parent_side).unwrap();
-                let parent_state = graph[parent_node].state.as_ref().unwrap();
+                let parent_state = graph.node_state(parent_node);
                 let spice = graph.hash_of(node) as u64;
                 EnviroFactors::varied_from(parent_state.enviro, spice)
             }
@@ -101,7 +101,7 @@ impl NodeState {
                 let ab_node = graph
                     .neighbor(graph.neighbor(node, a_side).unwrap(), b_side)
                     .unwrap();
-                let ab_state = graph[ab_node].state.as_ref().unwrap();
+                let ab_state = graph.node_state(ab_node);
                 EnviroFactors::continue_from(a_state.enviro, b_state.enviro, ab_state.enviro)
             }
             _ => unreachable!(),
@@ -683,9 +683,8 @@ mod test {
             let new_node = path.fold(NodeId::ROOT, |node, side| g.ensure_neighbor(node, side));
 
             // assigning state
-            let mut state = NodeState::root();
-            state.enviro.max_elevation = i as f32 + 1.0;
-            g[new_node].state = Some(state);
+            g.ensure_node_state(new_node);
+            g[new_node].state.as_mut().unwrap().enviro.max_elevation = i as f32 + 1.0;
         }
 
         let enviros =

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -491,13 +491,6 @@ impl Sim {
         let span = error_span!("step", step = self.step);
         let _guard = span.enter();
 
-        // Extend graph structure
-        for (_, (position, _)) in self.world.query::<(&mut Position, &mut Character)>().iter() {
-            ensure_nearby(&mut self.graph, position, self.cfg.view_distance);
-        }
-
-        self.populate_fresh_graph_nodes();
-
         // We want to load all chunks that a player can interact with in a single step, so chunk_generation_distance
         // is set up to cover that distance.
         let chunk_generation_distance = dodeca::BOUNDING_SPHERE_RADIUS
@@ -506,6 +499,20 @@ impl Sim {
             + self.cfg.character.ground_distance_tolerance
             + self.cfg.character.block_reach
             + 0.001;
+
+        // Extend graph structure
+        for (_, (position, _)) in self.world.query::<(&mut Position, &mut Character)>().iter() {
+            // An extra dodeca::BOUNDING_SPHERE_RADIUS is needed here because we need to generate
+            // enough chunks to ensure that the all chunks a character might interact with can be generated
+            // with world generation, which requires all nodes surrounding its vertex to be in the graph.
+            ensure_nearby(
+                &mut self.graph,
+                position,
+                chunk_generation_distance + dodeca::BOUNDING_SPHERE_RADIUS,
+            );
+        }
+
+        self.populate_fresh_graph_nodes();
 
         // Load all chunks around entities corresponding to clients, which correspond to entities
         // with a "Character" component.

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -493,8 +493,7 @@ impl Sim {
 
         // We want to load all chunks that a player can interact with in a single step, so chunk_generation_distance
         // is set up to cover that distance.
-        let chunk_generation_distance = dodeca::BOUNDING_SPHERE_RADIUS
-            + self.cfg.character.character_radius
+        let chunk_generation_distance = self.cfg.character.character_radius
             + self.cfg.character.speed_cap * self.cfg.step_interval.as_secs_f32()
             + self.cfg.character.ground_distance_tolerance
             + self.cfg.character.block_reach


### PR DESCRIPTION
Note: The first few (2 as of the time I'm writing this) commits match https://github.com/Ralith/hypermine/pull/452, so this PR effectively branches off of https://github.com/Ralith/hypermine/pull/452, and only the later commits should be reviewed.

Since keeping the server and client graphs entirely in sync is one of the main reasons `Graph` needed to keep track of its freshly created nodes, and now they no longer need to be in sync this way, this PR removes this functionality to simplify `Graph`'s usage. Specifically, each `Node` is initialized immediately when it's added to the graph instead of being initialized to `None`. The `NodeState` field, which is used in fewer places, is still kept optional, and instead of being populated for every fresh node, it is populated for a given `NodeId` with an `ensure_node_state` function.

Part of why `NodeState` is kept optional is that its initialization order will need to be more complicated for megastructures, although there may be a way in the future to make things simpler on that front as well.

Since this PR makes heavy changes to graph expansion, it also addresses most of #50 by making the "distance" computations correct. However, with the current level of optimization, it is impossible to avoid the following three problems: unacceptably thick fog, pop-in, and unacceptable performance issues. Therefore, we still allow pop-in by making fog distance, view distance, and chunk generation distance separate settings with different defaults in the config.