### PR TITLE
Fix package-linux workflow by removing unsupported Ubuntu 20.04

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,14 +43,15 @@ jobs:
   package-linux:
     name: Linux
     # Oldest supported runner, for wide glibc compat
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install dependencies
         run: sudo apt update && sudo apt-get -y install libasound2-dev libvulkan-dev libfontconfig-dev
-      # No prebuilt shaderc, since the official binaries don't to be compatible with Ubuntu 20.04.
+      # No prebuilt shaderc, since the official binaries don't seem to be compatible with Ubuntu 20.04,
+      # and we haven't tested them on Ubuntu 22.04.
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build Server


### PR DESCRIPTION
The Package/Linux workflow is currently failing on master, being auto-cancelled with the following error:
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101