### PR TITLE
Rename "length" to "depth" and make "parent" more useful

### DIFF
--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -181,7 +181,7 @@ impl Voxels {
                             }
                         }
                     }
-                    let node_is_odd = sim.graph.length(node) & 1 != 0;
+                    let node_is_odd = sim.graph.depth(node) & 1 != 0;
                     extractions.push(ExtractTask {
                         index: scratch_slot,
                         indirect_offset: self.surfaces.indirect_offset(slot.0),

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -41,12 +41,12 @@ impl Graph {
             return;
         }
 
-        for (_, parent) in self.descenders(node_id) {
+        for (_, parent) in self.parents(node_id) {
             self.ensure_node_state(parent);
         }
 
         let node_state = self
-            .parent(node_id)
+            .primary_parent_side(node_id)
             .map(|i| {
                 let parent_state = self.node_state(self.neighbor(node_id, i).unwrap());
                 parent_state.child(self, node_id, i)

--- a/common/src/worldgen.rs
+++ b/common/src/worldgen.rs
@@ -86,12 +86,10 @@ impl NodeState {
     }
 
     pub fn child(&self, graph: &Graph, node: NodeId, side: Side) -> Self {
-        let mut d = graph
-            .descenders(node)
-            .map(|(s, n)| (s, graph.node_state(n)));
+        let mut d = graph.parents(node).map(|(s, n)| (s, graph.node_state(n)));
         let enviro = match (d.next(), d.next()) {
             (Some(_), None) => {
-                let parent_side = graph.parent(node).unwrap();
+                let parent_side = graph.primary_parent_side(node).unwrap();
                 let parent_node = graph.neighbor(node, parent_side).unwrap();
                 let parent_state = graph.node_state(parent_node);
                 let spice = graph.hash_of(node) as u64;

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -81,9 +81,9 @@ impl Sim {
     pub fn save(&mut self, save: &mut save::Save) -> Result<(), save::DbError> {
         fn path_from_origin(graph: &Graph, mut node: NodeId) -> Vec<u8> {
             let mut result = Vec::new();
-            while let Some(parent) = graph.parent(node) {
-                result.push(parent as u8);
-                node = graph.neighbor(node, parent).unwrap();
+            while let Some(primary_parent) = graph.primary_parent_side(node) {
+                result.push(primary_parent as u8);
+                node = graph.neighbor(node, primary_parent).unwrap();
             }
             result.reverse();
             result
@@ -790,7 +790,7 @@ impl AccumulatedChanges {
                 .fresh_nodes
                 .iter()
                 .filter_map(|&id| {
-                    let side = graph.parent(id)?;
+                    let side = graph.primary_parent_side(id)?;
                     Some(FreshNode {
                         side,
                         parent: graph.neighbor(id, side).unwrap(),


### PR DESCRIPTION
The term "depth" is arguably more intuitive when expressing how far away from the root a graph's node is, so this should hopefully reduce the barrier to entry for learning the Hypermine codebase.

As for "parent", previously, it was often interpreted as though every node (except the root) has one parent, even though most logic took all "shorter neighbors" into account, so "parent" now refers to any neighbor node closer to the root. The old meaning of parent is renamed to "primary parent", which is the parent with the first side in enum order.

Given that I hope to add the new terminology of "peer" nodes into the code base, I think it makes sense to rethink existing terms to make sure they're consistent with each other and with what one might expect. I would like to rename some of the terminology in `dodeca` as well, but I'm less sure about the right terminology, so I'll need to think on it some more and/or open an issue.