### PR TITLE
Fix Clippy lint for 1.88.0 (clippy::neg_multiply)

### DIFF
--- a/common/src/plane.rs
+++ b/common/src/plane.rs
@@ -141,7 +141,7 @@ mod tests {
         let root = Plane::from(Side::A);
         assert_abs_diff_eq!(
             root.distance_to_chunk(Vertex::A, &na::Vector3::new(-1.0, 1.0, 1.0)),
-            root.distance_to_chunk(Vertex::J, &na::Vector3::new(-1.0, 1.0, 1.0)) * -1.0,
+            -root.distance_to_chunk(Vertex::J, &na::Vector3::new(-1.0, 1.0, 1.0)),
             epsilon = 1e-5
         );
     }


### PR DESCRIPTION
```
warning: this multiplication by -1 can be written more succinctly
   --> common\src\plane.rs:144:13
    |
144 |             root.distance_to_chunk(Vertex::J, &na::Vector3::new(-1.0, 1.0, 1.0)) * -1.0,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `-root.distance_to_chunk(Vertex::J, &na::Vector3::new(-1.0, 1.0, 1.0))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#neg_multiply
    = note: `#[warn(clippy::neg_multiply)]` on by default
```