### PR TITLE
Fix clippy lints for Rust 1.91.1

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -59,10 +59,10 @@ impl Config {
             data_dirs.push(dir);
         }
         data_dirs.push(dirs.data_dir().into());
-        if let Ok(path) = env::current_exe() {
-            if let Some(dir) = path.parent() {
-                data_dirs.push(dir.into());
-            }
+        if let Ok(path) = env::current_exe()
+            && let Some(dir) = path.parent()
+        {
+            data_dirs.push(dir.into());
         }
         #[cfg(feature = "use-repo-assets")]
         {

--- a/client/src/graphics/draw.rs
+++ b/client/src/graphics/draw.rs
@@ -493,20 +493,15 @@ impl Draw {
                             .world
                             .get::<&Position>(entity)
                             .expect("positionless entity in graph");
-                        if let Some(character_model) = self.loader.get(self.character_model) {
-                            if let Ok(ch) = sim.world.get::<&Character>(entity) {
-                                let transform = na::Matrix4::from(transform * pos.local)
-                                    * na::Matrix4::new_scaling(sim.cfg().meters_to_absolute)
-                                    * ch.state.orientation.to_homogeneous();
-                                for mesh in &character_model.0 {
-                                    self.meshes.draw(
-                                        device,
-                                        state.common_ds,
-                                        cmd,
-                                        mesh,
-                                        &transform,
-                                    );
-                                }
+                        if let Some(character_model) = self.loader.get(self.character_model)
+                            && let Ok(ch) = sim.world.get::<&Character>(entity)
+                        {
+                            let transform = na::Matrix4::from(transform * pos.local)
+                                * na::Matrix4::new_scaling(sim.cfg().meters_to_absolute)
+                                * ch.state.orientation.to_homogeneous();
+                            for mesh in &character_model.0 {
+                                self.meshes
+                                    .draw(device, state.common_ds, cmd, mesh, &transform);
                             }
                         }
                     }

--- a/client/src/graphics/voxels/mod.rs
+++ b/client/src/graphics/voxels/mod.rs
@@ -165,20 +165,19 @@ impl Voxels {
                     *surface = Some(slot);
                     let storage = self.extraction_scratch.storage(scratch_slot);
                     storage.copy_from_slice(&data[..]);
-                    if let Some((lru_slot, lru)) = removed {
-                        if let Populated {
+                    if let Some((lru_slot, lru)) = removed
+                        && let Populated {
                             ref mut surface,
                             ref mut old_surface,
                             ..
                         } = sim.graph[lru.node].chunks[lru.chunk]
-                        {
-                            // Remove references to released slot IDs
-                            if *surface == Some(lru_slot) {
-                                *surface = None;
-                            }
-                            if *old_surface == Some(lru_slot) {
-                                *old_surface = None;
-                            }
+                    {
+                        // Remove references to released slot IDs
+                        if *surface == Some(lru_slot) {
+                            *surface = None;
+                        }
+                        if *old_surface == Some(lru_slot) {
+                            *old_surface = None;
                         }
                     }
                     let node_is_odd = sim.graph.depth(node) & 1 != 0;

--- a/client/src/graphics/window.rs
+++ b/client/src/graphics/window.rs
@@ -174,10 +174,10 @@ impl Window {
                 state: ElementState::Pressed,
                 ..
             } => {
-                if self.input.mouse_captured {
-                    if let Some(sim) = self.sim.as_mut() {
-                        sim.set_break_block_pressed_true();
-                    }
+                if self.input.mouse_captured
+                    && let Some(sim) = self.sim.as_mut()
+                {
+                    sim.set_break_block_pressed_true();
                 }
                 let _ = self
                     .window
@@ -191,10 +191,10 @@ impl Window {
                 state: ElementState::Pressed,
                 ..
             } => {
-                if self.input.mouse_captured {
-                    if let Some(sim) = self.sim.as_mut() {
-                        sim.set_place_block_pressed_true();
-                    }
+                if self.input.mouse_captured
+                    && let Some(sim) = self.sim.as_mut()
+                {
+                    sim.set_place_block_pressed_true();
                 }
             }
             WindowEvent::KeyboardInput {
@@ -252,12 +252,11 @@ impl Window {
                     self.input.mouse_captured = false;
                 }
                 _ => {
-                    if let Some(material_idx) = number_key_to_index(key) {
-                        if state == ElementState::Pressed {
-                            if let Some(sim) = self.sim.as_mut() {
-                                sim.select_material(material_idx);
-                            }
-                        }
+                    if let Some(material_idx) = number_key_to_index(key)
+                        && state == ElementState::Pressed
+                        && let Some(sim) = self.sim.as_mut()
+                    {
+                        sim.select_material(material_idx);
                     }
                 }
             },

--- a/common/src/graph.rs
+++ b/common/src/graph.rs
@@ -50,10 +50,10 @@ impl Graph {
     pub fn canonicalize(&self, mut chunk: ChunkId) -> Option<ChunkId> {
         for side in chunk.vertex.canonical_sides().into_iter() {
             // missing neighbors are always longer
-            if let Some(neighbor) = self.neighbor(chunk.node, side) {
-                if self.depth(neighbor) < self.depth(chunk.node) {
-                    chunk.node = neighbor;
-                }
+            if let Some(neighbor) = self.neighbor(chunk.node, side)
+                && self.depth(neighbor) < self.depth(chunk.node)
+            {
+                chunk.node = neighbor;
             }
         }
         Some(chunk)
@@ -69,11 +69,11 @@ impl Graph {
         for side in Side::iter() {
             // filtering out not-yet-allocated neighbors is fine since
             // they have to be longer than us not to be allocated yet
-            if let Some(neighbor_node) = self.neighbor(node, side) {
-                if self.depth(neighbor_node) < node_depth {
-                    results[len] = Some((side, neighbor_node));
-                    len += 1;
-                }
+            if let Some(neighbor_node) = self.neighbor(node, side)
+                && self.depth(neighbor_node) < node_depth
+            {
+                results[len] = Some((side, neighbor_node));
+                len += 1;
             }
         }
 
@@ -311,11 +311,11 @@ impl<'a> TreeIter<'a> {
         let node_id = self.queue.pop_front()?;
         let node = &self.nodes[&node_id];
         for side in Side::iter() {
-            if let Some(neighbor) = node.neighbors[side as usize] {
-                if !self.visited.contains(&neighbor) {
-                    self.queue.push_back(neighbor);
-                    self.visited.insert(neighbor);
-                }
+            if let Some(neighbor) = node.neighbors[side as usize]
+                && !self.visited.contains(&neighbor)
+            {
+                self.queue.push_back(neighbor);
+                self.visited.insert(neighbor);
             }
         }
         Some(node)


### PR DESCRIPTION
The lint solved in this PR is `collapsible_if`, as Rust 1.88.0 stabilized the "let chains" feature (<https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/#let-chains>).