### PR TITLE
Improve anonymity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,6 @@ dependencies = [
  "tracing",
  "vk-shader-macros",
  "webpki",
- "whoami",
  "winit",
  "yakui",
  "yakui-vulkan",
@@ -963,7 +962,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1461,7 +1460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -3213,30 +3212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasite"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
-dependencies = [
- "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3435,17 +3416,6 @@ checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "whoami"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace4d5c7b5ab3d99629156d4e0997edbe98a4beb6d5ba99e2cae830207a81983"
-dependencies = [
- "libredox",
- "wasite",
- "web-sys",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,7 +26,6 @@ libm = "0.2.6"
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "macros"] }
 png = "0.18.0"
 anyhow = "1.0.26"
-whoami = "2.0.2"
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 toml = { workspace = true }
 fxhash = "0.2.1"

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -8,7 +8,7 @@ use std::{
 use serde::Deserialize;
 use tracing::{debug, error, info};
 
-use common::{SimConfig, SimConfigRaw};
+use common::{Anonymize, SimConfig, SimConfigRaw};
 
 pub struct Config {
     pub name: Arc<str>,
@@ -33,7 +33,7 @@ impl Config {
             server,
         } = match fs::read(&path) {
             Ok(data) => {
-                info!("found config at {}", path.display());
+                info!("found config at {}", path.anonymize().display());
                 match std::str::from_utf8(&data)
                     .map_err(anyhow::Error::from)
                     .and_then(|s| toml::from_str(s).map_err(anyhow::Error::from))
@@ -46,11 +46,15 @@ impl Config {
                 }
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                info!("{} not found, using defaults", path.display());
+                info!("{} not found, using defaults", path.anonymize().display());
                 RawConfig::default()
             }
             Err(e) => {
-                error!("failed to read config: {}: {}", path.display(), e);
+                error!(
+                    "failed to read config: {}: {}",
+                    path.anonymize().display(),
+                    e
+                );
                 RawConfig::default()
             }
         };
@@ -88,7 +92,7 @@ impl Config {
         for dir in &self.data_dirs {
             let full_path = dir.join(path);
             if full_path.exists() {
-                debug!(path = ?path.display(), dir = ?dir.display(), "found asset");
+                debug!(path = ?path.anonymize().display(), dir = ?dir.anonymize().display(), "found asset");
                 return Some(full_path);
             }
         }

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -75,11 +75,7 @@ impl Config {
         }
         // Massage into final form
         Config {
-            name: name.unwrap_or_else(|| {
-                whoami::username()
-                    .unwrap_or_else(|_| String::from("unknown"))
-                    .into()
-            }),
+            name: name.unwrap_or("player".into()),
             data_dirs,
             save: save.unwrap_or("default.save".into()),
             chunk_load_parallelism: chunk_load_parallelism.unwrap_or(256),

--- a/client/src/graphics/base.rs
+++ b/client/src/graphics/base.rs
@@ -1,6 +1,7 @@
 //! Common state shared throughout the graphics system
 
 use ash::ext::debug_utils;
+use common::Anonymize;
 use std::ffi::{CStr, c_char};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -69,7 +70,7 @@ impl Base {
                     if e.kind() == io::ErrorKind::NotFound {
                         info!("creating fresh pipeline cache");
                     } else {
-                        warn!(path=%path.display(), "failed to load pipeline cache: {}", e);
+                        warn!(path=%path.anonymize().display(), "failed to load pipeline cache: {}", e);
                     }
                     Vec::new()
                 }
@@ -309,7 +310,7 @@ impl Base {
                 trace!(len = data.len(), "wrote pipeline cache");
             }
             Err(e) => {
-                warn!(path=%path.display(), "failed to save pipeline cache: {}", e);
+                warn!(path=%path.anonymize().display(), "failed to save pipeline cache: {}", e);
             }
         }
     }

--- a/client/src/graphics/gltf_mesh.rs
+++ b/client/src/graphics/gltf_mesh.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 use ash::vk;
+use common::Anonymize;
 use futures_util::future::{BoxFuture, FutureExt, try_join_all};
 use lahar::{BufferRegionAlloc, DedicatedImage};
 use tracing::{error, trace};
@@ -33,12 +34,12 @@ impl GlbFile {
         let path = ctx
             .cfg
             .find_asset(&self.path)
-            .ok_or_else(|| anyhow!("{} not found", self.path.display()))?;
+            .ok_or_else(|| anyhow!("{} not found", self.path.anonymize().display()))?;
 
         let glb = gltf::Glb::from_reader(
-            File::open(&path).with_context(|| format!("opening {}", path.display()))?,
+            File::open(&path).with_context(|| format!("opening {}", path.anonymize().display()))?,
         )
-        .with_context(|| format!("reading {}", path.display()))?;
+        .with_context(|| format!("reading {}", path.anonymize().display()))?;
         let gltf = gltf::Document::from_json(
             gltf::json::deserialize::from_slice(&glb.json).context("JSON parsing")?,
         )
@@ -397,7 +398,7 @@ async fn load_material(
                 .cfg
                 .find_asset(Path::new(uri))
                 .ok_or_else(|| anyhow!("texture {} not found", uri))?;
-            trace!(path = %path.display(), "reading texture");
+            trace!(path = %path.anonymize().display(), "reading texture");
             Cow::Owned(fs::read(&path).context("reading texture")?)
         }
         gltf::image::Source::View { view, .. } => {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, thread};
 
 use client::{Config, graphics, metrics, net};
-use common::proto;
+use common::{Anonymize, proto};
 use save::Save;
 
 use ash::khr;
@@ -26,7 +26,7 @@ fn main() {
             let sim_cfg = config.local_simulation.clone();
 
             let save = dirs.data_local_dir().join(&config.save);
-            info!("using save file {}", save.display());
+            info!("using save file {}", save.anonymize().display());
             std::fs::create_dir_all(save.parent().unwrap()).unwrap();
             let save = match Save::open(&save, config.local_simulation.chunk_size) {
                 Ok(x) => x,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow};
 use quinn::rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use tracing::{info, warn};
 
-use common::SimConfig;
+use common::{Anonymize, SimConfig};
 use config::Config;
 use save::Save;
 
@@ -68,7 +68,7 @@ pub async fn run() -> Result<()> {
     let sim_cfg = SimConfig::from_raw(&cfg.simulation);
 
     let save = cfg.save.unwrap_or_else(|| "hypermine.save".into());
-    info!("using save file {}", save.display());
+    info!("using save file {}", save.anonymize().display());
     let save = Save::open(&save, sim_cfg.chunk_size)?;
 
     let server = server::Server::new(


### PR DESCRIPTION
This PR addresses two issues that can compromise the anonymity of people who play and discuss the game:
* The default username is now "player" instead of the computer name. This ensures that save files will no longer leak the user's computer's account name, as well as ensuring that nobody would accidentally log into a public server with their computer's account name as their username.
* File paths printed to the console have been modified to generally show paths like `$HOME/.local/share/hypermine/default.save` instead of `/home/patowen/.local/share/hypermine/default.save`.

Note that the whoami library is no longer needed, given this change.