### PR TITLE
Install shaderc with package manager in Linux CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,23 +17,21 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      VULKAN_VERSION: "1.3.290.0"
-      VULKAN_SDK: "C:/VulkanSDK/1.3.290.0"
-
     steps:
-      - name: Install shaderc
-        if: matrix.os == 'ubuntu-latest'
+      - name: Set Windows environment variables
+        if: matrix.os == 'windows-latest'
+        shell: bash
         run: |
-          wget -nv -r -nd -A install.tgz 'https://storage.googleapis.com/shaderc/badges/build_link_linux_clang_release.html'
-          tar xf install.tgz
-          echo "SHADERC_LIB_DIR=$PWD/install/lib" >> "$GITHUB_ENV"
+          echo "VULKAN_VERSION=1.3.290.0" >> "$GITHUB_ENV"
+          echo "VULKAN_SDK=C:/VulkanSDK/1.3.290.0" >> "$GITHUB_ENV"
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt update && sudo apt-get -y install libasound2-dev libvulkan-dev libfontconfig-dev libshaderc-dev
       - name: Install Vulkan SDK
         if: matrix.os == 'windows-latest'
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_VERSION }}/windows/VulkanSDK-${{ env.VULKAN_VERSION }}-Installer.exe" -OutFile vulkan.exe
           ./vulkan.exe --accept-licenses --default-answer --confirm-command install
-
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --workspace --all-targets --locked


### PR DESCRIPTION
Currently, the package.yml workflow for Linux uses the package manager to install Vulkan. I decided to replicate this setup for CI, as well as getting it to install shaderc.

This seems to work properly, as the unit tests pass. I also realize that the shaderc issues in package.yml were for Ubuntu 20.04, and we have since upgraded to 22.04, so it would probably make sense to install a pre-built version of shaderc there as well.

When I had tested with more verbose output in https://github.com/Ralith/hypermine/actions/runs/31316952178/job/93253646075 (using command `cargo build --workspace --all-targets --locked -vv 2>&1 | grep --line-buffered "shaderc\|Compiling"`), I got the following:

> cargo:warning=shaderc: searching native shaderc libraries in '/usr/lib/x86_64-linux-gnu' from pkg-config

The build log did not mention it was building from source, so I think we are good on that front.