### PR TITLE
Fix chunks_exact_to_as_chunks Clippy lint for Rust 1.98.0

### DIFF
--- a/client/src/graphics/gltf_mesh.rs
+++ b/client/src/graphics/gltf_mesh.rs
@@ -258,7 +258,7 @@ async fn load_geom(
         .ok_or_else(|| anyhow!("too large"))?;
     for ((pos, norm), storage) in positions
         .zip(normals)
-        .zip(v_staging.chunks_exact_mut(mem::size_of::<Vertex>()))
+        .zip(v_staging.as_chunks_mut::<{ mem::size_of::<Vertex>() }>().0)
     {
         let v = Vertex {
             position: na::Point3::from_homogeneous(
@@ -289,7 +289,7 @@ async fn load_geom(
         .alloc(index_count * 4)
         .await
         .ok_or_else(|| anyhow!("too large"))?;
-    for (idx, storage) in indices.zip(i_staging.chunks_exact_mut(4)) {
+    for (idx, storage) in indices.zip(i_staging.as_chunks_mut::<4>().0) {
         storage.copy_from_slice(&idx.to_ne_bytes());
     }
 

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -325,7 +325,9 @@ impl VoxelData {
 
         let mut materials = serialized
             .inner
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]));
 
         let mut data = vec![Material::Void; (usize::from(dimension) + 2).pow(3)];


### PR DESCRIPTION
I am happy that this new feature exists, although it would have been nice to have an `as_chunks_exact` method before linting against `chunks_exact`.