### PR TITLE
Use install-vulkan-sdk-action GitHub action, including lavapipe software rasterizer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,20 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set Windows environment variables
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          echo "VULKAN_VERSION=1.3.290.0" >> "$GITHUB_ENV"
-          echo "VULKAN_SDK=C:/VulkanSDK/1.3.290.0" >> "$GITHUB_ENV"
-      - name: Install dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt update && sudo apt-get -y install libasound2-dev libvulkan-dev libfontconfig-dev libshaderc-dev
       - name: Install Vulkan SDK
-        if: matrix.os == 'windows-latest'
-        run: |
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_VERSION }}/windows/VulkanSDK-${{ env.VULKAN_VERSION }}-Installer.exe" -OutFile vulkan.exe
-          ./vulkan.exe --accept-licenses --default-answer --confirm-command install
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: 1.3.290.0
+          install_runtime: true
+          install_lavapipe: true
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --workspace --all-targets --locked

--- a/client/src/graphics/tests.rs
+++ b/client/src/graphics/tests.rs
@@ -1,7 +1,6 @@
 use super::Base;
 
 #[test]
-#[ignore]
 fn init_base() {
     let _guard = common::tracing_guard();
     Base::headless();

--- a/client/src/graphics/voxels/tests.rs
+++ b/client/src/graphics/voxels/tests.rs
@@ -147,7 +147,6 @@ struct Surface {
 }
 
 #[test]
-#[ignore]
 fn surface_extraction() {
     assert_eq!(mem::size_of::<Surface>(), 8);
 


### PR DESCRIPTION
This PR also un-ignores the tests that were ignored due to the inability to run them on GitHub actions.

https://github.com/marketplace/actions/install-vulkan-sdk-and-runtime